### PR TITLE
feat: resources, leases, and polymorphic connection credentials

### DIFF
--- a/src/backend/alembic/versions/d2dcfc8b899f_resources_and_leases.py
+++ b/src/backend/alembic/versions/d2dcfc8b899f_resources_and_leases.py
@@ -1,0 +1,117 @@
+"""资源/租约表 + 连接凭据多态化（R2 #677，设计报告 §14）
+
+- ssh_credentials → connection_credentials：原表改名 + 加 kind（默认 'ssh'，存量行
+  即天然合法，数据零搬迁）+ payload_encrypted（非 ssh 的 Fernet 加密 JSON 载荷）；
+  username / private_key_encrypted 放开为可空（非 ssh 用不上）。
+  experiments.credential_id 的 FK 随表改名自动跟随（sqlite ≥3.26 / postgres 的
+  RENAME 都会改写引用方）。
+- resources：主机/队列/License 池/仪器的统一登记（capacity/exclusive 供租约计数）。
+- resource_leases：run 占用资源的租约行，released_at 为空即活租约。
+
+downgrade 注意：把 username/private_key_encrypted 恢复 NOT NULL 前提是没有
+非 ssh 行（有则先删，属有损回退，与本仓其他删列迁移同口径）。
+
+Revision ID: d2dcfc8b899f
+Revises: e867fcbae4ea
+Create Date: 2026-09-06
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "d2dcfc8b899f"
+down_revision: str | None = "e867fcbae4ea"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+JSON_VARIANT = sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql")
+
+
+def upgrade() -> None:
+    # 1) 凭据表多态化：改名 + kind + payload；ssh 专列放开可空
+    op.rename_table("ssh_credentials", "connection_credentials")
+    with op.batch_alter_table("connection_credentials") as batch:
+        batch.add_column(
+            sa.Column("kind", sa.String(length=16), nullable=False, server_default="ssh")
+        )
+        batch.add_column(sa.Column("payload_encrypted", sa.Text(), nullable=True))
+        batch.alter_column("username", existing_type=sa.String(length=255), nullable=True)
+        batch.alter_column("private_key_encrypted", existing_type=sa.Text(), nullable=True)
+    # 索引名跟着表名走（batch 重建表后旧名仍在，显式换名）
+    op.drop_index("ix_ssh_credentials_user_id", table_name="connection_credentials")
+    op.create_index(
+        op.f("ix_connection_credentials_user_id"), "connection_credentials", ["user_id"]
+    )
+
+    # 2) 资源登记表
+    op.create_table(
+        "resources",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "owner_id",
+            sa.Uuid(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        # host | queue | license_pool | instrument
+        sa.Column("kind", sa.String(length=16), nullable=False),
+        sa.Column("capacity", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("exclusive", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column(
+            "credential_id",
+            sa.Uuid(),
+            sa.ForeignKey("connection_credentials.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("config", JSON_VARIANT, nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index(op.f("ix_resources_owner_id"), "resources", ["owner_id"])
+
+    # 3) 租约表（released_at 为空 = 活租约；随资源/run 级联删除）
+    op.create_table(
+        "resource_leases",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "resource_id",
+            sa.Uuid(),
+            sa.ForeignKey("resources.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "run_id",
+            sa.Uuid(),
+            sa.ForeignKey("voyage_runs.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("acquired_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("released_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("note", sa.String(length=255), nullable=False, server_default=""),
+    )
+    op.create_index(op.f("ix_resource_leases_resource_id"), "resource_leases", ["resource_id"])
+    op.create_index(op.f("ix_resource_leases_run_id"), "resource_leases", ["run_id"])
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_resource_leases_run_id"), table_name="resource_leases")
+    op.drop_index(op.f("ix_resource_leases_resource_id"), table_name="resource_leases")
+    op.drop_table("resource_leases")
+    op.drop_index(op.f("ix_resources_owner_id"), table_name="resources")
+    op.drop_table("resources")
+
+    # 有损回退：非 ssh 行装不进旧表形状，先删（与删列类迁移同口径）
+    op.execute("DELETE FROM connection_credentials WHERE kind != 'ssh'")
+    op.drop_index(op.f("ix_connection_credentials_user_id"), table_name="connection_credentials")
+    with op.batch_alter_table("connection_credentials") as batch:
+        batch.alter_column("private_key_encrypted", existing_type=sa.Text(), nullable=False)
+        batch.alter_column("username", existing_type=sa.String(length=255), nullable=False)
+        batch.drop_column("payload_encrypted")
+        batch.drop_column("kind")
+    op.rename_table("connection_credentials", "ssh_credentials")
+    op.create_index(op.f("ix_ssh_credentials_user_id"), "ssh_credentials", ["user_id"])

--- a/src/backend/app/agents/voyage/engine.py
+++ b/src/backend/app/agents/voyage/engine.py
@@ -576,6 +576,12 @@ class VoyageEngine:
             run.status = await self._current_db_status(session, run.id)
             raise _ExternallyTerminated(run.status)
         run.status = status
+        if status in TERMINAL_STATUSES:
+            # 资源租约兜底释放（R2 #677）：不管以哪种终态落定都不再占资源。
+            # 正常路径由 runner cleanup 显式释放，这里是最后防线（幂等，无租约 no-op）
+            from app.services import resource_leases as resource_leases_service
+
+            await resource_leases_service.release_for_run(session, run.id)
         if status == "done":
             # 终态联动：仍非终态的关联实验随 voyage 落定为 done（报告动作完全不写
             # 终态，用户「接受当前结果」等路径都汇到这里；无关联实验时是 noop）

--- a/src/backend/app/api/resources.py
+++ b/src/backend/app/api/resources.py
@@ -1,0 +1,155 @@
+"""资源登记与通用连接凭据路由（R2 #677）。
+
+- /resources：主机/队列/License 池/仪器的 owner 范围 CRUD；
+- /connection-credentials：多态凭据（ssh|grpc|visa|http）。ssh 老端点
+  /ssh-credentials 原样保留（前端 SSH 凭据 UI 不动）；本组端点暂无前端 UI，
+  资源设置页归后续 PR（挂设置页「实验资源」分区）。
+"""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.auth import current_active_user
+from app.core.db import get_session
+from app.models.resource import Resource
+from app.models.user import User
+from app.schemas.resource import (
+    ConnectionCredentialCreate,
+    ConnectionCredentialRead,
+    ResourceCreate,
+    ResourceRead,
+    ResourceUpdate,
+)
+from app.services import resources as resources_service
+
+router = APIRouter(prefix="/resources", tags=["resources"])
+credentials_router = APIRouter(prefix="/connection-credentials", tags=["connection-credentials"])
+
+
+async def _get_owned(session: AsyncSession, resource_id: uuid.UUID, user: User) -> Resource:
+    resource = await resources_service.get_owned_resource(
+        session, resource_id=resource_id, owner_id=user.id
+    )
+    if resource is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="RESOURCE_NOT_FOUND")
+    return resource
+
+
+async def _check_credential_ref(
+    session: AsyncSession, credential_id: uuid.UUID | None, user: User
+) -> None:
+    """credential_id 只能指向自己的凭据（他人凭据同样 404 不泄露存在性）。"""
+    if credential_id is None:
+        return
+    credential = await resources_service.get_owned_credential(
+        session, credential_id=credential_id, owner_id=user.id
+    )
+    if credential is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="CREDENTIAL_NOT_FOUND")
+
+
+@router.get("", response_model=list[ResourceRead])
+async def list_resources(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> list[ResourceRead]:
+    resources = await resources_service.list_resources(session, owner_id=user.id)
+    return [ResourceRead.model_validate(r) for r in resources]
+
+
+@router.post("", response_model=ResourceRead, status_code=status.HTTP_201_CREATED)
+async def create_resource(
+    data: ResourceCreate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> ResourceRead:
+    await _check_credential_ref(session, data.credential_id, user)
+    try:
+        resource = await resources_service.create_resource(session, owner_id=user.id, data=data)
+    except resources_service.ResourceConfigError as exc:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)) from exc
+    return ResourceRead.model_validate(resource)
+
+
+@router.get("/{resource_id}", response_model=ResourceRead)
+async def get_resource(
+    resource_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> ResourceRead:
+    return ResourceRead.model_validate(await _get_owned(session, resource_id, user))
+
+
+@router.patch("/{resource_id}", response_model=ResourceRead)
+async def update_resource(
+    resource_id: uuid.UUID,
+    data: ResourceUpdate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> ResourceRead:
+    resource = await _get_owned(session, resource_id, user)
+    if "credential_id" in data.model_dump(exclude_unset=True):
+        await _check_credential_ref(session, data.credential_id, user)
+    try:
+        resource = await resources_service.update_resource(session, resource, data)
+    except resources_service.ResourceConfigError as exc:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)) from exc
+    return ResourceRead.model_validate(resource)
+
+
+@router.delete("/{resource_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_resource(
+    resource_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> None:
+    resource = await _get_owned(session, resource_id, user)
+    await resources_service.delete_resource(session, resource)
+
+
+# ---- 通用凭据端点（多态；响应绝不含密钥/载荷） ----
+
+
+@credentials_router.get("", response_model=list[ConnectionCredentialRead])
+async def list_credentials(
+    kind: str | None = None,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> list[ConnectionCredentialRead]:
+    credentials = await resources_service.list_connection_credentials(
+        session, user_id=user.id, kind=kind
+    )
+    return [ConnectionCredentialRead.model_validate(c) for c in credentials]
+
+
+@credentials_router.post(
+    "", response_model=ConnectionCredentialRead, status_code=status.HTTP_201_CREATED
+)
+async def create_credential(
+    data: ConnectionCredentialCreate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> ConnectionCredentialRead:
+    try:
+        credential = await resources_service.create_connection_credential(
+            session, user_id=user.id, data=data
+        )
+    except resources_service.CredentialPayloadError as exc:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)) from exc
+    return ConnectionCredentialRead.model_validate(credential)
+
+
+@credentials_router.delete("/{credential_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_credential(
+    credential_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> None:
+    credential = await resources_service.get_owned_credential(
+        session, credential_id=credential_id, owner_id=user.id
+    )
+    if credential is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="CREDENTIAL_NOT_FOUND")
+    await resources_service.delete_connection_credential(session, credential)

--- a/src/backend/app/api/router.py
+++ b/src/backend/app/api/router.py
@@ -33,6 +33,7 @@ from app.api import (
     presentations,
     projects,
     publications,
+    resources,
     search,
     shelf,
     skills,
@@ -83,6 +84,8 @@ api_router.include_router(market.router)
 api_router.include_router(mcp_meta.router)
 api_router.include_router(presentations.router)
 api_router.include_router(ssh_credentials.router)
+api_router.include_router(resources.router)
+api_router.include_router(resources.credentials_router)
 api_router.include_router(tts.router)
 api_router.include_router(evidence.router)
 api_router.include_router(experiments.router)

--- a/src/backend/app/api/voyages.py
+++ b/src/backend/app/api/voyages.py
@@ -301,6 +301,10 @@ async def answer_voyage_ask(
         ask.status = "consumed"
         run.status = "failed"
         await session.commit()
+        # 资源租约兜底释放（R2 #677）：不经引擎 _set_status 的终态写入点之一
+        from app.services import resource_leases as resource_leases_service
+
+        await resource_leases_service.release_for_run(session, run.id)
         await bus.publish_voyage_event(
             run.id, "status", {"status": run.status, "cursor": run.cursor}
         )

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -62,9 +62,10 @@ from app.models.paper_extraction import PaperExtraction
 from app.models.project import Project
 from app.models.publication import UserAuthorProfile, UserPublication
 from app.models.research_digest import LibraryResearchDigest
+from app.models.resource import Resource, ResourceLease
 from app.models.review import ReviewMessage, ReviewSession
 from app.models.skill import Skill, SkillListing, SkillVersion, UserSkill
-from app.models.ssh_credential import SSHCredential
+from app.models.ssh_credential import ConnectionCredential, SSHCredential
 from app.models.system_setting import SystemSetting
 from app.models.topic_shelf import TopicPaper
 from app.models.user import User
@@ -134,8 +135,11 @@ __all__ = [
     "PaperUserMeta",
     "PaperVector",
     "Project",
+    "ConnectionCredential",
     "ReviewMessage",
     "ReviewSession",
+    "Resource",
+    "ResourceLease",
     "SSHCredential",
     "Skill",
     "SkillListing",

--- a/src/backend/app/models/experiment.py
+++ b/src/backend/app/models/experiment.py
@@ -42,7 +42,7 @@ class Experiment(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         ForeignKey("voyage_runs.id", ondelete="SET NULL"), index=True
     )
     credential_id: Mapped[uuid.UUID | None] = mapped_column(
-        ForeignKey("ssh_credentials.id", ondelete="SET NULL")
+        ForeignKey("connection_credentials.id", ondelete="SET NULL")
     )
     # {"hypotheses": [{text, status}], "repro_strategy", "steps", "budget_estimate"}
     plan: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)

--- a/src/backend/app/models/resource.py
+++ b/src/backend/app/models/resource.py
@@ -1,0 +1,67 @@
+"""实验资源与租约（R2 #677，设计报告 §14）。
+
+Resource 是 Runner v2 manifest 里 resources/licenses 声明的运行时对应物：
+后端说「我要一台主机 / 一个 License 席位」，平台在这张表里找对应实体并发租约。
+
+- ``kind`` 四档：host（SSH 主机）| queue（集群队列）| license_pool（FlexLM 等
+  License 池）| instrument（实体仪器）。
+- ``exclusive``：独占资源（仪器/整机）同一时刻只允许一个活租约，此时 capacity
+  语义上恒为 1；非独占资源按 capacity 计数（License 池的席位数、队列的并发额）。
+- ``config`` 放 kind 特定的非敏感字段（敏感的进 ConnectionCredential.payload）：
+  host: {"workdir"?, "gpus"?}；queue: {"queue": 队列名, "partition"?}；
+  license_pool: {"feature": License feature 名, "server"?: "host:port"}；
+  instrument: {"resource"?: pyvisa 资源串（不敏感时）, "location"?}。
+
+ResourceLease 一行 = 一次「某 run 占用某资源」：released_at 为空即活租约。
+真正的持久化排队表（排队席位可见、跨进程公平）归后续 PR，本期 wait 语义用
+轮询实现（app/services/resource_leases.py）。
+"""
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.db import Base
+from app.models.base import JSONVariant, TimestampMixin, UUIDPrimaryKeyMixin, utcnow
+
+RESOURCE_KINDS = ("host", "queue", "license_pool", "instrument")
+
+
+class Resource(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "resources"
+
+    owner_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    # host | queue | license_pool | instrument
+    kind: Mapped[str] = mapped_column(String(16), nullable=False)
+    # 非独占资源的并发席位数（exclusive=True 时忽略，按 1 算）
+    capacity: Mapped[int] = mapped_column(Integer, default=1, nullable=False)
+    exclusive: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    # 连接凭据（多态）；凭据删除不连坐资源（SET NULL），用时再校验
+    credential_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("connection_credentials.id", ondelete="SET NULL")
+    )
+    # kind 特定的非敏感配置，字段约定见模块 docstring
+    config: Mapped[dict[str, Any] | None] = mapped_column(JSONVariant)
+
+
+class ResourceLease(UUIDPrimaryKeyMixin, Base):
+    __tablename__ = "resource_leases"
+
+    resource_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("resources.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    run_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("voyage_runs.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    acquired_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utcnow, nullable=False
+    )
+    # 空 = 活租约。释放三条路：prepare/cleanup 显式释放、run 终态兜底、cancel 兜底
+    released_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    note: Mapped[str] = mapped_column(String(255), default="", nullable=False)

--- a/src/backend/app/models/ssh_credential.py
+++ b/src/backend/app/models/ssh_credential.py
@@ -1,4 +1,25 @@
-"""每用户私有的 SSH 凭据（私钥 Fernet 加密入库，绝不回传）。"""
+"""连接凭据（多态，R2 #677）：ssh_credentials 泛化为 connection_credentials。
+
+为什么选「原表改造」而不是「新表 + 兼容视图」：SSHCredential 有 12 个消费方
+（ssh_exec / experiments / voyage runner …）全部按列名直接取值，experiments 还有
+指向本表的 FK。原表加 kind 列 + 表名改名，存量行零搬迁、消费方零改动（类名留
+别名）；新表方案反而要么双写、要么把旧表做成视图（SQLAlchemy 写视图一堆坑）。
+
+kind 与加密载荷约定（payload_encrypted = Fernet(json.dumps(payload))，见
+app/core/security.py；所有敏感字段绝不明文出库/出 API）：
+
+- ``ssh``：不用 payload_encrypted。沿用专列 host/port/username/
+  private_key_encrypted/passphrase_encrypted/proxy_url——保持 ssh_exec 等
+  消费方零改动，存量行即天然合法（kind 默认 'ssh'）。
+- ``grpc``：host/port = gRPC endpoint；payload = {"token"?: str,
+  "tls_ca"?: str(PEM 文本)}。
+- ``http``：host/port = 基地址（路径等非敏感部分放 Resource.config）；
+  payload = {"token"?: str, "username"?: str, "password"?: str,
+  "headers"?: dict}。
+- ``visa``：host = 仪器主机（展示用）；payload = {"resource": str
+  (pyvisa 资源串，如 "TCPIP0::10.0.0.5::INSTR"), "secret"?: str}。
+  资源串含内网定位信息，整体按敏感处理。
+"""
 
 import uuid
 from datetime import datetime
@@ -9,21 +30,34 @@ from sqlalchemy.orm import Mapped, mapped_column
 from app.core.db import Base
 from app.models.base import TimestampMixin, UUIDPrimaryKeyMixin
 
+# 合法凭据类型（Runner v2 manifest.credential_kinds 的运行时对应物）
+CREDENTIAL_KINDS = ("ssh", "grpc", "visa", "http")
 
-class SSHCredential(UUIDPrimaryKeyMixin, TimestampMixin, Base):
-    __tablename__ = "ssh_credentials"
+
+class ConnectionCredential(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "connection_credentials"
 
     user_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=False
     )
+    # ssh | grpc | visa | http（载荷约定见模块 docstring）
+    kind: Mapped[str] = mapped_column(String(16), default="ssh", nullable=False)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     host: Mapped[str] = mapped_column(String(255), nullable=False)
     port: Mapped[int] = mapped_column(Integer, default=22, nullable=False)
-    username: Mapped[str] = mapped_column(String(255), nullable=False)
-    # Fernet 加密（app/core/security.py），绝不以明文出库/出 API
-    private_key_encrypted: Mapped[str] = mapped_column(Text, nullable=False)
+    # ssh 必填；其他 kind 可空（http basic 的用户名放 payload，避免语义分叉）
+    username: Mapped[str | None] = mapped_column(String(255))
+    # ssh 专列：Fernet 加密（app/core/security.py），绝不以明文出库/出 API
+    private_key_encrypted: Mapped[str | None] = mapped_column(Text)
     passphrase_encrypted: Mapped[str | None] = mapped_column(Text)
+    # 非 ssh 的加密载荷：Fernet(json.dumps(payload))，字段约定见模块 docstring
+    payload_encrypted: Mapped[str | None] = mapped_column(Text)
     last_verified_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     # 服务器出外网需要的 HTTP 代理（如 http://10.205.70.120:7899），可空=直连；
     # 注入实验环境 http(s)_proxy，并对内网 LLM 地址设 no_proxy
     proxy_url: Mapped[str | None] = mapped_column(String(255))
+
+
+# 兼容别名：存量消费方（ssh_exec / experiments / voyage runner / 测试）继续用旧名。
+# 它们只走 kind='ssh' 的行，列名与语义完全不变。
+SSHCredential = ConnectionCredential

--- a/src/backend/app/schemas/resource.py
+++ b/src/backend/app/schemas/resource.py
@@ -1,0 +1,76 @@
+"""资源与连接凭据 schema（R2 #677）。凭据 Read 模型绝不含任何密钥字段。"""
+
+import uuid
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+ResourceKind = Literal["host", "queue", "license_pool", "instrument"]
+CredentialKind = Literal["ssh", "grpc", "visa", "http"]
+
+
+class ResourceCreate(BaseModel):
+    name: str = Field(min_length=1, max_length=255)
+    kind: ResourceKind
+    capacity: int = Field(default=1, ge=1)
+    exclusive: bool = True
+    credential_id: uuid.UUID | None = None
+    # kind 特定的非敏感配置；必填键在服务层校验（queue 要 queue 名、
+    # license_pool 要 feature），报错才能带上 kind 上下文
+    config: dict[str, Any] | None = None
+
+
+class ResourceUpdate(BaseModel):
+    """PATCH 语义：只更新给了的字段（kind 不可改——改类型等于换资源，重建去）。"""
+
+    name: str | None = Field(default=None, min_length=1, max_length=255)
+    capacity: int | None = Field(default=None, ge=1)
+    exclusive: bool | None = None
+    credential_id: uuid.UUID | None = None
+    config: dict[str, Any] | None = None
+
+
+class ResourceRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    name: str
+    kind: str
+    capacity: int
+    exclusive: bool
+    credential_id: uuid.UUID | None
+    config: dict[str, Any] | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class ConnectionCredentialCreate(BaseModel):
+    """通用凭据创建（各 kind 载荷约定见 app/models/ssh_credential.py docstring）。
+
+    ssh 也可以走这里（payload.private_key 必填，落存量专列）；但现有前端
+    继续用 /ssh-credentials 老端点，两条路殊途同归。
+    """
+
+    name: str = Field(min_length=1, max_length=255)
+    kind: CredentialKind
+    host: str = Field(min_length=1, max_length=255)
+    port: int = Field(default=22, ge=1, le=65535)
+    username: str | None = Field(default=None, max_length=255)
+    # 敏感载荷（整体 Fernet 加密入库，绝不回传）
+    payload: dict[str, Any] = Field(default_factory=dict)
+    proxy_url: str | None = Field(default=None, pattern=r"^https?://[A-Za-z0-9.\-]+(:\d+)?$")
+
+
+class ConnectionCredentialRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    kind: str
+    name: str
+    host: str
+    port: int
+    username: str | None
+    created_at: datetime
+    last_verified_at: datetime | None
+    proxy_url: str | None

