### PR TITLE
feat: Runner v2 contract, registry, and the python-ml adapter

### DIFF
--- a/src/backend/app/schemas/experiment.py
+++ b/src/backend/app/schemas/experiment.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class ExperimentBudget(BaseModel):
@@ -38,6 +38,19 @@ class ExperimentParams(BaseModel):
     # 开题问答（AI 按 idea 生成 ≤5 个整体性问题，用户作答后随创建提交；
     # 原文进 plan 与 codegen prompt——其余不确定点实验中经 ask 机制动态交互）
     intake: list[IntakeQA] | None = None
+    # 执行后端（Runner v2 显式分派键，#675）：默认 python-ml = 存量行为，全兼容。
+    # 单后端阶段前端不出选择 UI（无意义）；R4 接入 openfoam/ngspice 后由创建表单暴露。
+    backend: str = "python-ml"
+
+    @field_validator("backend")
+    @classmethod
+    def _backend_registered(cls, v: str) -> str:
+        # 延迟导入：schema 是叶子模块，别在 import 期拖起整个 runners 包
+        from app.services.runners.registry import known_backends
+
+        if v not in known_backends():
+            raise ValueError(f"unknown runner backend {v!r}; known: {known_backends()}")
+        return v
 
 
 class ExperimentIntakeQuestion(BaseModel):

--- a/src/backend/app/services/experiments.py
+++ b/src/backend/app/services/experiments.py
@@ -192,6 +192,9 @@ async def create_experiment(
                     if params and params.intake
                     else None
                 ),
+                # 执行后端（Runner v2，#675）：现阶段无读者（动作层仍走旧路），
+                # R4 起 navigator 把它写进 plan.backend 供 resolve_backend 分派
+                "backend": params.backend if params else "python-ml",
             }
         },
         budget=None,

--- a/src/backend/app/services/runners/__init__.py
+++ b/src/backend/app/services/runners/__init__.py
@@ -1,0 +1,47 @@
+"""Runner v2：可插拔实验执行后端（契约 + 注册表 + 适配器）。
+
+设计报告 §13（docs/rfcs/2026-09-02-polaris-2.0-design-report.zh.md）。
+现有 ML runner（app/agents/voyage/runner.py 的 19 原语）作为第一个后端
+`python-ml` 包在契约后面，行为零变化；新后端（openfoam/ngspice/fmu…）
+按同一契约挂进注册表。
+"""
+
+from app.services.runners.contract import (
+    Issue,
+    LicenseNeed,
+    MaterialSpec,
+    ResourceNeeds,
+    ResultBundle,
+    ResultFile,
+    RunContext,
+    RunHandle,
+    RunnerError,
+    RunnerManifest,
+    RunnerPlugin,
+    RunStatus,
+)
+from app.services.runners.registry import (
+    DEFAULT_BACKEND,
+    UnknownBackendError,
+    known_backends,
+    resolve_backend,
+)
+
+__all__ = [
+    "DEFAULT_BACKEND",
+    "Issue",
+    "LicenseNeed",
+    "MaterialSpec",
+    "ResourceNeeds",
+    "ResultBundle",
+    "ResultFile",
+    "RunContext",
+    "RunHandle",
+    "RunStatus",
+    "RunnerError",
+    "RunnerManifest",
+    "RunnerPlugin",
+    "UnknownBackendError",
+    "known_backends",
+    "resolve_backend",
+]

