### PR TITLE
feat: fuel-fed hypothesis generation

### DIFF
--- a/src/backend/app/agents/voyage/actions_discovery.py
+++ b/src/backend/app/agents/voyage/actions_discovery.py
@@ -513,6 +513,9 @@ async def hypothesis_expand(ctx: ActionContext, params: dict[str, Any]) -> dict[
                     # 检索留痕（D6 披露 #655）：本轮查询全录 + 三路灵感的论文集合
                     "queries": round_queries,
                     "inspiration_paper_ids": gen["trace"]["inspiration_paper_ids"],
+                    # 燃料留痕（#670）：本轮 generate 消费了哪些方法卡/概念对/
+                    # 缺口条目（全空 = 没有燃料可用），随账本进 D6 披露
+                    "fuels": gen["trace"]["fuels"],
                 }
                 why = (
                     f"第 {round_no} 轮：扩展最优 open 节点，管线产出 "

--- a/src/backend/app/core/llm/fake.py
+++ b/src/backend/app/core/llm/fake.py
@@ -1215,23 +1215,37 @@ class FakeProvider(LLMProvider):
     @staticmethod
     def _respond_hyp_generate(last_user: str) -> str:
         """生成：固定两个回显 direction 的候选。两条措辞刻意差异大——去重折叠
-        （SequenceMatcher>0.85）不该吃掉它们，完整 run 的树形状才可精确断言。"""
-        direction = str(FakeProvider._payload_of(last_user).get("direction") or "")[:40]
-        return json.dumps(
+        （SequenceMatcher>0.85）不该吃掉它们，完整 run 的树形状才可精确断言。
+
+        payload 带非空 fuels 节（#670）时**多产一条**回显「收到了哪些燃料节、
+        各几条」的候选：确定性、且让「燃料存在与否改变候选」在 fake 路径上
+        可直接断言——这正是 P2.5 F6 的出口判据。无燃料时输出与从前逐字节一致。"""
+        payload = FakeProvider._payload_of(last_user)
+        direction = str(payload.get("direction") or "")[:40]
+        candidates = [
             {
-                "candidates": [
-                    {
-                        "statement": f"机制假设（fake A）：{direction} 依赖显式规划机制",
-                        "rationale": "fake-generate：语义近邻灵感组合",
-                    },
-                    {
-                        "statement": f"证据闭环假设（fake B）：{direction} 需要检索增强验证",
-                        "rationale": "fake-generate：引文远端灵感组合",
-                    },
-                ]
+                "statement": f"机制假设（fake A）：{direction} 依赖显式规划机制",
+                "rationale": "fake-generate：语义近邻灵感组合",
             },
-            ensure_ascii=False,
-        )
+            {
+                "statement": f"证据闭环假设（fake B）：{direction} 需要检索增强验证",
+                "rationale": "fake-generate：引文远端灵感组合",
+            },
+        ]
+        fuels = payload.get("fuels")
+        if isinstance(fuels, dict) and fuels:
+            # 节名排序 + 逐节条目数：同样的燃料永远同样的回显（可精确断言）
+            summary = " ".join(
+                f"{name}={len(fuels[name]) if isinstance(fuels[name], list) else 0}"
+                for name in sorted(fuels)
+            )
+            candidates.append(
+                {
+                    "statement": f"燃料组合假设（fake F）：{summary} 融入 {direction}",
+                    "rationale": "fake-generate：回显收到的燃料节与条目数（确定性替身）",
+                }
+            )
+        return json.dumps({"candidates": candidates}, ensure_ascii=False)
 
     @staticmethod
     def _respond_hyp_ground(last_user: str) -> str:

--- a/src/backend/app/services/discovery_disclosure.py
+++ b/src/backend/app/services/discovery_disclosure.py
@@ -11,6 +11,7 @@
       "version": 1,
       "queries":  [{round, phase: generate|ground|novelty, node_id, query,
                     paper_ids}],                       # 检索了什么（全录）
+      "fuels":    {methods, concept_pairs, gaps},      # 消费了哪些燃料（#670）
       "papers":   {retrieved, cited, retrieved_not_cited, cited_not_retrieved},
       "branches": [{node_id, parent_id, statement, status, score,
                     timeline: [{event: created|expanded|pruned, round,
@@ -78,6 +79,9 @@ def build_disclosure(checkpoint: dict[str, Any], nodes: Sequence[Any]) -> dict[s
     # ---- queries：轮次账本里的检索留痕拉平（按轮序，轮内保持记录顺序） ----
     queries: list[dict[str, Any]] = []
     retrieved: list[str] = []
+    # 燃料账（#670）：各轮消费的燃料条目跨轮去重聚合。三个键恒在——「这次
+    # 没消费任何燃料」也是要如实说出口的事实（golden 场景就是全空）
+    fuels: dict[str, list[Any]] = {"methods": [], "concept_pairs": [], "gaps": []}
     for round_no, record in _sorted_rounds(rounds):
         for raw in record.get("queries") or []:
             if not isinstance(raw, dict):
@@ -104,6 +108,17 @@ def build_disclosure(checkpoint: dict[str, Any], nodes: Sequence[Any]) -> dict[s
         ):
             # 真扩展过却没有检索留痕：旧版本 run（#655 之前）或脏账，如实标注
             warnings.append({"code": "round_without_trace", "round": round_no})
+        fuel_rec = record.get("fuels")
+        if isinstance(fuel_rec, dict):
+            # 方法卡/缺口条目的原文进了 generate 的 prompt——这些论文同样被
+            # 读过，计入 retrieved（概念对没有单一论文出处，只记概念名对）
+            _add_unique(fuels["methods"], fuel_rec.get("methods") or [])
+            _add_unique(fuels["gaps"], fuel_rec.get("gaps") or [])
+            _add_unique(retrieved, fuel_rec.get("methods") or [])
+            _add_unique(retrieved, fuel_rec.get("gaps") or [])
+            for pair in fuel_rec.get("concept_pairs") or []:
+                if isinstance(pair, dict) and pair not in fuels["concept_pairs"]:
+                    fuels["concept_pairs"].append(pair)
 
     # ---- papers：retrieved 全集 vs 实引（grounding 立场引用 + 查新引用） ----
     cited: list[str] = []
@@ -217,6 +232,7 @@ def build_disclosure(checkpoint: dict[str, Any], nodes: Sequence[Any]) -> dict[s
     return {
         "version": 1,
         "queries": queries,
+        "fuels": fuels,
         "papers": papers,
         "branches": branches,
         "tournament": {

--- a/src/backend/app/services/hypothesis_pipeline.py
+++ b/src/backend/app/services/hypothesis_pipeline.py
@@ -9,9 +9,14 @@ LLM 只负责五件判断性的事——组合灵感成假设、拆子命题、�
 1. **generate**：三路灵感确定性取材——语义近邻（direction 直接检索）、引文图
    远端（命中论文沿引文边走 2 跳、只取非直接邻居：图距离远的实体更可能带来
    跨域组合，MOOSE-Chem「假设 ≈ 背景 + 灵感组合」）、多样窗（未被覆盖论文的
-   等距片段窗口，替代随机采样以保证可重放）→ ``hyp_generate`` 一次调用组合出
-   n 个候选 → SequenceMatcher 相似度 >0.85 折叠去重（Stanford 100+ 研究者盲评：
-   LLM 假设多样性坍缩严重，大量采样后去重是必要步骤，§12）。
+   等距片段窗口，替代随机采样以保证可重放）；#670（P2.5 F6）起再喂三路**预计算
+   燃料**——方法类比（同目的异机制的做法，#666）、未连接概念对（Swanson ABC
+   候选，#667）、开放缺口（文献自己指出的未解问题，#668）。燃料同样是确定性
+   取材，且**任何一路失败都静默降级为空**：燃料是加分项，供不上不该拖垮生成
+   （库刚建、还没有抽取产物时三路燃料天然为空，行为与纯检索路完全一致）。
+   → ``hyp_generate`` 一次调用组合出 n 个候选 → SequenceMatcher 相似度 >0.85
+   折叠去重（Stanford 100+ 研究者盲评：LLM 假设多样性坍缩严重，大量采样后
+   去重是必要步骤，§12）。
 2. **ground**：``hyp_ground`` 拆子命题（≤5）→ 逐子命题确定性检索 top-5 →
    同环节第二次调用只允许从检索结果里**选择** paper_id + 立场（support/refute）
    或判 speculation；后处理校验所选 id ∈ 检索集，越界一律降为 speculation——
@@ -29,6 +34,7 @@ score = novel 比例 × support 覆盖率。选这个最笨的公式是有意的
 """
 
 import json
+import logging
 import uuid
 from difflib import SequenceMatcher
 from typing import Any
@@ -42,8 +48,10 @@ from app.models.library_direction import LibraryPaper
 from app.models.paper import Paper, PaperChunk
 from app.models.paper_citation import PaperCitation
 from app.services import chunks as chunks_service
-from app.services import library_rag
+from app.services import concept_fuels, gap_ledger, library_rag, method_index
 from app.services.papers import PAPER_STATUS_GROUPS
+
+logger = logging.getLogger(__name__)
 
 # 四个 LLM 环节（router.py STAGES / 前端 LLM_STAGES 同步登记）：
 # generate/ground 是较长的结构化生成走中档，novelty/feasibility 是短 JSON 判定走短档
@@ -57,6 +65,7 @@ MAX_SUBCLAIMS = 5  # 子命题上限：多了检索与判定成本线性涨，�
 GROUND_TOP_K = 5  # 每条子命题送给 LLM 挑选的检索结果数
 DEDUP_THRESHOLD = 0.85  # 陈述相似度超过它视为同一假设（去重折叠）
 INSPIRATION_PER_ROUTE = 3  # 引文远端 / 多样窗两路各取几条灵感
+FUEL_PER_ROUTE = 3  # 三路燃料各取几条（#670）：prompt 是稀缺资源，燃料给最强的 top-3
 SNIPPET_CHARS = 300  # 灵感与证据片段的截断长度
 DENSITY_LIMIT = 50  # 相关片段密度统计的计数上限（信号要的是量级，不是全量）
 # expand 后低于此分自动剪枝（actions_discovery 消费）。0.15 = 「不到一半子命题
@@ -68,10 +77,15 @@ _MAX_JSON_ATTEMPTS = 3
 GENERATE_SYSTEM_PROMPT = """\
 POLARIS_HYP_GENERATE
 你是研究假设生成器。输入 JSON 里是研究方向和三路文献灵感（semantic=语义近邻、
-citation_far=引文图远端、diverse=多样窗口片段）。请把方向与灵感**组合**成最多 n 个
-彼此不同、可检验的研究假设（鼓励跨片段组合，而不是逐条改写）。
+citation_far=引文图远端、diverse=多样窗口片段）。输入可能还带 fuels 节——从库里
+预计算的三类燃料，每条都带来源（paper_id / 概念名）：
+- method_analogies：同目的异机制的做法（purpose 相近、mechanism 不同的方法卡）；
+- unconnected_pairs：尚未被共同研究的概念组合（经桥概念间接相连的 A、C）；
+- open_gaps：文献指出的未解问题（gap/矛盾/负结果的原文归纳）。
+请把方向与灵感/燃料**组合**成最多 n 个彼此不同、可检验的研究假设（鼓励跨片段、
+跨燃料组合，而不是逐条改写；有燃料时优先消费燃料——它们是库里最值得下注的线索）。
 只输出 JSON：{"candidates": [{"statement": "假设陈述（一句话，可检验）", \
-"rationale": "一句话依据（引用了哪路灵感）"}]}"""
+"rationale": "一句话依据（引用了哪路灵感或燃料）"}]}"""
 
 GROUND_SPLIT_SYSTEM_PROMPT = """\
 POLARIS_HYP_GROUND
