### PR TITLE
feat: process packs, phase 1

### DIFF
--- a/src/backend/app/agents/voyage/navigator.py
+++ b/src/backend/app/agents/voyage/navigator.py
@@ -15,6 +15,7 @@ from app.agents.voyage.skillset import skill_workflows
 from app.core.llm.base import Message
 from app.core.llm.router import LLMRouter
 from app.models.voyage import VoyageRun
+from app.services.process_packs import load_pack, plan_from_pack
 
 _MAX_ATTEMPTS = 3  # 首次 + 重试 2 次
 
@@ -759,6 +760,12 @@ class Navigator:
         if run.kind == "idea_proposal":
             return proposal_plan(run)
         if run.kind == "experiment":
+            # 流程包一期（#678，设计报告 §8.3）：创建实验时显式选了 process_pack
+            # 才走「加载包 → 由 phases 生成计划」；不选包走下面的原 plan 函数
+            # 原路径——直接 if 分支、不做任何抽象间接，保证行为逐字节不变（golden）。
+            pack_name = ((run.checkpoint or {}).get("params") or {}).get("process_pack")
+            if pack_name:
+                return plan_from_pack(load_pack(str(pack_name)), run)
             return experiment_plan(run)
         if run.kind == "paper_writing":
             return writing_plan(run)

--- a/src/backend/app/packs/base-experiment.yaml
+++ b/src/backend/app/packs/base-experiment.yaml
@@ -1,0 +1,34 @@
+# 内置流程包 base/experiment（#678 一期，设计报告 §8.3）：
+# 现有 experiment 计划函数（navigator.experiment_plan）输出的物化。
+#
+# 保真承诺：本包生成的计划与原 plan 函数输出**等价**——由
+# tests/test_process_packs.py 的逐 params 对照断言守护，两边任一漂移测试即红。
+# 步骤标题/验收/失败语义是动作侧元数据，见 process_packs._STEP_TEMPLATES；
+# 本文件只声明流程拓扑（phase 顺序、检查、循环）与软知识（guidance）。
+kind: research-process
+name: base/experiment
+phases:
+  - id: plan
+    actions: [experiment.plan]
+  - id: setup
+    # 预算闸门（compute_budget）不在这里声明：gates 字段本期惰性（deferral），
+    # 沿用 params.confirm_budget 开关（#626 默认不拦），由生成逻辑落到本步。
+    actions: [experiment.setup]
+  - id: smoke
+    # 冒烟用退出码机械判定（原 Sextant 硬编码逻辑，docs/voyage-loop.md §6）
+    actions: [experiment.smoke]
+    checks: ["exit_code:0"]
+  - id: iterate
+    # 螺旋迭代：run → analyze 为一轮；analyze 给出 improve/debug/finish 判定，
+    # 后续轮由 plan_edit.SIGNAL_TABLES 确定性追加（终止 → figures+report 收尾）。
+    # 本期引擎只顺序展开第 1 轮；fanout/funnel 拓扑等引擎支持后再消费 loop.kind。
+    actions: [experiment.run, experiment.analyze]
+    loop: { kind: spiral, exit_check: experiment.analyze }
+guidance: |
+  计划 → 建环境 → 冒烟 → 逐轮「运行 + 分析」螺旋迭代；分析步骤给出
+  improve/debug/finish 判定，终止后以图表 + 报告收尾。
+  失败语义按节点分派：plan/setup/analyze/figures/report 失败走 loop 回灌
+  （原地重试 → AI 计划调整）；冒烟与运行失败即硬停——冒烟动作内部已有
+  LLM 修复循环（只受时间预算约束），仍失败转向用户提问；运行级失败 =
+  预算超时/基础设施故障，盲目重跑烧算力；训练本身失败（exit != 0）不算
+  步骤失败，observation 携带 exit_code 交由分析步骤走 debug 分支。