--- a/src/backend/app/services/runners/contract.py
+++ b/src/backend/app/services/runners/contract.py
@@ -1,0 +1,188 @@
+"""Runner v2 契约：manifest 自述 + 七个生命周期方法（设计报告 §13）。
+
+为什么要 v2（现有 Runner Protocol 的四个硬伤，仓库摸底实证）：
+- 19 个原语里 ``setup_venv``/``probe_gpu``/``ensure_plot_deps`` 是 ML 专属，
+  仿真/仪器后端根本没有 venv 或 GPU 概念；
+- 分派靠「plan 有无 container」二值推断，``kind`` 参数被 noqa 忽略；
+- ``launch_run`` 返回 int pid——仪器会话、集群作业号、License 租约装不下；
+- 指标只有 stdout 标量序列一条通道，CSV/mat/图像等结果文件没有落点。
+
+v2 把「后端是什么、要什么、怎么跑」收进 ``RunnerManifest`` 自述（今天全局硬编码的
+requirements.txt + run.sh --smoke 物料检查，降格为 python-ml 一个后端的契约），把
+执行生命周期收敛为 validate → prepare → launch → poll → collect → cancel → cleanup
+七个方法，句柄一律 str。现有 19 原语不动，由 ``python_ml.PythonMLRunner`` 适配。
+
+安全铁律（v1 延续，任何后端不得破坏）：
+- **LLM 只产出文件内容**（run.sh / 求解器 case / netlist …），经 SFTP 等纯数据通道落盘；
+- **平台只跑 manifest 白名单的固定模板命令**，可变部分只有实验产物文件本身；
+- 求解器 CLI 参数来自 manifest 白名单（``parse_container_spec`` 的白名单校验模式），
+  永不来自 LLM 自由文本拼接。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal, Protocol, runtime_checkable
+
+# 运行句柄：一律字符串。python-ml 装 str(pid)；将来集群作业号 / gRPC 会话 id /
+# License 租约 id 都装得下（v1 的 int pid 是它的特例）。
+RunHandle = str
+
+Interaction = Literal["batch", "session", "streaming"]
+SideEffects = Literal["none", "filesystem", "network", "physical"]
+Severity = Literal["error", "warning"]
+RunState = Literal["pending", "running", "succeeded", "failed", "cancelled"]
+
+
+class RunnerError(Exception):
+    """Runner v2 生命周期方法的统一失败类型（prepare 装环境失败、launch 拿不到句柄等）。"""
+
+
+@dataclass(frozen=True, slots=True)
+class MaterialSpec:
+    """物料契约的一项：后端要求实验工作区里必须/可选存在的文件。
+
+    v1 把 requirements.txt/run.sh 硬编码在全局 validate_files 里；v2 里它们只是
+    python-ml 后端的物料——openfoam 要 case 目录、ngspice 要 netlist，各自声明。
+    """
+
+    path: str  # 相对工作区路径（校验走 ssh_exec._validate_relpath 同款白名单）
+    required: bool = True
+    description: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class LicenseNeed:
+    """License 席位需求（FlexLM 等建模为可调度资源：prepare 阶段排队获取而非报错）。"""
+
+    feature: str  # License feature 名（如 "HFSS"）
+    server: str = ""  # license server（host:port；空 = 后端默认）
+    count: int = 1
+
+
+@dataclass(frozen=True, slots=True)
+class ResourceNeeds:
+    """资源需求声明（None = 不声明该维度；调度/预检消费，R2 Resource 模型落地后生效）。"""
+
+    cpu: int | None = None
+    gpu: int | None = None
+    mem_gb: float | None = None
+    walltime_min: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RunnerManifest:
+    """后端自述：注册表分派、物料校验、资源调度、prompt 组装都以它为准。"""
+
+    backend: str  # 后端 id（注册表键，plan.backend 的合法取值）
+    interaction: Interaction  # batch=一次跑完 / session=会话交互 / streaming=持续流式
+    side_effects: SideEffects  # none/filesystem/network/physical（physical=动真设备）
+    materials: tuple[MaterialSpec, ...] = ()  # 物料契约（validate 据此静态检查）
+    io_schema: dict[str, Any] = field(default_factory=dict)  # 输入/输出形状的自述
+    resources: ResourceNeeds = field(default_factory=ResourceNeeds)
+    licenses: tuple[LicenseNeed, ...] = ()  # License 席位（python-ml 为空）
+    credential_kinds: tuple[str, ...] = ("ssh",)  # 接受的凭据类型（R2 泛化后扩展）
+    prompt_pack: str = ""  # plan/codegen/debug/reflect 提示词包引用（R3 消费）
+
+
+@dataclass(frozen=True, slots=True)
+class Issue:
+    """validate 的产出：一条物料/计划问题（error 阻断，warning 提示）。"""
+
+    code: str  # 机器可读（如 "materials.missing"）
+    message: str
+    path: str | None = None  # 关联的物料路径（有则填）
+    severity: Severity = "error"
+
+
+@dataclass(frozen=True, slots=True)
+class RunStatus:
+    """poll 的产出：运行状态快照。"""
+
+    state: RunState
+    exit_code: int | None = None
+    detail: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class ResultFile:
+    """collect 结果文件通道的一项（v1 只有标量指标一条通道，这是 v2 的并行新增）。"""
+
+    name: str  # 展示名（如 "primary_metric.png"）
+    path: str  # 工作区内相对路径
+    parser: str | None = None  # 用哪个解析器出摘要指标（如 "csv"；None=不解析）
+    summary: dict[str, Any] | None = None  # 解析器产出的摘要（如 {"rows": 100}）
+
+
+@dataclass(slots=True)
+class ResultBundle:
+    """collect 的产出：标量指标点 + 结果文件 + 备注。
+
+    metrics 沿用现有标量时间序列点形状 [{name, step, value}]（DB/UI 承重面不动）；
+    files 是新增的结果文件通道；notes 放人读的收尾说明（如日志尾部摘录）。
+    """
+
+    metrics: list[dict[str, Any]] = field(default_factory=list)
+    files: list[ResultFile] = field(default_factory=list)
+    notes: str = ""
+
+
+@dataclass(slots=True)
+class RunContext:
+    """一次 run 的执行上下文：计划 + 物料内容 + 执行底座。
+
+    ``substrate`` 是后端的执行底座——python-ml 传现有 Runner（SSH 主机/容器），
+    将来 grpc 会话、本地进程各按后端约定传各自的底座；契约层不约束其类型，
+    由具体 RunnerPlugin 自己收窄。``scratch`` 供插件在生命周期方法间传递私有状态
+    （如 launch 记下启动命令供审计）。
+    """
+
+    plan: dict[str, Any] = field(default_factory=dict)
+    files: dict[str, str] = field(default_factory=dict)  # 物料：相对路径 → 文件内容
+    substrate: Any = None
+    scratch: dict[str, Any] = field(default_factory=dict)
+
+
+@runtime_checkable
+class RunnerPlugin(Protocol):
+    """执行后端插件的生命周期契约（一个实例服务一次实验 run 的驱动）。
+
+    约定：
+    - ``cleanup`` 必然执行（成功/失败/取消都要走到——释放 License/设备归位靠它）；
+    - 会话型后端另有 open_session/close_session，等第一个会话后端（pyansys/comsol）
+      落地时再入契约；``dry_run`` 保留在契约中但暂缓启用（§13 拍板）。
+    """
+
+    manifest: RunnerManifest
+
+    async def validate(self, plan: dict[str, Any]) -> list[Issue]:
+        """物料契约静态校验：不碰远端，纯看 plan 与物料内容。空列表 = 可以往下走。"""
+        ...
+
+    async def prepare(self, ctx: RunContext) -> None:
+        """环境/License/设备获取：建工作区、落物料、装依赖；失败抛 RunnerError。"""
+        ...
+
+    async def launch(self, ctx: RunContext) -> RunHandle:
+        """启动运行，返回 str 句柄（后续 poll/cancel 凭它定位这次运行）。"""
+        ...
+
+    async def poll(self, handle: RunHandle) -> RunStatus:
+        """查询运行状态（幂等、只读）。"""
+        ...
+
+    async def collect(self, ctx: RunContext) -> ResultBundle:
+        """收集结果：标量指标 + 结果文件 + 备注（幂等，失败的 run 也要尽量收）。"""
+        ...
+
+    async def cancel(self, handle: RunHandle) -> None:
+        """取消运行（尽力而为、幂等：已结束的 run 取消是 no-op）。"""
+        ...
+
+    async def cleanup(self, ctx: RunContext) -> None:
+        """善后：断连接、释放 License/设备。必然执行，不得因 run 失败而跳过。"""
+        ...
+
+    async def dry_run(self, ctx: RunContext) -> RunStatus:
+        """无副作用预演（§13 保留暂缓：契约占位，后端可 NotImplementedError）。"""
+        ...

--- a/src/backend/app/services/runners/python_ml.py
+++ b/src/backend/app/services/runners/python_ml.py
@@ -1,0 +1,240 @@
+"""python-ml 后端：现有 19 原语 Runner 包成第一个 RunnerPlugin（行为零变化）。
+
+这是 v2 契约的**存量适配器**：不重写任何执行逻辑，每个生命周期方法委托
+app/agents/voyage/runner.py 的现有原语。19 原语 → v2 方法落点：
+
+    v2 方法      委托的 v1 原语                               备注
+    ---------   ------------------------------------------  ----------------------------
+    validate    （无远端原语）validate_files 的物料/冒烟契约    纯静态检查，manifest 驱动
+    prepare     mkdir_workdir + write_files + setup_venv     后台脱离版 launch_setup/
+                                                             read_setup_exit/read_setup_log
+                                                             是同一步的可恢复形态，修复循环
+                                                             仍由动作层直接驱动
+    launch      launch_run                                   int pid → str 句柄
+    poll        read_exit_code + check_pid                   幂等只读
+    collect     tail_log + read_metrics_json + list_dir      标量指标双通道 + figures 文件
+                + read_file（文件内容按需另取）
+    cancel      kill_pid
+    cleanup     close                                        缺位：v1 只有断连原语，无
+                                                             「清工作区/释放资源」——工作区
+                                                             留在远端是现网有意行为（复查
+                                                             产物）；License/设备释放等 R2
+                                                             资源模型落地后需补新原语
+    dry_run     ——                                           缺位：v1 无预演原语（run_smoke
+                                                             是小样本**真实执行**，有副作用，
+                                                             不是 dry run），NotImplemented
+
+    未进 v2 生命周期的 v1 原语（留在动作层，另有归宿）：
+    - run_smoke / run_plot / ensure_plot_deps：python-ml 专属的冒烟与产图**动作**，
+      属于该后端的 prompt pack 流程（R3 process pack 收编），不是通用生命周期；
+    - probe_gpu / read_setup_exit / read_setup_log / launch_setup：资源预检与
+      可恢复安装，R2 Resource 模型与 v2 prepare 的异步句柄形态落地后吸收；
+    - workdir / read_file / list_dir / tail_log / read_metrics_json / read_exit_code /
+      check_pid：观测面原语，poll/collect 之外动作层（运行台/代码浏览）仍直接消费。
+
+安全铁律不变：LLM 只产文件内容（requirements.txt/run.sh/*.py），经 SFTP 落盘；
+本适配器与底层原语只跑固定模板命令（bash run.sh、python plot_figures.py 等）。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.agents.voyage.runner import Runner
+from app.services.runners.contract import (
+    Issue,
+    MaterialSpec,
+    ResultBundle,
+    ResultFile,
+    RunContext,
+    RunHandle,
+    RunnerError,
+    RunnerManifest,
+    RunStatus,
+)
+
+PYTHON_ML_BACKEND = "python-ml"
+
+# 今天硬编码在全局 validate_files 里的 requirements.txt + run.sh --smoke 契约，
+# 降格为本后端的物料声明（设计报告 §13：物料契约按后端自述，不再全局绑死）。
+PYTHON_ML_MANIFEST = RunnerManifest(
+    backend=PYTHON_ML_BACKEND,
+    interaction="batch",
+    side_effects="filesystem",
+    materials=(
+        MaterialSpec(
+            "requirements.txt",
+            required=True,
+            description="pip 依赖清单（venv/容器内增量安装）",
+        ),
+        MaterialSpec(
+            "run.sh",
+            required=True,
+            description="实验入口脚本；必须支持 --smoke 小样本快速自检",
+        ),
+    ),
+    io_schema={
+        "inputs": {"files": "LLM 产出的实验代码文件（相对工作区路径 → 文本内容）"},
+        "outputs": {
+            "run.log": "stdout/stderr 合流日志（POLARIS_METRIC 行内嵌标量指标）",
+            "run.exit": "退出码落盘文件（poll 的判定依据）",
+            "metrics.json": "可选结构化指标（平台确定性解析，非 LLM）",
+            "figures/": "plot_figures.py 产出的图表",
+        },
+    },
+    # 资源需求不在 manifest 里写死：GPU 用量由 plan/资源预检按实验决定（R2 接管调度）。
+    licenses=(),
+    credential_kinds=("ssh",),
+    prompt_pack=PYTHON_ML_BACKEND,
+)
+
+
+class PythonMLRunner:
+    """把现有 Runner（SSH 裸机/容器）适配成 RunnerPlugin。
+
+    实例绑定一次 run 的执行底座（底座持有 SSH 会话），不跨 run 复用。
+    validate 是纯静态检查，可以在无底座时（resolve_backend 不传 runner）调用；
+    其余生命周期方法要求底座在场。
+    """
+
+    manifest = PYTHON_ML_MANIFEST
+
+    def __init__(self, runner: Runner | None = None) -> None:
+        self._runner = runner
+
+    @classmethod
+    def create(cls, *, runner: Runner | None = None, **_: Any) -> PythonMLRunner:
+        """注册表工厂入口（多余的 substrate 关键字忽略：别的后端可能收别的底座）。"""
+        return cls(runner=runner)
+
+    def _require_runner(self) -> Runner:
+        if self._runner is None:
+            raise RunnerError("python-ml 插件未绑定执行底座（resolve_backend 需传 runner=…）")
+        return self._runner
+
+    async def validate(self, plan: dict[str, Any]) -> list[Issue]:
+        """物料契约静态校验：manifest 声明的必需文件 + 存量 validate_files 的深检查。
+
+        plan["files"] 携带物料内容（相对路径 → 文本）。先按 manifest 报齐所有缺失项
+        （比 validate_files 的首错即抛对修复循环更友好），再委托存量检查兜
+        路径白名单 / run.sh --smoke / Python 语法（延迟导入避免 schemas→registry→
+        actions_experiment→schemas 的环）。
+        """
+        files = plan.get("files") if isinstance(plan, dict) else None
+        if not isinstance(files, dict) or not files:
+            return [
+                Issue(
+                    code="materials.missing",
+                    message=f"缺少必需物料 {m.path}（{m.description}）",
+                    path=m.path,
+                )
+                for m in self.manifest.materials
+                if m.required
+            ]
+        issues = [
+            Issue(
+                code="materials.missing",
+                message=f"缺少必需物料 {m.path}（{m.description}）",
+                path=m.path,
+            )
+            for m in self.manifest.materials
+            if m.required and m.path not in files
+        ]
+        if issues:
+            return issues
+        from app.agents.voyage.actions_experiment import validate_files
+
+        try:
+            validate_files({"files": files})
+        except ValueError as e:
+            issues.append(Issue(code="materials.invalid", message=str(e)))
+        return issues
+
+    async def prepare(self, ctx: RunContext) -> None:
+        """备环境 = mkdir_workdir + write_files + setup_venv（前台形态）。
+
+        动作层的可恢复安装（launch_setup + read_setup_exit/read_setup_log 轮询、
+        pip 失败回 LLM 修 requirements.txt）是同一步的脱离形态，仍由动作层驱动；
+        v2 的 prepare 引入异步句柄形态时再吸收。
+        """
+        runner = self._require_runner()
+        made = await runner.mkdir_workdir()
+        if made.exit_status != 0:
+            raise RunnerError(f"创建工作区失败：{(made.stderr or made.stdout).strip()[:300]}")
+        if ctx.files:
+            await runner.write_files(ctx.files)
+        setup = await runner.setup_venv()
+        if setup.exit_status != 0:
+            raise RunnerError(f"依赖安装失败：{(setup.stderr or setup.stdout).strip()[:300]}")
+
+    async def launch(self, ctx: RunContext) -> RunHandle:
+        """启动正式运行：launch_run 的 int pid 包成 str 句柄；启动命令记入 scratch 供审计。"""
+        runner = self._require_runner()
+        pid, command = await runner.launch_run()
+        ctx.scratch["launch_command"] = command
+        return str(pid)
+
+    async def poll(self, handle: RunHandle) -> RunStatus:
+        runner = self._require_runner()
+        try:
+            pid = int(handle)
+        except ValueError as e:  # 句柄一定来自本插件的 launch；非数字 = 用错了插件/句柄
+            raise RunnerError(f"python-ml 句柄应为 pid 字符串，得到 {handle!r}") from e
+        exit_code = await runner.read_exit_code()
+        if exit_code is None and not await runner.check_pid(pid):
+            # 竞态：进程可能在两次探测之间刚好结束——再读一次 run.exit 才能下结论
+            exit_code = await runner.read_exit_code()
+            if exit_code is None:
+                return RunStatus(
+                    state="failed",
+                    detail="进程已退出但未落盘 run.exit（疑被 kill -9 或主机重启）",
+                )
+        if exit_code is None:
+            return RunStatus(state="running")
+        if exit_code == 0:
+            return RunStatus(state="succeeded", exit_code=0)
+        return RunStatus(state="failed", exit_code=exit_code)
+
+    async def collect(self, ctx: RunContext) -> ResultBundle:
+        """收结果：标量指标双通道（run.log 的 POLARIS_METRIC 行 + 可选 metrics.json）
+        照抄动作层的确定性解析；figures/ 走 v2 新增的结果文件通道。
+
+        与已入库指标点的去重是调用方的事（动作层轮询期间已逐段解析过日志）。
+        """
+        runner = self._require_runner()
+        from app.agents.voyage.actions_experiment import parse_metric_lines, parse_metrics_json
+
+        metrics: list[dict[str, Any]] = []
+        log_text, _ = await runner.tail_log(0)
+        metrics.extend(parse_metric_lines(log_text))
+        metrics_text = await runner.read_metrics_json()
+        if metrics_text:
+            metrics.extend(parse_metrics_json(metrics_text))
+        files = [
+            ResultFile(name=name, path=f"figures/{name}")
+            for name in await runner.list_dir("figures")
+        ]
+        notes = log_text[-2000:].strip()
+        return ResultBundle(metrics=metrics, files=files, notes=notes)
+
+    async def cancel(self, handle: RunHandle) -> None:
+        runner = self._require_runner()
+        try:
+            pid = int(handle)
+        except ValueError as e:
+            raise RunnerError(f"python-ml 句柄应为 pid 字符串，得到 {handle!r}") from e
+        await runner.kill_pid(pid)  # v1 语义：kill TERM，尽力而为（已退出 = no-op）
+
+    async def cleanup(self, ctx: RunContext) -> None:
+        """善后 = close（断 SSH 连接）。
+
+        缺位原语：v1 没有「清工作区/释放资源」——远端工作区**有意**保留（用户复查
+        产物、失败诊断都要它）；License/设备归位要等 R2 资源模型给出新原语。
+        """
+        runner = self._require_runner()
+        await runner.close()
+
+    async def dry_run(self, ctx: RunContext) -> RunStatus:
+        # 缺位原语：v1 无预演能力。run_smoke 是小样本**真实执行**（装依赖、写文件、
+        # 跑代码），不是无副作用的 dry run，不能拿来冒充。契约占位，暂缓启用（§13）。
+        raise NotImplementedError("python-ml 后端暂无 dry_run（v1 无预演原语）")

--- a/src/backend/app/services/runners/registry.py
+++ b/src/backend/app/services/runners/registry.py
@@ -1,0 +1,78 @@
+"""Runner v2 注册表：backend id → 插件工厂，`plan.backend` 显式分派。
+
+替代 v1 的「plan 有无 container」二值推断：后端选择是**显式数据**（plan.backend），
+默认 `python-ml` 保全兼容——今天所有存量实验不写 backend，走 python-ml，行为不变。
+实验 kind（eval/training/…）退役为科学语义标签，不再暗示执行后端。
+
+分派现状与迁移计划：本阶段（R1）注册表与 python-ml 适配器就位，`resolve_backend`
+可拿到并驱动插件，但 **actions_experiment 仍走旧路**（直接调 open_runner + 19 原语）——
+切换动作层到 v2 分派是 R4 接入第一个非 ML 后端（openfoam/ngspice）时的事：届时
+动作层按 resolve_backend 拿插件，python-ml 的行为因适配器全部委托存量原语而保持逐字节一致。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from app.services.runners.contract import RunnerPlugin
+from app.services.runners.python_ml import PYTHON_ML_BACKEND, PythonMLRunner
+
+DEFAULT_BACKEND = PYTHON_ML_BACKEND  # 缺省后端：兼容全部存量实验
+
+
+class UnknownBackendError(ValueError):
+    """plan.backend 指了注册表里没有的后端（拼错/插件未安装）。"""
+
+    def __init__(self, backend: str, known: list[str]) -> None:
+        self.backend = backend
+        self.known = known
+        super().__init__(f"unknown runner backend {backend!r}; known: {', '.join(known)}")
+
+
+# 后端 id → 插件工厂。工厂收关键字参数（如 python-ml 的 runner=执行底座），返回插件实例；
+# 存工厂而非单例，是因为插件实例绑定一次 run 的底座（SSH 会话等），不能跨 run 复用。
+_FACTORIES: dict[str, Callable[..., RunnerPlugin]] = {}
+
+
+def register(backend: str, factory: Callable[..., RunnerPlugin]) -> None:
+    """注册后端插件工厂。重名直接拒绝——静默覆盖会把分派变成 import 顺序问题。"""
+    key = backend.strip()
+    if not key:
+        raise ValueError("runner backend id must be non-empty")
+    if key in _FACTORIES:
+        raise ValueError(f"runner backend already registered: {key!r}")
+    _FACTORIES[key] = factory
+
+
+def get(backend: str) -> Callable[..., RunnerPlugin]:
+    """按 id 取插件工厂；未注册 → UnknownBackendError。"""
+    factory = _FACTORIES.get(backend)
+    if factory is None:
+        raise UnknownBackendError(backend, known_backends())
+    return factory
+
+
+def known_backends() -> list[str]:
+    """已注册后端 id（排序稳定；schema 校验 params.backend ∈ 此集合）。"""
+    return sorted(_FACTORIES)
+
+
+def resolve_backend(plan: Any, **substrate: Any) -> RunnerPlugin:
+    """分派入口：读 plan.backend（缺省 python-ml），从注册表实例化插件。
+
+    substrate 关键字参数透传给插件工厂（python-ml 需要 runner=现有执行底座）。
+    plan.backend 是受校验数据（ExperimentParams 入口已限定 ∈ 注册表），这里再兜一道：
+    未注册后端抛 UnknownBackendError，绝不静默回退——静默回退会把「插件没装」变成
+    「用错后端跑了实验」。
+    """
+    backend = DEFAULT_BACKEND
+    if isinstance(plan, dict):
+        raw = str(plan.get("backend") or "").strip()
+        if raw:
+            backend = raw
+    return get(backend)(**substrate)
+
+
+# —— 内建后端注册（新后端在各自模块里定义工厂，在这里挂进注册表）——
+register(PYTHON_ML_BACKEND, PythonMLRunner.create)

--- a/src/backend/tests/test_runner_v2.py
+++ b/src/backend/tests/test_runner_v2.py
@@ -1,0 +1,225 @@
+"""Runner v2 契约测试（#675）：manifest / 注册表分派 / python-ml 适配器映射，
+外加一条经 v2 契约驱动的最小假 run（fake SSH 底座，照现有 runner 测试模式）。
+
+动作层（actions_experiment）本阶段仍走旧路——这里只证明：经 resolve_backend
+拿到的插件能独立驱动一次完整生命周期，且全部委托存量原语（行为零变化）。
+"""
+
+import json
+import uuid
+
+import pytest
+import pytest_asyncio
+from pydantic import ValidationError
+
+from app.core.db import get_sessionmaker
+from app.models.project import Project
+from app.models.user import User
+from app.schemas.experiment import ExperimentParams
+from app.services import ssh_exec
+from app.services.runners import contract, registry
+from app.services.runners.python_ml import PYTHON_ML_MANIFEST, PythonMLRunner
+from tests.fake_ssh import FakeSSHServer, FakeSSHSession
+
+# 合格物料：满足 python-ml manifest（requirements.txt + 支持 --smoke 的 run.sh）
+GOOD_FILES = {
+    "requirements.txt": "numpy\n",
+    "run.sh": "#!/bin/bash\npython train.py $1\n# supports --smoke\n",
+    "train.py": "print('POLARIS_METRIC ' + '{}')\n",
+}
+
+
+# ---- manifest：物料契约降格为后端自述 ----
+
+
+def test_python_ml_manifest_declares_the_legacy_contract():
+    m = PYTHON_ML_MANIFEST
+    assert m.backend == "python-ml"
+    assert m.interaction == "batch"
+    assert m.side_effects == "filesystem"
+    required = [mat.path for mat in m.materials if mat.required]
+    assert required == ["requirements.txt", "run.sh"]  # 原全局校验降格至此
+    assert m.credential_kinds == ("ssh",)
+    assert m.licenses == ()  # python-ml 无 License 席位需求
+    assert m.prompt_pack == "python-ml"
+
+
+def test_python_ml_satisfies_runner_plugin_protocol():
+    assert isinstance(PythonMLRunner(), contract.RunnerPlugin)
+
+
+# ---- 注册表与分派 ----
+
+
+def test_registry_knows_python_ml_and_dispatches_default():
+    assert "python-ml" in registry.known_backends()
+    plugin = registry.resolve_backend({})  # plan 未声明 backend → 默认
+    assert isinstance(plugin, PythonMLRunner)
+    assert registry.resolve_backend({"backend": "python-ml"}).manifest is PYTHON_ML_MANIFEST
+    assert registry.resolve_backend(None).manifest.backend == "python-ml"  # 非 dict 也走默认
+
+
+def test_registry_rejects_unknown_backend():
+    with pytest.raises(registry.UnknownBackendError) as exc:
+        registry.resolve_backend({"backend": "quantum-annealer"})
+    assert "quantum-annealer" in str(exc.value)
+    assert "python-ml" in str(exc.value)  # 报错带出已知后端，拼错时可自纠
+
+
+def test_registry_rejects_duplicate_and_empty_registration():
+    with pytest.raises(ValueError, match="already registered"):
+        registry.register("python-ml", PythonMLRunner.create)
+    with pytest.raises(ValueError, match="non-empty"):
+        registry.register("  ", PythonMLRunner.create)
+
+
+# ---- schema：params.backend 校验 ∈ 注册表 ----
+
+
+def test_experiment_params_backend_defaults_and_validates():
+    assert ExperimentParams().backend == "python-ml"
+    assert ExperimentParams(backend="python-ml").backend == "python-ml"
+    with pytest.raises(ValidationError, match="unknown runner backend"):
+        ExperimentParams(backend="quantum-annealer")
+
+
+# ---- validate：manifest 驱动的物料静态检查（委托存量 validate_files 深检查） ----
+
+
+async def test_validate_reports_all_missing_materials():
+    issues = await PythonMLRunner().validate({"files": {"train.py": "x = 1\n"}})
+    assert [i.path for i in issues] == ["requirements.txt", "run.sh"]
+    assert all(i.code == "materials.missing" and i.severity == "error" for i in issues)
+    # 完全没给物料：同样按 manifest 报齐必需项（validate 无底座也可用）
+    issues = await PythonMLRunner().validate({})
+    assert [i.path for i in issues] == ["requirements.txt", "run.sh"]
+
+
+async def test_validate_delegates_legacy_smoke_and_syntax_checks():
+    plugin = PythonMLRunner()
+    no_smoke = {**GOOD_FILES, "run.sh": "#!/bin/bash\npython train.py\n"}
+    issues = await plugin.validate({"files": no_smoke})
+    assert [i.code for i in issues] == ["materials.invalid"]
+    assert "--smoke" in issues[0].message
+    bad_py = {**GOOD_FILES, "train.py": "def broken(:\n"}
+    issues = await plugin.validate({"files": bad_py})
+    assert [i.code for i in issues] == ["materials.invalid"]
+    assert (await plugin.validate({"files": GOOD_FILES})) == []
+
+
+# ---- python-ml 适配器：v2 生命周期端到端驱动一个最小假 run ----
+
+
+@pytest_asyncio.fixture
+async def project_id(app):
+    """真实课题行：底座每条命令过 _audit 落 Activity（FK 指向 projects）。"""
+    owner = User(
+        id=uuid.uuid4(),
+        email="runner-v2@example.com",
+        hashed_password="test",
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+    )
+    project = Project(
+        id=uuid.uuid4(),
+        name="runner-v2",
+        slug=f"runner-v2-{uuid.uuid4().hex[:8]}",
+        owner_id=owner.id,
+    )
+    async with get_sessionmaker()() as session:
+        session.add(owner)
+        await session.flush()
+        session.add(project)
+        await session.commit()
+    return project.id
+
+
+def _executor(server: FakeSSHServer, project_id: uuid.UUID) -> ssh_exec.SSHExecutor:
+    return ssh_exec.SSHExecutor(
+        FakeSSHSession(server),
+        exp_id=str(uuid.uuid4()),
+        host="gpu.example",
+        project_id=project_id,
+    )
+
+
+async def test_v2_drives_a_minimal_python_ml_run(project_id):
+    """经 v2 契约走完 validate→prepare→launch→poll→collect→cancel→cleanup 全周期。
+
+    每步都应落在存量原语上（断言 fake 收到的命令/文件与 v1 直调完全一致）。
+    app 夹具提供 DB：底座每条命令过 _audit 落 Activity（v1 审计行为原样保留）。
+    """
+    server = FakeSSHServer(
+        run_log='POLARIS_METRIC {"name": "accuracy", "step": 1, "value": 0.75}\ndone\n',
+        run_exit=None,  # 先模拟仍在运行
+        metrics_json=json.dumps({"f1": 0.5}),
+    )
+    executor = _executor(server, project_id)
+    plugin = registry.resolve_backend({}, runner=executor)
+
+    assert await plugin.validate({"files": GOOD_FILES}) == []
+
+    ctx = contract.RunContext(plan={}, files=GOOD_FILES, substrate=executor)
+    await plugin.prepare(ctx)
+    sftp_root = f"polaris_runs/{executor.exp_id}"
+    assert f"{sftp_root}/requirements.txt" in server.files  # 物料经 SFTP 落盘，不进 shell
+    assert any(c.startswith("mkdir -p") for c in server.commands)
+    assert any("pip install" in c for c in server.commands)  # setup_venv 原样执行
+
+    handle = await plugin.launch(ctx)
+    assert handle == str(server.pid)  # int pid → str 句柄（v2 唯一的形态变化）
+    assert ctx.scratch["launch_command"].endswith("echo $!")  # 启动命令留档供审计
+
+    status = await plugin.poll(handle)
+    assert status.state == "running"
+    server.run_exit = 0  # 假进程结束
+    status = await plugin.poll(handle)
+    assert status == contract.RunStatus(state="succeeded", exit_code=0)
+
+    server.files[f"{sftp_root}/figures/primary_metric.png"] = b"\x89PNG fake"
+    bundle = await plugin.collect(ctx)
+    by_name = {p["name"]: p["value"] for p in bundle.metrics}
+    assert by_name == {"accuracy": 0.75, "f1": 0.5}  # 双通道：日志行 + metrics.json
+    assert [f.path for f in bundle.files] == ["figures/primary_metric.png"]
+    assert "done" in bundle.notes
+
+    await plugin.cancel(handle)
+    assert server.killed == [server.pid]  # cancel → kill_pid（幂等，已结束也是 no-op）
+    await plugin.cleanup(ctx)
+
+    with pytest.raises(NotImplementedError):  # v1 无预演原语，dry_run 暂缓（§13）
+        await plugin.dry_run(ctx)
+
+
+async def test_prepare_failure_surfaces_as_runner_error(project_id):
+    server = FakeSSHServer(venv_exit=1)
+    plugin = PythonMLRunner(runner=_executor(server, project_id))
+    with pytest.raises(contract.RunnerError, match="依赖安装失败"):
+        await plugin.prepare(contract.RunContext(files=GOOD_FILES))
+
+
+async def test_poll_flags_vanished_process_without_exit_file(project_id):
+    """进程消失且未落盘 run.exit → failed 带说明（而非永远 running）。"""
+    server = FakeSSHServer(run_exit=None)
+    plugin = PythonMLRunner(runner=_executor(server, project_id))
+    handle = await plugin.launch(contract.RunContext())
+    server.launched = False  # 模拟进程凭空消失（kill -9 / 主机重启）
+    status = await plugin.poll(handle)
+    assert status.state == "failed"
+    assert status.exit_code is None
+    assert "run.exit" in status.detail
+
+
+async def test_unbound_plugin_refuses_lifecycle_but_allows_validate():
+    """resolve_backend 不传底座：validate 可用（纯静态），生命周期方法明确报错。"""
+    plugin = registry.resolve_backend({})
+    assert await plugin.validate({"files": GOOD_FILES}) == []
+    with pytest.raises(contract.RunnerError, match="执行底座"):
+        await plugin.prepare(contract.RunContext())
+
+
+async def test_poll_rejects_foreign_handle(project_id):
+    plugin = PythonMLRunner(runner=_executor(FakeSSHServer(), project_id))
+    with pytest.raises(contract.RunnerError, match="pid"):
+        await plugin.poll("lease:abc123")  # 别的后端的句柄形态

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -2592,6 +2592,9 @@ export interface CreateExperimentInput {
     extra_notes?: string;
     /** 开题问答（AI 按 idea 生成的问题 + 用户回答；进计划与代码生成 prompt） */
     intake?: ExperimentIntakeQA[];