@@ -327,6 +341,92 @@ async def _diverse_window_chunks(
     return pool[::stride][:INSPIRATION_PER_ROUTE]
 
 
+async def _gather_fuels(
+    session: AsyncSession,
+    *,
+    library_id: uuid.UUID,
+    direction: str,
+    user_id: uuid.UUID | None,
+) -> tuple[dict[str, list[dict[str, Any]]], dict[str, Any]]:
+    """三路燃料确定性取材（#670）：返回 (prompt 的 fuels 节, trace 的 fuels 节)。
+
+    prompt 节只收**非空**的路——空路进 prompt 只是噪音，且「无任何燃料时 payload
+    与纯检索路完全一致」是行为判据（golden 场景靠它保证等价）。trace 节三个键
+    恒在（哪怕全空）：披露报告要能如实说「这次没消费任何燃料」。
+
+    每一路独立 try/except **静默降级为空**：燃料服务依赖抽取产物/概念/向量等
+    可选设施，任何一路坏了都不该把整个 generate 拖下水——没有燃料的生成是
+    降级，不是失败。
+    """
+    sections: dict[str, list[dict[str, Any]]] = {}
+    trace: dict[str, Any] = {"methods": [], "concept_pairs": [], "gaps": []}
+
+    # 燃料 1：方法类比——同目的异机制（#666）。带 purpose/mechanism 原文与出处，
+    # LLM 才能据此做「换个机制达成同一目的」的类比组合
+    try:
+        cards, _mode = await method_index.search_methods(
+            session,
+            library_id,
+            direction,
+            mode="different_mechanism",
+            limit=FUEL_PER_ROUTE,
+            user_id=user_id,
+        )
+    except Exception:  # noqa: BLE001 — 燃料失败静默降级（见 docstring）
+        logger.warning("method analogy fuel unavailable", exc_info=True)
+        cards = []
+    if cards:
+        sections["method_analogies"] = [
+            {
+                "paper_id": str(c["paper_id"]),
+                "title": c["title"],
+                "purpose": c["purpose"],
+                "mechanism": c["mechanism"],
+            }
+            for c in cards
+        ]
+        trace["methods"] = list(dict.fromkeys(str(c["paper_id"]) for c in cards))
+
+    # 燃料 2：未连接概念对（#667）。A、C 与桥概念一起给：桥是「为什么值得把
+    # 它们放在一起想」的可解释依据
+    try:
+        pairs = await concept_fuels.mine_unconnected_pairs(
+            session, library_id=library_id, top_n=FUEL_PER_ROUTE
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning("unconnected pair fuel unavailable", exc_info=True)
+        pairs = []
+    if pairs:
+        sections["unconnected_pairs"] = [
+            {
+                "concept_a": p["concept_a"]["name"],
+                "concept_c": p["concept_c"]["name"],
+                "bridges": [b["name"] for b in p["bridges"]],
+            }
+            for p in pairs
+        ]
+        trace["concept_pairs"] = [
+            {"concept_a": p["concept_a"]["name"], "concept_c": p["concept_c"]["name"]}
+            for p in pairs
+        ]
+
+    # 燃料 3：开放缺口（#668）。kind 不限：gap/contradiction 优先已由台账的
+    # 排序权重保证，这里只管取 top
+    try:
+        gaps = await gap_ledger.library_gaps(session, library_id, top=FUEL_PER_ROUTE)
+    except Exception:  # noqa: BLE001
+        logger.warning("open gap fuel unavailable", exc_info=True)
+        gaps = []
+    if gaps:
+        sections["open_gaps"] = [
+            {"paper_id": str(g.paper_id), "kind": g.kind, "statement": g.statement}
+            for g in gaps
+        ]
+        trace["gaps"] = list(dict.fromkeys(str(g.paper_id) for g in gaps))
+
+    return sections, trace
+
+
 def _norm_statement(text: str) -> str:
     return " ".join(str(text).lower().split())
 
@@ -411,6 +511,10 @@ async def generate(
     )
     all_ids = list({c.paper_id for c in semantic_chunks + far_chunks + diverse_chunks})
     titles = await _paper_titles(session, all_ids)
+    # 三路燃料（#670）：方法类比 / 未连接概念对 / 开放缺口，失败静默降级为空
+    fuel_sections, fuel_trace = await _gather_fuels(
+        session, library_id=library_id, direction=direction, user_id=user_id
+    )
     payload = {
         "direction": direction,
         "n": n_candidates,
@@ -420,6 +524,9 @@ async def generate(
             "diverse": [_chunk_entry(c, titles) for c in diverse_chunks],
         },
     }
+    if fuel_sections:
+        # 全空时不加键：无燃料的 payload 与纯检索路逐字节一致（行为等价判据）
+        payload["fuels"] = fuel_sections
     raw = await _complete_json(
         llm,
         GENERATE_STAGE,
@@ -446,6 +553,9 @@ async def generate(
                 "citation_far": _ordered_paper_ids(far_chunks),
                 "diverse": _ordered_paper_ids(diverse_chunks),
             },
+            # 燃料留痕（#670）：消费了哪些方法卡/概念对/缺口条目，三键恒在
+            # （全空 = 这次没有燃料可用），供轮次账本与 D6 披露归档
+            "fuels": fuel_trace,
         },
     }
 

--- a/src/backend/tests/golden/data/discovery_run.json
+++ b/src/backend/tests/golden/data/discovery_run.json
@@ -146,12 +146,12 @@
           },
           "<uuid-8>": {
             "completion_tokens": 91,
-            "prompt_tokens": 433
+            "prompt_tokens": 492
           }
         },
         "total": {
           "completion_tokens": 321,
-          "prompt_tokens": 2107
+          "prompt_tokens": 2166
         }
       },
       "branches": [
@@ -199,6 +199,11 @@
           ]
         }
       ],