--- a/src/backend/app/services/experiments.py
+++ b/src/backend/app/services/experiments.py
@@ -152,7 +152,9 @@ async def create_experiment(
     if idea.status != "promoted":
         raise IdeaNotPromotedError(str(idea.id))
     credential = await session.get(SSHCredential, data.credential_id)
-    if credential is None or credential.user_id != user_id:
+    # kind 校验（#677 凭据多态化后）：实验直跑只吃 ssh 凭据，别的 kind 私钥列为空，
+    # 放进来会在 ssh_exec 解密时炸得不知所云——这里当不存在处理
+    if credential is None or credential.user_id != user_id or credential.kind != "ssh":
         raise CredentialNotFoundError(str(data.credential_id))
 
     params = data.params

--- a/src/backend/app/services/gates.py
+++ b/src/backend/app/services/gates.py
@@ -114,5 +114,9 @@ async def fail_voyage(session: AsyncSession, voyage_id: uuid.UUID) -> VoyageRun 
         return run
     run.status = "failed"
     await session.commit()
+    # 资源租约兜底释放（R2 #677）：驳回失败的 run 不再占资源
+    from app.services import resource_leases as resource_leases_service
+
+    await resource_leases_service.release_for_run(session, run.id)
     await session.refresh(run)
     return run

--- a/src/backend/app/services/resource_leases.py
+++ b/src/backend/app/services/resource_leases.py
@@ -1,0 +1,180 @@
+"""资源租约服务（R2 #677）：acquire / release + run 终态兜底释放。
+
+语义：
+- exclusive 资源：同一时刻最多一个活租约（capacity 忽略，按 1 算）；
+- 非 exclusive：活租约数 < capacity 即可获（License 席位 / 队列并发额的计数语义）；
+- wait=True 是「排队席位」的轮询实现——prepare 阶段可以等一会儿再开跑；真正的
+  持久化排队表（席位可见、跨进程公平、断电不丢位）归后续 PR。
+
+并发安全为什么这么做（而不是唯一约束或 BEGIN IMMEDIATE）：
+- capacity>1 的计数语义没法用唯一约束表达，必须「数活租约 + 插入」原子化；
+- postgres：SELECT … FOR UPDATE 锁资源行，两个并发 acquire 在行锁上串行，
+  计数+插入压进同一事务，天然跨进程正确；
+- sqlite（dev/测试）：没有行锁；async 引擎的连接池里对所有事务全局改
+  BEGIN IMMEDIATE 副作用太大（每个只读事务都抢写锁）。这里用进程内
+  asyncio.Lock 串行化临界区。**局限**：只护得住单进程——api 与 worker 两个
+  进程同时 acquire 同一资源时仍有 check-then-insert 竞窗，只能靠 sqlite 库级
+  单写者缩小窗口。生产环境是 postgres，不受此限。
+"""
+
+import asyncio
+import time
+import uuid
+
+from sqlalchemy import func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.base import utcnow
+from app.models.resource import Resource, ResourceLease
+from app.models.voyage import VoyageRun
+
+
+class ResourceBusyError(Exception):
+    """资源没有空闲席位（wait=False 直接抛；wait=True 等到超时也抛它）。"""
+
+
+# sqlite 下串行化「数活租约 + 插入」的进程内锁（见模块 docstring 的 why 与局限）
+_sqlite_acquire_lock = asyncio.Lock()
+
+
+def effective_capacity(resource: Resource) -> int:
+    """独占资源恒为 1；非独占取 capacity（防御脏数据，至少 1）。"""
+    return 1 if resource.exclusive else max(1, resource.capacity)
+
+
+async def count_active_leases(session: AsyncSession, resource_id: uuid.UUID) -> int:
+    stmt = (
+        select(func.count())
+        .select_from(ResourceLease)
+        .where(ResourceLease.resource_id == resource_id, ResourceLease.released_at.is_(None))
+    )
+    return int((await session.execute(stmt)).scalar_one())
+
+
+def _is_postgres(session: AsyncSession) -> bool:
+    return session.bind is not None and session.bind.dialect.name == "postgresql"
+
+
+async def _try_acquire(
+    session: AsyncSession,
+    *,
+    resource_id: uuid.UUID,
+    capacity: int,
+    run_id: uuid.UUID,
+    note: str,
+) -> ResourceLease | None:
+    """一次获取尝试：事务内计数 + 插入；没有空位返回 None（不抛）。
+
+    只收标量不收 ORM 对象：失败路径要 rollback（释放行锁、别拖住别人），
+    rollback 会把会话里已加载的对象全部 expire，异步会话下再摸它们的属性会
+    炸 MissingGreenlet——调用方在 rollback 前把要用的字段抄成标量最稳。
+    """
+    if _is_postgres(session):
+        # 行锁串行化并发 acquire（锁到 commit/rollback 为止）
+        await session.execute(
+            select(Resource.id).where(Resource.id == resource_id).with_for_update()
+        )
+    if await count_active_leases(session, resource_id) >= capacity:
+        await session.rollback()
+        return None
+    lease = ResourceLease(resource_id=resource_id, run_id=run_id, note=note)
+    session.add(lease)
+    await session.commit()
+    await session.refresh(lease)
+    return lease
+
+
+async def _guarded_try_acquire(
+    session: AsyncSession,
+    *,
+    resource_id: uuid.UUID,
+    capacity: int,
+    run_id: uuid.UUID,
+    note: str,
+) -> ResourceLease | None:
+    kwargs = {"resource_id": resource_id, "capacity": capacity, "run_id": run_id, "note": note}
+    if _is_postgres(session):
+        return await _try_acquire(session, **kwargs)
+    async with _sqlite_acquire_lock:
+        return await _try_acquire(session, **kwargs)
+
+
+async def acquire(
+    session: AsyncSession,
+    resource: Resource,
+    run: VoyageRun,
+    *,
+    wait: bool = False,
+    timeout: float = 300.0,
+    note: str = "",
+) -> ResourceLease:
+    """给 run 获取一个资源席位。
+
+    - wait=False：没有空位立刻抛 ResourceBusyError（调用方自己决定怎么办）；
+    - wait=True：转轮询等位（wait_and_acquire），等到 timeout 还没有空位才抛。
+    """
+    label, resource_id = resource.name, resource.id  # rollback 前抄标量，见 _try_acquire
+    capacity, run_id = effective_capacity(resource), run.id
+    if not wait:
+        lease = await _guarded_try_acquire(
+            session, resource_id=resource_id, capacity=capacity, run_id=run_id, note=note
+        )
+        if lease is None:
+            raise ResourceBusyError(f"resource {label} ({resource_id}) has no free slot")
+        return lease
+    return await wait_and_acquire(session, resource, run, timeout=timeout, note=note)
+
+
+async def wait_and_acquire(
+    session: AsyncSession,
+    resource: Resource,
+    run: VoyageRun,
+    *,
+    timeout: float = 300.0,
+    poll_interval: float = 1.0,
+    note: str = "",
+) -> ResourceLease:
+    """轮询版「排队席位」：反复尝试直到拿到或超时（prepare 阶段调用）。
+
+    没有持久化队列 → 不保证先来先得（两个等位者谁先轮询到谁得）；
+    这是本期的已知局限，排队表落地后此函数改为入队+等通知。
+    """
+    label, resource_id = resource.name, resource.id  # rollback 前抄标量，见 _try_acquire
+    capacity, run_id = effective_capacity(resource), run.id
+    deadline = time.monotonic() + timeout
+    while True:
+        lease = await _guarded_try_acquire(
+            session, resource_id=resource_id, capacity=capacity, run_id=run_id, note=note
+        )
+        if lease is not None:
+            return lease
+        if time.monotonic() >= deadline:
+            raise ResourceBusyError(
+                f"resource {label} ({resource_id}) still busy after {timeout:.0f}s"
+            )
+        await asyncio.sleep(poll_interval)
+
+
+async def release(session: AsyncSession, lease: ResourceLease) -> None:
+    """释放租约（幂等：已释放的再释放是 no-op）。"""
+    if lease.released_at is not None:
+        return
+    lease.released_at = utcnow()
+    await session.commit()
+
+
+async def release_for_run(session: AsyncSession, run_id: uuid.UUID) -> int:
+    """run 终态兜底：一次释放该 run 的全部活租约，返回释放数（幂等）。
+
+    正常路径应由 runner 的 cleanup 显式释放；这里是「不管怎么死的都不占着资源」
+    的最后防线，挂在 voyage run 的终态写入点（engine._set_status / cancel_voyage /
+    gates.fail_voyage）。
+    """
+    stmt = (
+        update(ResourceLease)
+        .where(ResourceLease.run_id == run_id, ResourceLease.released_at.is_(None))
+        .values(released_at=utcnow())
+    )
+    result = await session.execute(stmt)
+    await session.commit()
+    return int(result.rowcount or 0)

--- a/src/backend/app/services/resources.py
+++ b/src/backend/app/services/resources.py
@@ -1,0 +1,175 @@
+"""资源登记 CRUD + 通用连接凭据（R2 #677，不 import fastapi）。
+
+凭据的通用创建也放这里（而不是塞进 ssh_credentials.py）：那个模块是 ssh 专用
+老面（私钥专列 + asyncssh 连通性测试），继续原样服务老端点；多态凭据是资源
+体系的配套件，跟资源 CRUD 一起演化。
+"""
+
+import json
+import uuid
+from collections.abc import Sequence
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import encrypt_secret
+from app.models.resource import RESOURCE_KINDS, Resource
+from app.models.ssh_credential import ConnectionCredential
+from app.schemas.resource import ConnectionCredentialCreate, ResourceCreate, ResourceUpdate
+
+
+class ResourceConfigError(ValueError):
+    """kind 特定配置不合法（缺必填键等），API 层转 422。"""
+
+
+# kind → config 必填键（非敏感；敏感字段一律进凭据 payload）
+_REQUIRED_CONFIG_KEYS: dict[str, tuple[str, ...]] = {
+    "queue": ("queue",),  # 队列名
+    "license_pool": ("feature",),  # License feature 名（如 "HFSS"）
+    "host": (),
+    "instrument": (),
+}
+
+
+def validate_kind_config(kind: str, config: dict | None) -> None:
+    """轻校验：kind 合法 + 必填键在场且是非空字符串。不做白名单封闭
+    （config 是各 runner 后端的自留地，键集合随后端演化）。"""
+    if kind not in RESOURCE_KINDS:
+        raise ResourceConfigError(f"unknown resource kind: {kind}")
+    for key in _REQUIRED_CONFIG_KEYS[kind]:
+        value = (config or {}).get(key)
+        if not isinstance(value, str) or not value.strip():
+            raise ResourceConfigError(f"resource kind '{kind}' requires config.{key}")
+
+
+# ---- 资源 CRUD（owner 范围） ----
+
+
+async def create_resource(
+    session: AsyncSession, *, owner_id: uuid.UUID, data: ResourceCreate
+) -> Resource:
+    validate_kind_config(data.kind, data.config)
+    resource = Resource(
+        owner_id=owner_id,
+        name=data.name,
+        kind=data.kind,
+        capacity=data.capacity,
+        exclusive=data.exclusive,
+        credential_id=data.credential_id,
+        config=data.config,
+    )
+    session.add(resource)
+    await session.commit()
+    await session.refresh(resource)
+    return resource
+
+
+async def list_resources(session: AsyncSession, *, owner_id: uuid.UUID) -> Sequence[Resource]:
+    stmt = (
+        select(Resource)
+        .where(Resource.owner_id == owner_id)
+        .order_by(Resource.created_at.desc())
+    )
+    return (await session.execute(stmt)).scalars().all()
+
+
+async def get_owned_resource(
+    session: AsyncSession, *, resource_id: uuid.UUID, owner_id: uuid.UUID
+) -> Resource | None:
+    """取资源；非本人视为不存在（返回 None，同凭据口径不泄露存在性）。"""
+    resource = await session.get(Resource, resource_id)
+    if resource is None or resource.owner_id != owner_id:
+        return None
+    return resource
+
+
+async def update_resource(
+    session: AsyncSession, resource: Resource, data: ResourceUpdate
+) -> Resource:
+    fields = data.model_dump(exclude_unset=True)
+    if "config" in fields:
+        validate_kind_config(resource.kind, fields["config"])
+    for key, value in fields.items():
+        setattr(resource, key, value)
+    await session.commit()
+    await session.refresh(resource)
+    return resource
+
+
+async def delete_resource(session: AsyncSession, resource: Resource) -> None:
+    # 租约行随 CASCADE 一起删；活租约的 run 由终态兜底不至于悬空占用
+    await session.delete(resource)
+    await session.commit()
+
+
+async def get_owned_credential(
+    session: AsyncSession, *, credential_id: uuid.UUID, owner_id: uuid.UUID
+) -> ConnectionCredential | None:
+    credential = await session.get(ConnectionCredential, credential_id)
+    if credential is None or credential.user_id != owner_id:
+        return None
+    return credential
+
+
+# ---- 通用凭据（多态） ----
+
+
+class CredentialPayloadError(ValueError):
+    """凭据载荷不合法（ssh 缺 private_key 等），API 层转 422。"""
+
+
+async def create_connection_credential(
+    session: AsyncSession, *, user_id: uuid.UUID, data: ConnectionCredentialCreate
+) -> ConnectionCredential:
+    """通用创建：ssh 落存量专列（消费方零改动），其余 kind 整包加密进 payload。"""
+    private_key_encrypted = passphrase_encrypted = payload_encrypted = None
+    if data.kind == "ssh":
+        private_key = data.payload.get("private_key")
+        if not isinstance(private_key, str) or not private_key:
+            raise CredentialPayloadError("ssh credential requires payload.private_key")
+        if not data.username:
+            raise CredentialPayloadError("ssh credential requires username")
+        private_key_encrypted = encrypt_secret(private_key)
+        passphrase = data.payload.get("passphrase")
+        if passphrase:
+            passphrase_encrypted = encrypt_secret(str(passphrase))
+    else:
+        if data.kind == "visa" and not str(data.payload.get("resource", "")).strip():
+            raise CredentialPayloadError("visa credential requires payload.resource")
+        payload_encrypted = encrypt_secret(json.dumps(data.payload, ensure_ascii=False))
+    credential = ConnectionCredential(
+        user_id=user_id,
+        kind=data.kind,
+        name=data.name,
+        host=data.host,
+        port=data.port,
+        username=data.username,
+        private_key_encrypted=private_key_encrypted,
+        passphrase_encrypted=passphrase_encrypted,
+        payload_encrypted=payload_encrypted,
+        proxy_url=data.proxy_url,
+    )
+    session.add(credential)
+    await session.commit()
+    await session.refresh(credential)
+    return credential
+
+
+async def list_connection_credentials(
+    session: AsyncSession, *, user_id: uuid.UUID, kind: str | None = None
+) -> Sequence[ConnectionCredential]:
+    stmt = (
+        select(ConnectionCredential)
+        .where(ConnectionCredential.user_id == user_id)
+        .order_by(ConnectionCredential.created_at.desc())
+    )
+    if kind:
+        stmt = stmt.where(ConnectionCredential.kind == kind)
+    return (await session.execute(stmt)).scalars().all()
+
+
+async def delete_connection_credential(
+    session: AsyncSession, credential: ConnectionCredential
+) -> None:
+    await session.delete(credential)
+    await session.commit()

--- a/src/backend/app/services/voyages.py
+++ b/src/backend/app/services/voyages.py
@@ -191,5 +191,9 @@ async def cancel_voyage(session: AsyncSession, run: VoyageRun) -> VoyageRun:
     await messages_service.supersede_open_asks(session, run.id)
     run.status = "cancelled"
     await session.commit()
+    # 资源租约兜底释放（R2 #677）：取消不走引擎的 _set_status，这里补上同款防线
+    from app.services import resource_leases as resource_leases_service
+
+    await resource_leases_service.release_for_run(session, run.id)
     await session.refresh(run)
     return run

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,7 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "e867fcbae4ea"  # Method purpose/mechanism vectors (#663)
+HEAD_REVISION = "d2dcfc8b899f"  # Resources, leases, polymorphic credentials (#677)
+METHOD_VECTORS_REVISION = "e867fcbae4ea"  # Method purpose/mechanism vectors (#663)
 EXTRACTIONS_REVISION = "58b0bc2d809d"  # Paper skeleton extractions (#661)
 CITATIONS_REVISION = "57543f6328a1"  # Paper citation edges (#639)
 HYPOTHESIS_TREE_REVISION = "7e2b9f4c1a86"  # Hypothesis/experiment tree nodes (#637)
@@ -161,6 +162,10 @@ def _inspect_db(db_path: Path) -> tuple[str, dict[str, set[str]]]:
                     "registration_codes",  # head 已删；仅 downgrade 断言用
                     "project_members",  # head 已删（#625）；仅 downgrade 断言用
                     "hypothesis_nodes",
+                    "connection_credentials",  # head 新增（#677）：ssh_credentials 改名
+                    "ssh_credentials",  # head 已改名（#677）；仅 downgrade 断言用
+                    "resources",
+                    "resource_leases",
                 )
                 if table in tables  # downgrade 后新表不存在，跳过列检查
             }