--- a/src/backend/app/schemas/experiment.py
+++ b/src/backend/app/schemas/experiment.py
@@ -41,6 +41,10 @@ class ExperimentParams(BaseModel):
     # 执行后端（Runner v2 显式分派键，#675）：默认 python-ml = 存量行为，全兼容。
     # 单后端阶段前端不出选择 UI（无意义）；R4 接入 openfoam/ngspice 后由创建表单暴露。
     backend: str = "python-ml"
+    # 流程包（#678 一期）：显式选包 → Navigator 按包 phases 生成计划；
+    # 不选（None，默认）= 原 plan 函数原路径，行为逐字节不变。
+    # 本期只有内置包（如 "base/experiment"），无编辑/选择 UI（deferral）。
+    process_pack: str | None = None
 
     @field_validator("backend")
     @classmethod
@@ -50,6 +54,20 @@ class ExperimentParams(BaseModel):
 
         if v not in known_backends():
             raise ValueError(f"unknown runner backend {v!r}; known: {known_backends()}")
+        return v
+
+    @field_validator("process_pack")
+    @classmethod
+    def _process_pack_exists(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        # 延迟导入：同 backend 校验，别在 import 期拖起服务层
+        from app.services.process_packs import known_pack_names
+
+        if v not in known_pack_names():
+            raise ValueError(
+                f"unknown process pack {v!r}; known: {sorted(known_pack_names())}"
+            )
         return v
 
 

--- a/src/backend/app/services/experiments.py
+++ b/src/backend/app/services/experiments.py
@@ -195,6 +195,8 @@ async def create_experiment(
                 # 执行后端（Runner v2，#675）：现阶段无读者（动作层仍走旧路），
                 # R4 起 navigator 把它写进 plan.backend 供 resolve_backend 分派
                 "backend": params.backend if params else "python-ml",
+                # 流程包（#678）：非空时 navigator 按包生成计划；None = 原路径
+                "process_pack": params.process_pack if params else None,
             }
         },
         budget=None,