+      "fuels": {
+        "concept_pairs": [],
+        "gaps": [],
+        "methods": []
+      },
       "invariants": {
         "cited_subset_of_retrieved": true,
         "pruned_have_reasons": true
@@ -641,13 +646,13 @@
               "round": 1,
               "usage": {
                 "completion_tokens": 294,
-                "prompt_tokens": 2055
+                "prompt_tokens": 2114
               }
             },
             "started_at": "<ts>",
             "tokens": {
               "completion_tokens": 294,
-              "prompt_tokens": 2055
+              "prompt_tokens": 2114
             },
             "verdict": {
               "passed": true,
@@ -670,7 +675,7 @@
           "round": 1,
           "usage": {
             "completion_tokens": 294,
-            "prompt_tokens": 2055
+            "prompt_tokens": 2114
           }
         },
         "params": {
@@ -687,7 +692,7 @@
         "title": "第 1 轮扩展假设",
         "tokens": {
           "completion_tokens": 294,
-          "prompt_tokens": 2055
+          "prompt_tokens": 2114
         },
         "verdict": {
           "passed": true,
@@ -768,8 +773,8 @@
     "updated_at": "<ts>",
     "usage": {
       "completion_tokens": 340,
-      "prompt_tokens": 2202,
-      "total_tokens": 2542
+      "prompt_tokens": 2261,
+      "total_tokens": 2601
     }
   }
 }