@@ -250,8 +255,28 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     assert "payload" in columns["review_sessions"]
     assert "author_name" in columns["review_messages"]
     assert "agent_persona" not in columns["review_messages"]
-    # M4：ssh_credentials 表 + experiments / experiment_runs 新列
-    assert "ssh_credentials" in columns["_tables"]
+    # M4 的 ssh_credentials 在 head 已泛化改名为 connection_credentials（#677）
+    assert "ssh_credentials" not in columns["_tables"]
+    assert "connection_credentials" in columns["_tables"]
+    assert {"kind", "payload_encrypted", "private_key_encrypted", "proxy_url"} <= columns[
+        "connection_credentials"
+    ]
+    assert "ix_connection_credentials_user_id" in _index_names(db_path, "connection_credentials")
+    # R2（#677）：资源登记与租约表
+    assert {"resources", "resource_leases"} <= columns["_tables"]
+    assert {
+        "owner_id",
+        "name",
+        "kind",
+        "capacity",
+        "exclusive",
+        "credential_id",
+        "config",
+    } <= columns["resources"]
+    assert {"resource_id", "run_id", "acquired_at", "released_at", "note"} <= columns[
+        "resource_leases"
+    ]
+    assert "ix_resource_leases_run_id" in _index_names(db_path, "resource_leases")
     assert {"project_id", "voyage_id", "credential_id", "report", "metrics"} <= columns[
         "experiments"
     ]