+    /** 执行后端（Runner v2 分派键，#675）：缺省 python-ml=存量行为。
+     * 单后端阶段创建表单不出选择 UI；接入 openfoam/ngspice 等后端后在此暴露。 */
+    backend?: string;
   };
 }
 


### PR DESCRIPTION
Closes #675. Part of #674 (P3 wave 1, item R1); design report §13.

The v2 execution contract with the existing ML runner wrapped as its first backend. Zero behavior change: the action layer's calls are untouched and the existing experiment suites pass identically.

- `contract.py`: frozen `RunnerManifest` (backend, interaction, side-effect class, materials contract, io schema, resource/license needs, credential kinds, prompt-pack ref) and the `RunnerPlugin` protocol (validate / prepare / launch→str handle / poll / collect→ResultBundle with a result-file channel / cancel / cleanup, plus a deferred dry_run placeholder). The safety invariant is stated at the top: LLMs produce file contents only; the platform runs fixed template commands with manifest-whitelisted arguments
- `registry.py`: factory registration (a plugin instance binds one run's substrate), duplicate-id rejection, and `resolve_backend(plan)` defaulting to `python-ml` — an unknown backend raises rather than silently falling back; the migration note documents that action-layer dispatch flips with R4
- `python_ml.py`: the 19 v1 primitives mapped into the v2 lifecycle (mapping table in the PR discussion below); the global requirements.txt/run.sh validation demotes to this backend's manifest; genuinely missing primitives (workspace cleanup, dry-run) are documented as such instead of faked
- `ExperimentParams.backend` (default `python-ml`, registry-validated) recorded into run params for R4's dispatch flip; frontend type updated, no UI while a single backend exists

13 new tests (manifest/registry/dispatch, adapter mapping over the fake substrate, a minimal end-to-end v2-driven run) alongside the untouched existing experiment suites.

Verification: clean baseline 1577 passed / 3 pre-existing #581 failures; branch 1589 passed = baseline + exactly the 13 new tests, +1 known clock flake green standalone — zero new real failures; goldens untouched; frontend build + vitest 158 green.