--- a/src/backend/tests/golden/test_golden_discovery.py
+++ b/src/backend/tests/golden/test_golden_discovery.py
@@ -174,6 +174,10 @@ async def test_discovery_chain_matches_golden(client, queue_stub):
     }
     assert disclosure["warnings"] == []
     assert disclosure["queries"], "披露里必须有检索留痕"
+    # 燃料节（#670）：golden 的两篇 bibtex 论文没有全文 → 没有抽取产物/概念 →
+    # 三路燃料合法为空，generate 行为与纯检索路等价（有燃料的差异走常规测试）。
+    # 断言「节存在且为空」钉住这条降级路径本身。
+    assert disclosure["fuels"] == {"methods": [], "concept_pairs": [], "gaps": []}
 
     rendered = json.dumps(transcript, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
     if os.environ.get("POLARIS_GOLDEN") == "record":

--- a/src/backend/tests/test_discovery_disclosure.py
+++ b/src/backend/tests/test_discovery_disclosure.py
@@ -31,7 +31,7 @@ from tests.conftest import (
 # ---- 纯函数：伪造一次两轮探索的完整现场 ----
 
 ROOT, CHILD_A, CHILD_B, GRANDCHILD = "n-root", "n-a", "n-b", "n-ba"
-P1, P2, P3, P4 = "p1", "p2", "p3", "p4"
+P1, P2, P3, P4, P5 = "p1", "p2", "p3", "p4", "p5"
 
 
 def _node(node_id, parent_id, status, *, score=0.5, grounding=None, novelty=None):
@@ -51,6 +51,8 @@ def _fixture():
 
     检索留痕：generate 捞到 P1/P2（灵感另含 P3），A 的接地查询捞 P1、查新捞
     P2；实引 = A 的 grounding 引 P1 + 查新引 P2 → P3 是「检了没用」差集。
+    燃料留痕（#670）：方法类比消费 P3（与灵感重叠，retrieved 不重复计）、
+    缺口消费 P5（只有燃料读过它）、外加一个概念对。
     """
     nodes = [
         _node(ROOT, None, "expanded", score=0.8),
@@ -102,6 +104,11 @@ def _fixture():
                         "citation_far": [P3],
                         "diverse": [],
                     },
+                    "fuels": {
+                        "methods": [P3],
+                        "concept_pairs": [{"concept_a": "alpha", "concept_c": "gamma"}],
+                        "gaps": [P5],
+                    },
                 },
             },
             "decisions": [
@@ -138,11 +145,19 @@ def test_build_disclosure_full_fixture():
     ]
     assert d["queries"][0]["paper_ids"] == [P1, P2]
 
-    # papers：retrieved = 查询命中 ∪ 灵感论文；cited = 接地立场引用 + 查新引用
-    assert d["papers"]["retrieved"] == [P1, P2, P3]
+    # papers：retrieved = 查询命中 ∪ 灵感论文 ∪ 燃料论文（方法卡/缺口的原文
+    # 进了 prompt，同样算读过）；cited = 接地立场引用 + 查新引用
+    assert d["papers"]["retrieved"] == [P1, P2, P3, P5]
     assert d["papers"]["cited"] == [P1, P2]
-    assert d["papers"]["retrieved_not_cited"] == [P3]
+    assert d["papers"]["retrieved_not_cited"] == [P3, P5]
     assert d["papers"]["cited_not_retrieved"] == []
+
+    # fuels（#670）：跨轮聚合的燃料消费账，概念对原样归档
+    assert d["fuels"] == {
+        "methods": [P3],
+        "concept_pairs": [{"concept_a": "alpha", "concept_c": "gamma"}],
+        "gaps": [P5],
+    }
 
     # branches：根第 0 轮出生、第 1 轮被扩展；B 有直接剪枝原因；
     # B 的孩子无决策 → 反查到级联来源 B
@@ -210,6 +225,8 @@ def test_build_disclosure_tolerates_empty_run():
     d = build_disclosure({}, [])
     assert d["queries"] == [] and d["branches"] == []
     assert d["papers"]["retrieved"] == [] and d["papers"]["cited"] == []
+    # 燃料节恒在（#670）：旧 run / 无燃料 run 如实报「什么都没消费」
+    assert d["fuels"] == {"methods": [], "concept_pairs": [], "gaps": []}
     assert d["invariants"] == {
         "cited_subset_of_retrieved": True,
         "pruned_have_reasons": True,
@@ -288,6 +305,8 @@ async def test_disclosure_artifact_written_and_served(client, queue_stub):
         "pruned_have_reasons": True,
     }
     assert d["warnings"] == []
+    # 燃料节恒在（#670）：本库没有抽取产物/概念 → 三路燃料如实为空
+    assert d["fuels"] == {"methods": [], "concept_pairs": [], "gaps": []}
     # 检索留痕齐全：generate 1 条 + 每子假设接地 2 条/查新 1 条（fake 确定性形状）
     phases = [q["phase"] for q in d["queries"]]
     assert phases == [

--- a/src/backend/tests/test_hypothesis_pipeline.py
+++ b/src/backend/tests/test_hypothesis_pipeline.py
@@ -14,10 +14,13 @@ import uuid
 
 from app.core.db import get_sessionmaker
 from app.core.llm.router import LLMRouter
-from app.models.paper import PaperChunk
+from app.models.library_direction import DirectionLibrary
+from app.models.paper import Paper, PaperChunk
 from app.models.paper_citation import PaperCitation
+from app.models.paper_extraction import PaperExtraction
 from app.services import hypothesis_pipeline as pipeline
-from tests.conftest import add_paper, make_project_with_library, register_and_login
+from app.services.method_index import refresh_paper_method_index
+from tests.conftest import add_concept, add_paper, make_project_with_library, register_and_login
 
 DIRECTION = "agent planning verification"
 
@@ -181,6 +184,116 @@ async def test_generate_returns_deduped_candidates_with_usage(client):
     assert len(statements) == 2  # fake 固定两候选，措辞差异大、不被折叠
     assert all(DIRECTION[:20] in s for s in statements)
     assert result["usage"]["prompt_tokens"] > 0
+    # 无燃料（本库没有方法卡/概念/缺口产物）：燃料留痕三键恒在且全空，
+    # 且没有燃料回显候选——行为与 #670 之前的纯检索路一致
+    assert result["trace"]["fuels"] == {"methods": [], "concept_pairs": [], "gaps": []}
+    assert not any("燃料组合假设" in s for s in statements)
+
+
+# ---- 燃料喂养（#670，P2.5 F6）：燃料存在与否改变候选 + 静默降级 ----
+
+
+async def _seed_fuels(session, library_id, ids):
+    """给库埋齐三路燃料：A/M 的方法卡（purpose 含方向词、机制互异）、
+    alpha–bridge–gamma 的未连接概念对、B 的缺口条目。"""
+    project_id = (await session.get(DirectionLibrary, library_id)).project_id
+    # 燃料 1：方法卡 + 双轴索引（fake 词袋嵌入：purpose 用词与方向重叠即相近）
+    session.add(
+        PaperExtraction(
+            paper_id=ids["A"],
+            schema_id="method",
+            payload={
+                "purpose": "agent planning verification purpose",
+                "mechanism": "tree search rollout mechanism",
+            },
+        )
+    )
+    session.add(
+        PaperExtraction(
+            paper_id=ids["M"],
+            schema_id="method",
+            payload={
+                "purpose": "agent planning verification purpose",
+                "mechanism": "reinforcement fine-tuning mechanism",
+            },
+        )
+    )
+    await session.commit()
+    for key in ("A", "M"):
+        await refresh_paper_method_index(session, await session.get(Paper, ids[key]))
+    # 燃料 2：alpha–bridge、bridge–gamma 共现，alpha–gamma 从未同篇 → 未连接对
+    alpha = await add_concept(session, project_id=project_id, name="alpha", slug="hyp-alpha")
+    bridge = await add_concept(session, project_id=project_id, name="bridge", slug="hyp-bridge")
+    gamma = await add_concept(session, project_id=project_id, name="gamma", slug="hyp-gamma")
+    await add_paper(
+        session, project_id=project_id, title="Fuel Pair One",
+        status="included", concepts=[alpha, bridge],
+    )
+    await add_paper(
+        session, project_id=project_id, title="Fuel Pair Two",
+        status="included", concepts=[bridge, gamma],
+    )
+    # 燃料 3：B 的缺口台账条目
+    session.add(
+        PaperExtraction(
+            paper_id=ids["B"],
+            schema_id="gaps",
+            payload={
+                "entries": [
+                    {
+                        "kind": "gap",
+                        "statement": "跨域泛化仍未解决（fuel gap）",
+                        "source_span": "cross-domain generalization remains open",
+                    }
+                ]
+            },
+        )
+    )
+    await session.commit()
+
+
+async def test_generate_fuels_change_candidates_and_trace(client):
+    """P2.5 F6 出口判据：同一方向，燃料存在 → fake 多产一条回显「燃料节 +
+    条目数」的候选（与无燃料时可断言地不同），trace.fuels 记齐消费清单。"""
+    library_id, ids = await _setup(client)
+    async with get_sessionmaker()() as session:
+        await _seed_fuels(session, library_id, ids)
+        result = await pipeline.generate(
+            session, LLMRouter(), library_id=library_id, direction=DIRECTION, n_candidates=3
+        )
+    statements = [c["statement"] for c in result["candidates"]]
+    assert len(statements) == 3  # 纯检索路只有 2 条：燃料确实改变了候选
+    fuel_echo = statements[2]
+    # fake 回显收到的燃料节（按节名排序）与条目数：三路都被喂进了 prompt
+    assert "method_analogies=2 open_gaps=1 unconnected_pairs=1" in fuel_echo
+    fuels = result["trace"]["fuels"]
+    assert set(fuels["methods"]) == {str(ids["A"]), str(ids["M"])}
+    assert fuels["gaps"] == [str(ids["B"])]
+    # 概念对的 a/c 取 uuid 规范序（随机 uuid 下方向不定），按名字集合断言
+    assert [
+        sorted((p["concept_a"], p["concept_c"])) for p in fuels["concept_pairs"]
+    ] == [["alpha", "gamma"]]
+
+
+async def test_generate_fuel_service_failure_degrades_silently(client, monkeypatch):
+    """三路燃料服务全炸也不许拖垮 generate：静默降级为空、行为等同纯检索路。"""
+    library_id, ids = await _setup(client)
+    async with get_sessionmaker()() as session:
+        await _seed_fuels(session, library_id, ids)  # 数据在，但服务炸了
+
+        async def _boom(*args, **kwargs):
+            raise RuntimeError("fuel service down")
+
+        monkeypatch.setattr(pipeline.method_index, "search_methods", _boom)
+        monkeypatch.setattr(pipeline.concept_fuels, "mine_unconnected_pairs", _boom)
+        monkeypatch.setattr(pipeline.gap_ledger, "library_gaps", _boom)
+        result = await pipeline.generate(
+            session, LLMRouter(), library_id=library_id, direction=DIRECTION, n_candidates=3
+        )
+    statements = [c["statement"] for c in result["candidates"]]
+    assert len(statements) == 2  # 与纯检索路相同的两条 fake 候选
+    assert not any("燃料组合假设" in s for s in statements)
+    assert result["trace"]["fuels"] == {"methods": [], "concept_pairs": [], "gaps": []}
 
 
 # ---- 接地 / 查新 / 可行性（fake 端到端） ----

--- a/src/backend/tests/test_voyage_discovery.py
+++ b/src/backend/tests/test_voyage_discovery.py
@@ -381,6 +381,10 @@ async def test_discovery_low_score_children_auto_pruned(client, queue_stub):
     assert {d["node_id"] for d in pruned_decisions} == pruned_ids
     assert all("自动剪枝" in d["why"] for d in pruned_decisions)
     assert set(state["rounds"]["1"]["pruned"]) == pruned_ids
+    # 燃料留痕（#670）：轮次账本三键恒在；本库无抽取产物/概念 → 如实全空
+    assert state["rounds"]["1"]["fuels"] == {
+        "methods": [], "concept_pairs": [], "gaps": [],
+    }
     # 汇总产物：方案主体只剩根，附录如实收录被剪分支及原因
     async with get_sessionmaker()() as session:
         run = await session.get(VoyageRun, run_id)

--- a/src/frontend/src/features/voyages/__tests__/discoveryDisclosure.test.ts
+++ b/src/frontend/src/features/voyages/__tests__/discoveryDisclosure.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  fuelClueCount,
   parseDisclosure,
   pruneRecordsOf,
   prunedBranches,
@@ -17,10 +18,15 @@ const ARTIFACT = {
     { round: 1, phase: 'novelty', node_id: 'a', query: 'q-n1', paper_ids: ['p2'] },
     { round: 2, phase: 'ground', node_id: 'b', query: 'q-g2', paper_ids: [] },
   ],
+  fuels: {
+    methods: ['p3'],
+    concept_pairs: [{ concept_a: 'alpha', concept_c: 'gamma' }],
+    gaps: ['p4'],
+  },
   papers: {
-    retrieved: ['p1', 'p2', 'p3'],
+    retrieved: ['p1', 'p2', 'p3', 'p4'],
     cited: ['p1', 'p2'],
-    retrieved_not_cited: ['p3'],
+    retrieved_not_cited: ['p3', 'p4'],
     cited_not_retrieved: [],
   },
   branches: [
@@ -74,7 +80,14 @@ describe('parseDisclosure', () => {
       query: 'q-gen',
       paperIds: ['p1', 'p2'],
     });
-    expect(d.papers.retrievedNotCited).toEqual(['p3']);
+    expect(d.papers.retrievedNotCited).toEqual(['p3', 'p4']);
+    // 燃料小节（#670）：方法卡/概念对/缺口出处解析成干净类型
+    expect(d.fuels).toEqual({
+      methods: ['p3'],
+      conceptPairs: [{ a: 'alpha', c: 'gamma' }],
+      gaps: ['p4'],
+    });
+    expect(fuelClueCount(d.fuels!)).toBe(3);
     expect(d.branches.map((b) => b.nodeId)).toEqual(['root', 'b', 'ba']);
     expect(d.warnings).toEqual([{ code: 'round_without_trace' }]);
     expect(d.totalTokens).toEqual({ prompt: 17, completion: 8 });
@@ -97,6 +110,21 @@ describe('parseDisclosure', () => {
     expect(d.warnings).toEqual([{ code: 'k' }]);
     expect(d.totalTokens).toBeNull();
     expect(d.papers.retrieved).toEqual([]);
+    // 旧产物没有 fuels 节 → null（小节整体不渲染）
+    expect(d.fuels).toBeNull();
+  });
+
+  it('燃料节容错：脏概念对丢弃、空节数得出 0', () => {
+    const d = parseDisclosure({
+      fuels: {
+        methods: ['m1', 7],
+        concept_pairs: [{ concept_a: 'a', concept_c: 'c' }, { concept_a: 'x' }, 'junk'],
+        gaps: [],
+      },
+    })!;
+    expect(d.fuels).toEqual({ methods: ['m1'], conceptPairs: [{ a: 'a', c: 'c' }], gaps: [] });
+    const empty = parseDisclosure({ fuels: { methods: [], concept_pairs: [], gaps: [] } })!;
+    expect(fuelClueCount(empty.fuels!)).toBe(0);
   });
 });
 

--- a/src/frontend/src/features/voyages/discovery.tsx
+++ b/src/frontend/src/features/voyages/discovery.tsx
@@ -29,6 +29,7 @@ import {
   type Stance,
 } from './discoveryEvidence';
 import {
+  fuelClueCount,
   parseDisclosure,
   pruneRecordsOf,
   prunedBranches,
@@ -800,12 +801,18 @@ function DisclosureSection({ title, children }: { title: string; children: React
 
 function DisclosureView({ disclosure, active }: { disclosure: DisclosureData | null; active: boolean }) {
   const pruned = disclosure ? prunedBranches(disclosure) : [];
-  // 差集论文解析标题（读了没引用 + 引了没检到两侧都要能点开看）
+  // 差集论文 + 燃料出处论文都要解析标题（差集两侧与「参考了哪些线索」小节
+  // 的芯片都要能点开看）
   const diffIds = useMemo(() => {
     if (!disclosure) return [];
     const seen = new Set<string>();
     const out: string[] = [];
-    for (const id of [...disclosure.papers.retrievedNotCited, ...disclosure.papers.citedNotRetrieved]) {
+    for (const id of [
+      ...disclosure.papers.retrievedNotCited,
+      ...disclosure.papers.citedNotRetrieved,
+      ...(disclosure.fuels?.methods ?? []),
+      ...(disclosure.fuels?.gaps ?? []),
+    ]) {
       if (!seen.has(id)) {
         seen.add(id);
         out.push(id);
@@ -850,6 +857,58 @@ function DisclosureView({ disclosure, active }: { disclosure: DisclosureData | n
             );
           })}
         </div>
+      )}
+
+      {/* 参考了哪些线索（#670 燃料）：生成假设前喂进去的预计算线索。
+          旧产物没有这一节（fuels 为 null）时小节整体不渲染。 */}
+      {disclosure.fuels && (
+        <DisclosureSection title={tr('参考了哪些线索', 'What clues were consulted')}>
+          {fuelClueCount(disclosure.fuels) === 0 ? (
+            <div style={{ fontSize: 12, color: 'var(--text-3)' }}>
+              {tr(
+                '这次没有额外线索可参考（库里还没有方法卡、概念或未解问题的数据），只靠检索。',
+                'No extra clues were available (the library has no method cards, concepts, or open-problem data yet), so only searches were used.',
+              )}
+            </div>
+          ) : (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+              {disclosure.fuels.methods.length > 0 && (
+                <div>
+                  <div style={{ fontSize: 11.5, color: 'var(--text-3)', marginBottom: 4 }}>
+                    {tr('换个做法的论文（目的相近、路子不同）：', 'Papers that reach a similar goal a different way:')}
+                  </div>
+                  <PaperChips ids={disclosure.fuels.methods} titles={titles} />
+                </div>
+              )}
+              {disclosure.fuels.conceptPairs.length > 0 && (
+                <div>
+                  <div style={{ fontSize: 11.5, color: 'var(--text-3)', marginBottom: 4 }}>
+                    {tr('还没被放到一起研究的概念组合：', 'Concept pairs never studied together yet:')}
+                  </div>
+                  <span className="row" style={{ gap: 4, flexWrap: 'wrap' }}>
+                    {disclosure.fuels.conceptPairs.map((pair, i) => (
+                      <span
+                        key={i}
+                        className="pill sm"
+                        style={{ background: 'var(--surface-3)', color: 'var(--text-2)' }}
+                      >
+                        {pair.a} × {pair.c}
+                      </span>
+                    ))}
+                  </span>
+                </div>
+              )}
+              {disclosure.fuels.gaps.length > 0 && (
+                <div>
+                  <div style={{ fontSize: 11.5, color: 'var(--text-3)', marginBottom: 4 }}>
+                    {tr('文献自己指出的未解问题，出自：', 'Open problems the literature itself points out, from:')}
+                  </div>
+                  <PaperChips ids={disclosure.fuels.gaps} titles={titles} />
+                </div>
+              )}
+            </div>
+          )}
+        </DisclosureSection>
       )}
 
       {/* 检索了什么：查询全录，按阶段分组 */}

--- a/src/frontend/src/features/voyages/discoveryDisclosure.ts
+++ b/src/frontend/src/features/voyages/discoveryDisclosure.ts
@@ -42,6 +42,16 @@ export interface DisclosureWarning {
   code: string;
 }
 
+/** 燃料消费账（#670）：生成假设时参考了哪些方法卡 / 概念组合 / 缺口条目。 */
+export interface DisclosureFuels {
+  /** 方法类比消费的论文（同目的异机制的方法卡出处） */
+  methods: string[];
+  /** 尚未被共同研究的概念组合（概念名对） */
+  conceptPairs: { a: string; c: string }[];
+  /** 开放缺口条目的论文出处 */
+  gaps: string[];
+}
+
 export interface DisclosureData {
   queries: DisclosureQuery[];
   papers: {
@@ -51,6 +61,8 @@ export interface DisclosureData {
     citedNotRetrieved: string[];
   };
   branches: DisclosureBranch[];
+  /** 燃料消费账；旧产物（#670 之前）没有这一节，为 null（小节整体不渲染） */
+  fuels: DisclosureFuels | null;
   warnings: DisclosureWarning[];
   /** 全 run token 总量（accounting.total；缺失为 null） */
   totalTokens: { prompt: number; completion: number } | null;
@@ -113,6 +125,26 @@ function parseBranch(raw: unknown): DisclosureBranch | null {
   };
 }
 
+function parseFuels(raw: unknown): DisclosureFuels | null {
+  if (typeof raw !== 'object' || raw === null) return null;
+  const rec = raw as Record<string, unknown>;
+  const conceptPairs: { a: string; c: string }[] = [];
+  if (Array.isArray(rec.concept_pairs)) {
+    for (const pair of rec.concept_pairs) {
+      if (typeof pair !== 'object' || pair === null) continue;
+      const pr = pair as Record<string, unknown>;
+      if (typeof pr.concept_a === 'string' && typeof pr.concept_c === 'string') {
+        conceptPairs.push({ a: pr.concept_a, c: pr.concept_c });
+      }
+    }
+  }
+  return {
+    methods: asStringArray(rec.methods),
+    conceptPairs,
+    gaps: asStringArray(rec.gaps),
+  };
+}
+
 /** 产物 JSON → 干净结构；根本不是对象（旧产物/坏数据）返回 null，组件降级。 */
 export function parseDisclosure(raw: unknown): DisclosureData | null {
   if (typeof raw !== 'object' || raw === null) return null;
@@ -142,6 +174,7 @@ export function parseDisclosure(raw: unknown): DisclosureData | null {
     branches: Array.isArray(rec.branches)
       ? rec.branches.map(parseBranch).filter((b): b is DisclosureBranch => b !== null)
       : [],
+    fuels: parseFuels(rec.fuels),
     warnings: Array.isArray(rec.warnings)
       ? rec.warnings
           .filter(
@@ -199,4 +232,9 @@ export function pruneRecordsOf(disclosure: DisclosureData): Map<string, PruneRec
 /** 被剪分支列表（时间线视图用）：保持产物顺序（＝建树顺序）。 */
 export function prunedBranches(disclosure: DisclosureData): DisclosureBranch[] {
   return disclosure.branches.filter((b) => b.status === 'pruned');
+}
+
+/** 燃料小节的条目总数（#670）：为 0 表示「这次没有额外线索可参考」。 */
+export function fuelClueCount(fuels: DisclosureFuels): number {
+  return fuels.methods.length + fuels.conceptPairs.length + fuels.gaps.length;
 }


### PR DESCRIPTION
Closes #670. Part of #660 (P2.5 wave 3, item F6 — the P2.5 exit criterion).

The generate stage now draws on the precomputed fuels instead of chunk retrieval alone.

- `_gather_fuels()` deterministically collects three routes, top-3 each: same-purpose/different-mechanism method analogies (#666), unconnected concept pairs with their bridges (#667), and open gaps/contradictions (#668); each route degrades silently to empty on failure
- the prompt gains a per-route sectioned `fuels` block where every entry carries its provenance; empty routes are omitted, and with no fuels at all the payload is byte-identical to the pure-retrieval path — behavioral equivalence is pinned, not assumed
- the fake provider makes the difference assertable: with fuels present it emits an extra candidate echoing section names and entry counts, deterministically
- provenance flows through: the generate trace and round ledger record consumed fuel entries; the disclosure report gains a deduplicated `fuels` section (fuel-source papers count into `retrieved` under the same "read" semantics); the process-log view adds a plain-language "clues consulted" section (older artifacts without the section simply don't render it)
- goldens: the discovery chain was intentionally re-recorded — the diff is exactly the empty `fuels` section plus a constant prompt-token delta from the longer system prompt; candidates, tree shape, and queries unchanged; the golden now pins the legal fuel-less degradation path; `import_wiki.json` byte-identical

Verification: clean baseline 1567 passed / 4 failed; branch 1570 passed / 3 failed — a strict subset of the baseline set (the extra baseline failure is the known clock-step replay flake, green standalone) — zero new real failures; rebased onto #671; frontend vitest 151 and build green.