@@ -583,7 +608,18 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     } <= columns["paper_extractions"]
     assert "ix_paper_extractions_paper_id" in _index_names(db_path, "paper_extractions")
 
-    # 先退掉方法向量表（#663）：抽取产物表不受影响。
+    # 先退掉资源/租约与凭据多态化（#677）：ssh_credentials 按原形状回来。
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == METHOD_VECTORS_REVISION
+    assert not {"resources", "resource_leases"} & columns["_tables"]
+    assert "connection_credentials" not in columns["_tables"]
+    assert "ssh_credentials" in columns["_tables"]
+    assert not {"kind", "payload_encrypted"} & columns["ssh_credentials"]
+    assert "ix_ssh_credentials_user_id" in _index_names(db_path, "ssh_credentials")
+    assert "method_vectors" in columns["_tables"]  # 只退一步：方法向量表仍在
+
+    # 再退掉方法向量表（#663）：抽取产物表不受影响。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == EXTRACTIONS_REVISION
@@ -972,6 +1008,9 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     command.upgrade(cfg, "head")
     version, columns = _inspect_db(db_path)
     assert version == HEAD_REVISION
+    # 资源/租约/多态凭据回归（#677）
+    assert {"resources", "resource_leases", "connection_credentials"} <= columns["_tables"]
+    assert "ssh_credentials" not in columns["_tables"]
     assert "paper_extractions" in columns["_tables"]  # 抽取产物表回归（#661）
     assert "paper_citations" in columns["_tables"]  # 引文边表回归（#639）
     assert "effort" in columns["model_routes"]