--- a/src/backend/app/services/process_packs.py
+++ b/src/backend/app/services/process_packs.py
@@ -1,0 +1,286 @@
+"""流程包（research-process）一期：科研流程从代码降级为数据（设计报告 §8.3，#678）。
+
+学科流程差异集中在四维——循环拓扑、硬闸门位置、不可逆性、确定性/判断性配比——
+流程包把流程定义收进 YAML：phases（引用注册表里的 action）+ checks/rubrics +
+loop 拓扑 + guidance 软知识。本期范围（其余按 deferral 决策明确不做）：
+
+- 只读内置包目录（``app/packs/``，file-over-app）；用户数据目录的包后续接入；
+- ``gates`` / ``irreversible`` 字段进 schema 但**惰性**：IRB 类学科现实需要表达力，
+  schema 先收下占位，引擎本期不消费（deferral 决策，见 #678）；预算闸门仍沿用
+  params 开关（与原 plan 函数逐字节一致）；
+- loop 只做顺序展开第 1 轮（后续轮由 plan_edit.SIGNAL_TABLES 确定性追加）；
+  fanout/funnel 拓扑等引擎支持后再消费 ``loop.kind``；
+- 不选包 = navigator 原 plan 函数原路径，行为逐字节不变（golden 保全铁律）。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from app.models.voyage import VoyageRun
+
+# 内置包目录（随 app 包分发，见 pyproject [tool.setuptools.package-data]）
+BUILTIN_PACKS_DIR = Path(__file__).resolve().parents[1] / "packs"
+
+
+class ProcessPackError(Exception):
+    """流程包非法（YAML 解析失败 / schema 不符 / 引用未注册的 action 等）。
+
+    message 必须 actionable：指明哪个文件/哪个 phase、期望什么——它会原样出现在
+    创建实验的 422 响应与任务失败诊断里。
+    """
+
+
+class PackLoop(BaseModel):
+    """phase 的循环拓扑声明。本期只作标注：引擎仍顺序展开第 1 轮，
+    后续轮由确定性分支表追加；fanout（扇出并行）/funnel（漏斗收敛）待引擎支持。"""
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: Literal["fanout", "spiral", "funnel"]
+    exit_check: str | None = None
+    max_parallel: int | None = Field(default=None, ge=1)
+
+
+class PackPhase(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(min_length=1)
+    # 引用动作注册表里的 action 名（app/agents/voyage/actions.py register()）
+    actions: list[str] = []
+    # 确定性校验（Sextant 检查项的字符串写法，见 _parse_check）；None = 缺省 no_error
+    checks: list[str] | None = None
+    # LLM 评审 rubric（追加为 llm_rubric 检查项）
+    rubrics: list[str] | None = None
+    loop: PackLoop | None = None
+
+
+class ProcessPack(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: Literal["research-process"]
+    name: str = Field(min_length=1)
+    # 单层继承：phases 追加/覆盖同 id、guidance 拼接（父包自身不得再 extends）
+    extends: str | None = None
+    phases: list[PackPhase] = []
+    # 软知识：后续渲染进 Navigator 规划提示（自由档投影）；严格档本期不消费
+    guidance: str = ""
+    # ---- 惰性字段（deferral，#678）----
+    # 硬闸门与不可逆声明进 schema 占位（IRB/湿实验类学科需要这份表达力），
+    # 引擎本期不消费：写了不报错、也不产生任何行为。
+    gates: list[dict[str, Any]] = []
+    irreversible: list[str] = []
+
+
+# ---- 检查项字符串语法 ----
+# YAML 里 checks 用紧凑字符串（"no_error" / "exit_code:0" / "artifact_exists:<键>"），
+# 解析成 Sextant 检查项 dict（app/agents/voyage/checks.py）。只开放包目前用得上的
+# 确定性检查；新增 kind 时同步扩这里，别让包写出引擎不认识的检查。
+
+
+def _parse_check(spec: str) -> dict[str, Any]:
+    kind, _, arg = spec.partition(":")
+    if kind == "no_error" and not arg:
+        return {"kind": "no_error"}
+    if kind == "exit_code":
+        try:
+            return {"kind": "exit_code", "value": int(arg or "0")}
+        except ValueError as e:
+            raise ProcessPackError(f"exit_code 检查的期望值必须是整数：{spec!r}") from e
+    if kind == "artifact_exists" and arg:
+        return {"kind": "artifact_exists", "key": arg}
+    raise ProcessPackError(
+        f"未知的检查写法 {spec!r}；支持：no_error / exit_code:<int> / artifact_exists:<键>"
+    )
+
+
+def _phase_checks(phase: PackPhase) -> list[dict[str, Any]]:
+    """phase 的检查项：显式 checks（+ rubrics）；都没写则缺省机械验收 no_error。"""
+    checks = [_parse_check(spec) for spec in phase.checks or []]
+    checks += [{"kind": "llm_rubric", "rubric": r} for r in phase.rubrics or []]
+    return checks or [{"kind": "no_error"}]
+
+
+# ---- 加载与校验 ----
+
+
+def _read_pack_file(path: Path) -> ProcessPack:
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as e:
+        raise ProcessPackError(f"流程包 {path.name} YAML 解析失败：{e}") from e
+    if not isinstance(data, dict):
+        raise ProcessPackError(f"流程包 {path.name} 顶层必须是映射（mapping）")
+    try:
+        return ProcessPack.model_validate(data)
+    except ValidationError as e:
+        raise ProcessPackError(f"流程包 {path.name} schema 校验失败：{e}") from e
+
+
+def _load_all() -> dict[str, ProcessPack]:
+    """读入包目录下全部 YAML，按 name 索引。
+
+    不缓存：包是磁盘上的数据（file-over-app），目录很小，每次现读省掉
+    「改了包文件测试/进程还拿旧缓存」一整类坑。
+    """
+    packs: dict[str, ProcessPack] = {}
+    if not BUILTIN_PACKS_DIR.is_dir():
+        return packs
+    for path in sorted(BUILTIN_PACKS_DIR.rglob("*.yaml")):
+        pack = _read_pack_file(path)
+        if pack.name in packs:
+            raise ProcessPackError(f"流程包重名 {pack.name!r}（{path.name}）")
+        packs[pack.name] = pack
+    return packs
+
+
+def known_pack_names() -> frozenset[str]:
+    """可选的流程包名集合（ExperimentParams.process_pack 校验用）。"""
+    return frozenset(_load_all())
+
+
+def _merge(parent: ProcessPack, child: ProcessPack) -> ProcessPack:
+    """单层继承合并：phases 同 id 覆盖（保持父序）、新 id 追加；guidance 拼接。
+
+    gates/irreversible 是惰性字段，不做合并语义（取子包自己的声明），
+    等启用拦截时再定合并规则——现在定了也没人消费，白背兼容包袱。
+    """
+    phases = list(parent.phases)
+    index = {p.id: i for i, p in enumerate(phases)}
+    for phase in child.phases:
+        if phase.id in index:
+            phases[index[phase.id]] = phase
+        else:
+            phases.append(phase)
+    guidance = "\n".join(g for g in (parent.guidance, child.guidance) if g)
+    return child.model_copy(update={"phases": phases, "guidance": guidance})
+
+
+def _validate_pack(pack: ProcessPack) -> None:
+    """语义校验：action 必须在注册表内（报错列出已知 action 名）、检查写法合法。"""
+    # 延迟导入：注册表随 app.agents.voyage 包的 import 副作用填充，
+    # 这里主动 import 一次保证独立调用（测试/脚本）时注册表非空
+    import app.agents.voyage  # noqa: F401
+    from app.agents.voyage.actions import known_actions
+
+    known = known_actions()
+    for phase in pack.phases:
+        for action in phase.actions:
+            if action not in known:
+                raise ProcessPackError(
+                    f"流程包 {pack.name!r} 的 phase {phase.id!r} 引用了未注册的 "
+                    f"action {action!r}；已注册：{', '.join(sorted(known))}"
+                )
+        _phase_checks(phase)  # 检查写法非法在加载期就报，别拖到生成计划时
+
+
+def load_pack(name: str) -> ProcessPack:
+    """按名加载流程包（含 extends 解析与语义校验）；非法/未知抛 ProcessPackError。"""
+    packs = _load_all()
+    pack = packs.get(name)
+    if pack is None:
+        raise ProcessPackError(
+            f"未知流程包 {name!r}；可选：{', '.join(sorted(packs)) or '（无）'}"
+        )
+    if pack.extends is not None:
+        parent = packs.get(pack.extends)
+        if parent is None:
+            raise ProcessPackError(
+                f"流程包 {name!r} 继承的 {pack.extends!r} 不存在；"
+                f"可选：{', '.join(sorted(packs))}"
+            )
+        if parent.extends is not None:
+            raise ProcessPackError(
+                f"流程包 {name!r} 继承的 {pack.extends!r} 自身还有 extends——只支持单层继承"
+            )
+        pack = _merge(parent, pack)
+    _validate_pack(pack)
+    return pack
+
+
+# ---- 包 → 计划生成 ----
+
+# action → 计划节点元数据（标题 / 验收 / 失败语义）。这些是动作自身的呈现与失败
+# 语义，属于「动作注册侧」的元数据——组件注册表（Runner v2 manifest 方向）成型前
+# 先表驱动收在这里，包 YAML 只写流程拓扑。与 navigator 原 plan 函数的保真由
+# tests/test_process_packs.py 的逐 params 对照断言守护：表漂移测试即红。
+# round_param=True 的动作在 loop phase 里带 {"round": N} 参数、标题按轮次格式化。
+_STEP_TEMPLATES: dict[str, dict[str, Any]] = {
+    "experiment.plan": {
+        "title": "实验计划（LLM）",
+        "acceptance": "plan JSON（含 primary_metric）已通过严格校验并写入 Experiment.plan",
+    },
+    "experiment.setup": {
+        "title": "建环境（SSH + 代码生成）",
+        "acceptance": "远端 workdir 就绪、代码文件已写入、venv 依赖安装成功",
+    },
+    "experiment.smoke": {
+        "title": "冒烟测试",
+        "acceptance": "run.sh --smoke 退出码为 0",
+        # 动作内部已有 LLM 修复循环：步骤级不重试也不交 AI 重排（原 plan 函数语义）
+        "on_failure": "fail",
+        "budget": {"max_attempts": 1},
+    },
+    "experiment.run": {
+        "title": "第 {round} 轮运行",
+        "acceptance": "本轮运行已结束并解析主指标（失败轮交由分析步骤诊断）",
+        # 运行级失败 = 预算超时/基础设施故障，盲目重跑烧算力，诚实硬停
+        "on_failure": "fail",
+        "budget": {"max_attempts": 1},
+        "round_param": True,
+    },
+    "experiment.analyze": {
+        "title": "第 {round} 轮分析",
+        "acceptance": "reflection 已落库并给出继续/收束判定",
+        "round_param": True,
+    },
+}
+
+
+def plan_from_pack(pack: ProcessPack, run: VoyageRun | None) -> list[dict[str, Any]]:
+    """把流程包展开为 voyage 计划步骤（phases 顺序展开，action 逐一映射节点）。
+
+    与 navigator 的原 plan 函数**等价**是硬约束（物化保真）：base/experiment 包
+    生成的计划必须与 experiment_plan() 输出一致（测试逐 params 断言）。
+
+    loop phase 本期只展开第 1 轮（round=1）：后续轮由动作的 plan_signal 走
+    plan_edit.SIGNAL_TABLES 确定性追加，与现状同一套机制；fanout/funnel 等
+    引擎支持后再按 loop.kind 分派展开方式。
+    """
+    checkpoint = (run.checkpoint if run is not None else None) or {}
+    params = checkpoint.get("params") or {}
+    steps: list[dict[str, Any]] = []
+    for phase in pack.phases:
+        checks = _phase_checks(phase)
+        in_loop = phase.loop is not None
+        for action in phase.actions:
+            tpl = _STEP_TEMPLATES.get(action) or {}
+            title = str(tpl.get("title") or action)
+            node_params: dict[str, Any] = {}
+            if in_loop and tpl.get("round_param"):
+                node_params["round"] = 1
+                title = title.format(round=1)
+            node: dict[str, Any] = {
+                "title": title,
+                "action": action,
+                "params": node_params,
+                "acceptance": tpl.get("acceptance"),
+                "checks": [dict(c) for c in checks],  # 每节点独立副本，防共享可变态
+                "requires_gate": None,
+            }
+            if tpl.get("on_failure"):
+                node["on_failure"] = tpl["on_failure"]
+            if tpl.get("budget"):
+                node["budget"] = dict(tpl["budget"])
+            steps.append(node)
+    # gates 字段本期惰性（deferral）：预算闸门沿用 params 开关（#626 默认不拦），
+    # 与原 plan 函数逐字节一致；待 gates 启用后改由包声明闸门位置。
+    if bool(params.get("confirm_budget")):
+        for node in steps:
+            if node["action"] == "experiment.setup":
+                node["requires_gate"] = "compute_budget"
+    return steps

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "pycrdt>=0.10",
     "pycrdt-websocket>=0.15",
     "python-pptx>=1.0",
+    "pyyaml>=6.0",
     "tzdata>=2025.2",
     # desktop 档位运行时依赖（POLARIS_PROFILE=desktop：SQLite + 进程内 redis 替身）
     "aiosqlite>=0.20",
@@ -51,7 +52,8 @@ include = ["app*", "worker*"]
 
 [tool.setuptools.package-data]
 # 论文模板 pack（meta.json / main.tex / .sty）随包分发（docker 非 editable 安装用）
-app = ["assets/templates/*/*"]
+# 流程包 YAML（app/packs/，#678）同样随包分发
+app = ["assets/templates/*/*", "packs/*.yaml"]
 
 [tool.ruff]
 target-version = "py312"

--- a/src/backend/tests/test_process_packs.py
+++ b/src/backend/tests/test_process_packs.py
@@ -1,0 +1,249 @@
+"""流程包一期（#678，设计报告 §8.3）：加载/校验、extends 合并、物化保真对照。
+
+保真是本 PR 的核心断言：base/experiment 包生成的计划必须与原 plan 函数
+（navigator.experiment_plan）输出**相等**——两边任一漂移测试即红；
+不选包的路径必须原样走 plan 函数（golden 保全铁律）。
+"""
+
+from pathlib import Path
+
+import pytest
+
+import app.agents.voyage  # noqa: F401  注册动作（包校验依赖注册表非空）
+from app.agents.voyage.navigator import Navigator, experiment_plan
+from app.models.voyage import VoyageRun
+from app.schemas.experiment import ExperimentParams
+from app.services import process_packs
+from app.services.process_packs import (
+    ProcessPackError,
+    known_pack_names,
+    load_pack,
+    plan_from_pack,
+)
+
+
+def _run(params: dict | None) -> VoyageRun:
+    return VoyageRun(
+        kind="experiment",
+        goal="实验验证：测试",
+        status="planning",
+        cursor=0,
+        checkpoint={"params": params} if params is not None else None,
+    )
+
+
+# ---- 加载与校验 ----
+
+
+def test_builtin_pack_loads():
+    assert "base/experiment" in known_pack_names()
+    pack = load_pack("base/experiment")
+    assert pack.kind == "research-process"
+    assert [p.id for p in pack.phases] == ["plan", "setup", "smoke", "iterate"]
+    iterate = pack.phases[-1]
+    assert iterate.loop is not None and iterate.loop.kind == "spiral"
+    assert pack.guidance.strip()
+
+
+def test_unknown_pack_rejected_with_known_list():
+    with pytest.raises(ProcessPackError, match="base/experiment"):
+        load_pack("no/such-pack")
+
+
+def _write_pack(dir_: Path, filename: str, content: str) -> None:
+    (dir_ / filename).write_text(content, encoding="utf-8")
+
+
+def test_unknown_action_rejected_listing_known_actions(tmp_path, monkeypatch):
+    monkeypatch.setattr(process_packs, "BUILTIN_PACKS_DIR", tmp_path)
+    _write_pack(
+        tmp_path,
+        "bad.yaml",
+        """
+kind: research-process
+name: bad/pack
+phases:
+  - id: p1
+    actions: [experiment.teleport]
+""",
+    )
+    with pytest.raises(ProcessPackError) as exc:
+        load_pack("bad/pack")
+    msg = str(exc.value)
+    # 报错必须 actionable：指明未知 action 并列出已注册的 action 名
+    assert "experiment.teleport" in msg
+    assert "experiment.plan" in msg
+    assert "p1" in msg
+
+
+def test_bad_schema_and_bad_check_rejected(tmp_path, monkeypatch):
+    monkeypatch.setattr(process_packs, "BUILTIN_PACKS_DIR", tmp_path)
+    # kind 不对
+    _write_pack(tmp_path, "wrongkind.yaml", "kind: pipeline\nname: x\n")
+    with pytest.raises(ProcessPackError, match="schema"):
+        process_packs._load_all()
+    (tmp_path / "wrongkind.yaml").unlink()
+    # 检查写法不认识
+    _write_pack(
+        tmp_path,
+        "badcheck.yaml",
+        """
+kind: research-process
+name: bad/check
+phases:
+  - id: p1
+    actions: [experiment.plan]
+    checks: ["telepathy:9"]
+""",
+    )
+    with pytest.raises(ProcessPackError, match="telepathy"):
+        load_pack("bad/check")
+
+
+def test_duplicate_pack_name_rejected(tmp_path, monkeypatch):
+    monkeypatch.setattr(process_packs, "BUILTIN_PACKS_DIR", tmp_path)
+    body = "kind: research-process\nname: dup/pack\nphases: []\n"
+    _write_pack(tmp_path, "a.yaml", body)
+    _write_pack(tmp_path, "b.yaml", body)
+    with pytest.raises(ProcessPackError, match="重名"):
+        known_pack_names()
+
+
+def test_extends_single_level_merge(tmp_path, monkeypatch):
+    monkeypatch.setattr(process_packs, "BUILTIN_PACKS_DIR", tmp_path)
+    _write_pack(
+        tmp_path,
+        "parent.yaml",
+        """
+kind: research-process
+name: base/parent
+phases:
+  - id: a
+    actions: [experiment.plan]
+  - id: b
+    actions: [experiment.setup]
+guidance: 父包提示。
+""",
+    )
+    _write_pack(
+        tmp_path,
+        "child.yaml",
+        """
+kind: research-process
+name: sub/child
+extends: base/parent
+phases:
+  - id: b
+    actions: [experiment.smoke]
+    checks: ["exit_code:0"]
+  - id: c
+    actions: [experiment.analyze]
+guidance: 子包提示。
+""",
+    )
+    pack = load_pack("sub/child")
+    # 同 id 覆盖（保持父序）、新 id 追加
+    assert [p.id for p in pack.phases] == ["a", "b", "c"]
+    assert pack.phases[1].actions == ["experiment.smoke"]
+    assert pack.phases[2].actions == ["experiment.analyze"]
+    # guidance 拼接：父在前子在后
+    assert pack.guidance == "父包提示。\n子包提示。"
+
+
+def test_extends_unknown_parent_and_chain_rejected(tmp_path, monkeypatch):
+    monkeypatch.setattr(process_packs, "BUILTIN_PACKS_DIR", tmp_path)
+    _write_pack(
+        tmp_path,
+        "orphan.yaml",
+        "kind: research-process\nname: sub/orphan\nextends: no/parent\nphases: []\n",
+    )
+    with pytest.raises(ProcessPackError, match="不存在"):
+        load_pack("sub/orphan")
+    _write_pack(
+        tmp_path, "g.yaml", "kind: research-process\nname: g\nextends: mid\nphases: []\n"
+    )
+    _write_pack(
+        tmp_path, "mid.yaml", "kind: research-process\nname: mid\nextends: root\nphases: []\n"
+    )
+    _write_pack(tmp_path, "root.yaml", "kind: research-process\nname: root\nphases: []\n")
+    with pytest.raises(ProcessPackError, match="单层"):
+        load_pack("g")
+
+
+def test_inert_fields_accepted(tmp_path, monkeypatch):
+    """gates / irreversible 进 schema 但惰性（deferral）：写了不报错、不产生行为。"""
+    monkeypatch.setattr(process_packs, "BUILTIN_PACKS_DIR", tmp_path)
+    _write_pack(
+        tmp_path,
+        "gated.yaml",
+        """
+kind: research-process
+name: base/gated
+phases:
+  - id: p1
+    actions: [experiment.setup]
+gates:
+  - {phase: p1, kind: irb_approval}
+irreversible: [p1]
+""",
+    )
+    pack = load_pack("base/gated")
+    plan = plan_from_pack(pack, _run({}))
+    # 惰性：声明的 gate 不落到计划节点上
+    assert plan[0]["requires_gate"] is None
+
+
+# ---- 物化保真：包生成的计划 == 原 plan 函数输出 ----
+
+FIDELITY_PARAMS = [
+    None,  # run=None（失败语义单测直接调计划模板的路径）
+    {},
+    {"confirm_budget": True},
+    {"confirm_budget": False, "gpu_hint": "A100", "extra_notes": "备注"},
+    {"confirm_budget": True, "eval_model": "gpt-x", "hf_mirror": True},
+]
+
+
+@pytest.mark.parametrize("params", FIDELITY_PARAMS)
+def test_base_experiment_pack_matches_plan_function(params):
+    run = _run(params) if params is not None else None
+    pack = load_pack("base/experiment")
+    assert plan_from_pack(pack, run) == experiment_plan(run)
+
+
+# ---- Navigator 接入：不选包 = 原路径；选包 = 包生成 ----
+
+
+@pytest.mark.asyncio
+async def test_navigator_without_pack_uses_plan_function_verbatim():
+    # 固定 kind 分支不触碰 LLM：llm=None 即可
+    nav = Navigator(llm=None)  # type: ignore[arg-type]
+    for params in ({}, {"confirm_budget": True}, {"process_pack": None}):
+        run = _run(params)
+        assert await nav.plan(run) == experiment_plan(run)
+
+
+@pytest.mark.asyncio
+async def test_navigator_with_pack_generates_equivalent_plan():
+    nav = Navigator(llm=None)  # type: ignore[arg-type]
+    for extra in ({}, {"confirm_budget": True}):
+        run = _run({"process_pack": "base/experiment", **extra})
+        assert await nav.plan(run) == experiment_plan(run)
+
+
+@pytest.mark.asyncio
+async def test_navigator_with_unknown_pack_raises_actionable():
+    nav = Navigator(llm=None)  # type: ignore[arg-type]
+    run = _run({"process_pack": "no/such"})
+    with pytest.raises(ProcessPackError, match="base/experiment"):
+        await nav.plan(run)
+
+
+# ---- ExperimentParams.process_pack 校验 ----
+
+
+def test_experiment_params_process_pack_validation():
+    assert ExperimentParams().process_pack is None
+    assert ExperimentParams(process_pack="base/experiment").process_pack == "base/experiment"
+    with pytest.raises(ValueError, match="unknown process pack"):
+        ExperimentParams(process_pack="no/such-pack")

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -2595,6 +2595,9 @@ export interface CreateExperimentInput {
     /** 执行后端（Runner v2 分派键，#675）：缺省 python-ml=存量行为。
      * 单后端阶段创建表单不出选择 UI；接入 openfoam/ngspice 等后端后在此暴露。 */
     backend?: string;
+    /** 流程包（#678 一期）：显式选包（如 "base/experiment"）→ 按包 phases 生成计划；
+     * 缺省 = 原计划路径（行为不变）。本期无编辑/选择 UI——接入创建表单时在此消费。 */
+    process_pack?: string;
   };
 }
 


### PR DESCRIPTION
Closes #678. Part of #674 (P3 wave 2, item R3); design report §8.3 — research processes become data.

- `process_packs.py`: the `research-process` schema (phases with actions/checks/rubrics, loop topology fanout|spiral|funnel, guidance; `gates`/`irreversible` present but inert per the deferral decision), a file-over-app loader over the built-in `app/packs/` directory (unknown action references fail at load with the full known-action list; single-level `extends` merges phases by id and concatenates guidance), and `plan_from_pack` (sequential phase expansion; loops expand their first round with later rounds still appended by the existing deterministic signal tables — the pack does not re-declare that mechanism)
- `base/experiment` materializes the existing experiment plan function: the real function's output was printed for representative params and translated faithfully; step titles/acceptance/failure semantics live in an action-side template table so the YAML stays topology-only
- **fidelity is proven, not claimed**: tests assert `plan_from_pack(base/experiment) == experiment_plan(run)` across 5 param sets including both budget-gate states; runs without `process_pack` take the original function through a direct branch — no indirection, byte-compatible
- `ExperimentParams.process_pack` (optional, existence-validated) flows into checkpoint params; checks use a compact string syntax parsed at load into Sextant items; no editing UI (deferred); pyyaml declared and packs shipped as package data; no migration — packs live on disk

Verification: branch 1607 passed / 3 failed (all three pre-existing on the clean baseline, which also showed one known flake that passes here) — zero new real failures; goldens byte-identical (the golden chains never enter the experiment plan path); 17 new tests; frontend vitest 158 + build green.