--- a/src/backend/tests/test_resources.py
+++ b/src/backend/tests/test_resources.py
@@ -1,0 +1,414 @@
+"""资源/租约/多态凭据（R2 #677）：CRUD、互斥与容量计数、终态兜底、凭据加密往返。"""
+
+import asyncio
+import json
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.core.security import decrypt_secret
+from app.models.resource import Resource, ResourceLease
+from app.models.ssh_credential import ConnectionCredential
+from app.models.user import User
+from app.models.voyage import VoyageRun
+from app.services import resource_leases as leases_service
+from app.services import voyages as voyages_service
+from tests.conftest import register_and_login
+
+FAKE_PEM = "-----BEGIN OPENSSH PRIVATE KEY-----\nfake\n-----END OPENSSH PRIVATE KEY-----\n"
+
+
+async def _auth(client, email="alice@example.com"):
+    token = await register_and_login(client, email)
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _user_id(email="alice@example.com") -> uuid.UUID:
+    async with get_sessionmaker()() as session:
+        return (
+            await session.execute(select(User.id).where(User.email == email))
+        ).scalar_one()
+
+
+async def _make_run(session) -> VoyageRun:
+    run = VoyageRun(kind="experiment", goal="lease-test", status="executing")
+    session.add(run)
+    await session.commit()
+    await session.refresh(run)
+    return run
+
+
+async def _make_resource(session, owner_id, **overrides) -> Resource:
+    fields = {"name": "gpu-box", "kind": "host", "capacity": 1, "exclusive": True}
+    fields.update(overrides)
+    resource = Resource(owner_id=owner_id, **fields)
+    session.add(resource)
+    await session.commit()
+    await session.refresh(resource)
+    return resource
+
+
+async def _active_lease_count(resource_id) -> int:
+    async with get_sessionmaker()() as session:
+        return await leases_service.count_active_leases(session, resource_id)
+
+
+# ---- 资源 CRUD API ----
+
+
+async def test_resource_crud_api(client):
+    headers = await _auth(client)
+
+    resp = await client.post(
+        "/api/resources",
+        json={"name": "lab-a100", "kind": "host", "config": {"workdir": "~/runs"}},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    created = resp.json()
+    assert created["kind"] == "host" and created["capacity"] == 1 and created["exclusive"]
+    resource_id = created["id"]
+
+    resp = await client.get("/api/resources", headers=headers)
+    assert [r["id"] for r in resp.json()] == [resource_id]
+
+    resp = await client.patch(
+        f"/api/resources/{resource_id}",
+        json={"name": "lab-a100-renamed", "capacity": 4, "exclusive": False},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["name"] == "lab-a100-renamed" and body["capacity"] == 4
+
+    resp = await client.delete(f"/api/resources/{resource_id}", headers=headers)
+    assert resp.status_code == 204
+    resp = await client.get("/api/resources", headers=headers)
+    assert resp.json() == []
+
+
+async def test_resource_kind_and_config_validation(client):
+    headers = await _auth(client)
+
+    # 未知 kind → pydantic Literal 校验 422
+    resp = await client.post(
+        "/api/resources", json={"name": "x", "kind": "spaceship"}, headers=headers
+    )
+    assert resp.status_code == 422
+
+    # queue 缺 config.queue → 422（服务层轻校验）
+    resp = await client.post(
+        "/api/resources", json={"name": "slurm", "kind": "queue"}, headers=headers
+    )
+    assert resp.status_code == 422
+    assert "config.queue" in resp.text
+
+    # license_pool 带 feature 才放行
+    resp = await client.post(
+        "/api/resources",
+        json={
+            "name": "hfss-pool",
+            "kind": "license_pool",
+            "capacity": 3,
+            "exclusive": False,
+            "config": {"feature": "HFSS", "server": "lic.lab:1055"},
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+
+    # PATCH 换 config 也走同一校验（换掉 feature 键 → 422）
+    resource_id = resp.json()["id"]
+    resp = await client.patch(
+        f"/api/resources/{resource_id}", json={"config": {"server": "x"}}, headers=headers
+    )
+    assert resp.status_code == 422
+
+
+async def test_resource_owner_isolation(client):
+    headers_a = await _auth(client, "alice@example.com")
+    headers_b = await _auth(client, "bob@example.com")
+    resp = await client.post(
+        "/api/resources", json={"name": "mine", "kind": "host"}, headers=headers_a
+    )
+    resource_id = resp.json()["id"]
+
+    resp = await client.get("/api/resources", headers=headers_b)
+    assert resp.json() == []
+    for method, url in (
+        ("get", f"/api/resources/{resource_id}"),
+        ("delete", f"/api/resources/{resource_id}"),
+    ):
+        resp = await getattr(client, method)(url, headers=headers_b)
+        assert resp.status_code == 404
+    resp = await client.patch(
+        f"/api/resources/{resource_id}", json={"name": "hijack"}, headers=headers_b
+    )
+    assert resp.status_code == 404
+
+
+async def test_resource_credential_ref_must_be_owned(client):
+    headers_a = await _auth(client, "alice@example.com")
+    headers_b = await _auth(client, "bob@example.com")
+    resp = await client.post(
+        "/api/connection-credentials",
+        json={"name": "b-token", "kind": "http", "host": "api.lab", "payload": {"token": "t"}},
+        headers=headers_b,
+    )
+    other_cred = resp.json()["id"]
+
+    # 引用他人凭据 → 404（不泄露存在性）
+    resp = await client.post(
+        "/api/resources",
+        json={"name": "x", "kind": "host", "credential_id": other_cred},
+        headers=headers_a,
+    )
+    assert resp.status_code == 404
+
+
+# ---- 多态凭据：各 kind 加密往返 ----
+
+
+async def test_generic_credential_roundtrip_encrypted(client):
+    headers = await _auth(client)
+    cases = {
+        "grpc": {"token": "grpc-secret", "tls_ca": "-----BEGIN CERT-----"},
+        "http": {"token": "http-secret", "headers": {"X-Lab": "1"}},
+        "visa": {"resource": "TCPIP0::10.0.0.5::INSTR", "secret": "pin"},
+    }
+    ids = {}
+    for kind, payload in cases.items():
+        resp = await client.post(
+            "/api/connection-credentials",
+            json={"name": f"{kind}-cred", "kind": kind, "host": "10.0.0.5", "payload": payload},
+            headers=headers,
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        ids[kind] = body["id"]
+        # 响应绝不含载荷/密钥
+        assert "payload" not in body and "payload_encrypted" not in body
+        assert body["kind"] == kind
+
+    async with get_sessionmaker()() as session:
+        for kind, payload in cases.items():
+            row = await session.get(ConnectionCredential, uuid.UUID(ids[kind]))
+            assert row.kind == kind and row.private_key_encrypted is None
+            raw = row.payload_encrypted
+            assert raw is not None and "secret" not in raw
+            assert json.loads(decrypt_secret(raw)) == payload
+
+    # kind 过滤
+    resp = await client.get("/api/connection-credentials?kind=visa", headers=headers)
+    assert [c["id"] for c in resp.json()] == [ids["visa"]]
+    resp = await client.get("/api/connection-credentials", headers=headers)
+    assert len(resp.json()) == 3
+
+
+async def test_generic_credential_ssh_lands_in_legacy_columns(client):
+    """通用端点建 ssh：私钥/口令进存量专列（ssh_exec 消费方零改动）。"""
+    headers = await _auth(client)
+    resp = await client.post(
+        "/api/connection-credentials",
+        json={
+            "name": "gpu1",
+            "kind": "ssh",
+            "host": "gpu1.lab",
+            "username": "polaris",
+            "payload": {"private_key": FAKE_PEM, "passphrase": "s3cret"},
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    async with get_sessionmaker()() as session:
+        row = await session.get(ConnectionCredential, uuid.UUID(resp.json()["id"]))
+        assert row.kind == "ssh" and row.payload_encrypted is None
+        assert decrypt_secret(row.private_key_encrypted) == FAKE_PEM
+        assert decrypt_secret(row.passphrase_encrypted) == "s3cret"
+
+    # 缺 private_key → 422
+    resp = await client.post(
+        "/api/connection-credentials",
+        json={"name": "bad", "kind": "ssh", "host": "h", "username": "u", "payload": {}},
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+    # visa 缺 resource → 422
+    resp = await client.post(
+        "/api/connection-credentials",
+        json={"name": "bad", "kind": "visa", "host": "h", "payload": {"secret": "x"}},
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
+async def test_legacy_ssh_rows_default_kind(client):
+    """老端点建的凭据 kind='ssh'，通用端点列表看得到（同一张表）。"""
+    headers = await _auth(client)
+    resp = await client.post(
+        "/api/ssh-credentials",
+        json={
+            "name": "legacy",
+            "host": "gpu1.lab",
+            "port": 22,
+            "username": "polaris",
+            "private_key": FAKE_PEM,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    resp = await client.get("/api/connection-credentials?kind=ssh", headers=headers)
+    assert [c["name"] for c in resp.json()] == ["legacy"]
+
+
+# ---- 租约：互斥 / 容量 / 释放 / 终态兜底 ----
+
+
+async def test_exclusive_lease_busy_then_wait_acquire(client):
+    headers = await _auth(client)
+    del headers  # 只为造出 users 行
+    owner = await _user_id()
+    maker = get_sessionmaker()
+    async with maker() as session:
+        resource = await _make_resource(session, owner, exclusive=True)
+        run1 = await _make_run(session)
+        run2 = await _make_run(session)
+        lease1 = await leases_service.acquire(session, resource, run1)
+        assert lease1.released_at is None
+        # 抄标量：下面的失败 acquire 会 rollback，把会话内对象全部 expire
+        resource_id, run2_id, lease1_id = resource.id, run2.id, lease1.id
+
+        # 独占资源已有活租约：wait=False 立刻 Busy
+        with pytest.raises(leases_service.ResourceBusyError):
+            await leases_service.acquire(session, resource, run2)
+
+    # wait=True：先占着，0.05s 后由另一会话释放，等位者应拿到
+    async def _release_soon():
+        await asyncio.sleep(0.05)
+        async with maker() as s2:
+            lease = await s2.get(ResourceLease, lease1_id)
+            await leases_service.release(s2, lease)
+
+    async with maker() as session:
+        resource = await session.get(Resource, resource_id)
+        run2 = await session.get(VoyageRun, run2_id)
+        releaser = asyncio.create_task(_release_soon())
+        lease2 = await leases_service.acquire(
+            session, resource, run2, wait=True, timeout=5.0
+        )
+        await releaser
+        assert lease2.run_id == run2_id
+    assert await _active_lease_count(resource_id) == 1
+
+
+async def test_wait_and_acquire_times_out(client):
+    headers = await _auth(client)
+    del headers
+    owner = await _user_id()
+    async with get_sessionmaker()() as session:
+        resource = await _make_resource(session, owner)
+        run1 = await _make_run(session)
+        run2 = await _make_run(session)
+        await leases_service.acquire(session, resource, run1)
+        with pytest.raises(leases_service.ResourceBusyError):
+            await leases_service.wait_and_acquire(
+                session, resource, run2, timeout=0.2, poll_interval=0.05
+            )
+
+
+async def test_capacity_counting_semantics(client):
+    """capacity=2 非独占：两个活租约可并存，第三个 Busy；释放一个又能进。"""
+    headers = await _auth(client)
+    del headers
+    owner = await _user_id()
+    async with get_sessionmaker()() as session:
+        resource = await _make_resource(
+            session, owner, kind="license_pool", capacity=2, exclusive=False,
+            config={"feature": "HFSS"},
+        )
+        runs = [await _make_run(session) for _ in range(3)]
+        lease_a = await leases_service.acquire(session, resource, runs[0])
+        await leases_service.acquire(session, resource, runs[1])
+        # 抄标量：下面的失败 acquire 会 rollback，把会话内对象全部 expire
+        resource_id, run3_id, lease_a_id = resource.id, runs[2].id, lease_a.id
+        with pytest.raises(leases_service.ResourceBusyError):
+            await leases_service.acquire(session, resource, runs[2])
+
+        # rollback 后重取（异步会话摸 expired 属性会炸 MissingGreenlet）
+        resource = await session.get(Resource, resource_id)
+        run3 = await session.get(VoyageRun, run3_id)
+        lease_a = await session.get(ResourceLease, lease_a_id)
+        await leases_service.release(session, lease_a)
+        lease_c = await leases_service.acquire(session, resource, run3)
+        assert lease_c.released_at is None
+        assert await leases_service.count_active_leases(session, resource_id) == 2
+
+
+async def test_concurrent_acquire_single_winner(client):
+    """并发安全：两个会话同时抢独占资源，只允许一个成功。"""
+    headers = await _auth(client)
+    del headers
+    owner = await _user_id()
+    maker = get_sessionmaker()
+    async with maker() as session:
+        resource = await _make_resource(session, owner)
+        run1 = await _make_run(session)
+        run2 = await _make_run(session)
+        resource_id, run1_id, run2_id = resource.id, run1.id, run2.id
+
+    async def _attempt(run_id):
+        async with maker() as s:
+            resource = await s.get(Resource, resource_id)
+            run = await s.get(VoyageRun, run_id)
+            try:
+                await leases_service.acquire(s, resource, run)
+                return "ok"
+            except leases_service.ResourceBusyError:
+                return "busy"
+
+    results = await asyncio.gather(_attempt(run1_id), _attempt(run2_id))
+    assert sorted(results) == ["busy", "ok"]
+    assert await _active_lease_count(resource_id) == 1
+
+
+async def test_release_idempotent_and_release_for_run(client):
+    headers = await _auth(client)
+    del headers
+    owner = await _user_id()
+    async with get_sessionmaker()() as session:
+        r1 = await _make_resource(session, owner)
+        r2 = await _make_resource(session, owner, name="q", kind="queue",
+                                  exclusive=False, capacity=2, config={"queue": "gpu"})
+        run = await _make_run(session)
+        lease = await leases_service.acquire(session, r1, run)
+        await leases_service.acquire(session, r2, run)
+
+        await leases_service.release(session, lease)
+        first_released_at = lease.released_at
+        await leases_service.release(session, lease)  # 幂等
+        assert lease.released_at == first_released_at
+
+        # run 终态兜底：剩下的活租约一次清光；再调一次是 no-op
+        assert await leases_service.release_for_run(session, run.id) == 1
+        assert await leases_service.release_for_run(session, run.id) == 0
+        assert await leases_service.count_active_leases(session, r1.id) == 0
+        assert await leases_service.count_active_leases(session, r2.id) == 0
+
+
+async def test_cancel_voyage_releases_leases(client):
+    """取消任务（不经引擎的终态写入）也会兜底释放租约。"""
+    headers = await _auth(client)
+    del headers
+    owner = await _user_id()
+    async with get_sessionmaker()() as session:
+        resource = await _make_resource(session, owner)
+        run = await _make_run(session)
+        await leases_service.acquire(session, resource, run)
+        assert await leases_service.count_active_leases(session, resource.id) == 1
+
+        await voyages_service.cancel_voyage(session, run)
+        assert run.status == "cancelled"
+        assert await leases_service.count_active_leases(session, resource.id) == 0


### PR DESCRIPTION
Closes #677. Part of #674 (P3 wave 2, item R2); design report §14 — the device/resource model the codebase entirely lacked.

- `resources` (kind host|queue|license_pool|instrument, capacity, exclusive flag, encrypted credential ref, kind-specific config) and `resource_leases` (run↔resource, release timestamp): an exclusive or capacity-exhausted resource makes a second acquirer either raise `ResourceBusyError` or poll-wait via `wait_and_acquire` — the prepare-stage queueing seam; leases release on every run terminal path (engine status write, cancel, gate-fail, abort — four hooks)
- concurrency: `SELECT … FOR UPDATE` on postgres; an in-process asyncio lock on sqlite with the cross-process residual window documented (sqlite's single-writer narrows it; production runs postgres)
- credential generalization chose in-place evolution: `ssh_credentials` renames to `connection_credentials` with a `kind` column (default ssh) and a generic encrypted payload; the `SSHCredential` alias keeps all 12 existing consumers and every stored row untouched; per-kind payload conventions (ssh/grpc/visa/http) documented on the model. Old `/ssh-credentials` endpoints and UI unchanged; new `/connection-credentials` and `/resources` CRUD are owner-scoped
- migration `d2dcfc8b899f` (on `e867fcbae4ea`) with downgrade; roundtrip green on sqlite and exercised up/down/up on a postgres scratch database

Verification: clean baseline 1590 passed / 3 pre-existing failures; branch 1602 passed / the same 3 + one known clock flake green standalone — zero new real failures; goldens untouched; rebased onto #679 with zero conflicts and a targeted cross-suite re-run (41 green: resources, credentials, migrations, process packs, goldens). No frontend changes.