### PR TITLE
feat: ngspice and openfoam container backends

### DIFF
--- a/src/backend/app/services/runners/container_substrate.py
+++ b/src/backend/app/services/runners/container_substrate.py
@@ -1,0 +1,288 @@
+"""容器执行底座：本机 docker 上按**固定模板**拉起一次性批处理容器（#681，R4）。
+
+ngspice/openfoam 等零 license 后端共用这一个底座。与 voyage/runner.py 的
+ContainerRunner（SSH 主机 + docker exec 长驻容器）不同，这里是本机 docker 的
+一次性批处理形态：`docker run -d --rm` 一个容器跑完即走，产物全部落在唯一
+挂载的工作目录里。
+
+安全铁律（v1/v2 一贯，任何调用方不得破坏——见 contract.py 模块 docstring）：
+- **LLM 只产出文件内容**（netlist / OpenFOAM case …），经纯数据通道落盘；
+- **进 docker CLI 的每个参数都来自 manifest/模板或白名单校验后的 plan 字段**
+  （镜像名过 _IMAGE_RE、容器内命令是后端模块里的字符串常量模板、可变段
+  只有白名单枚举如求解器名），LLM 自由文本**绝不**拼进命令行；
+- host 侧不经过 shell：argv 列表直接 create_subprocess_exec，连引号注入的
+  土壤都没有；容器内的 `sh -c` 只收固定模板串。
+
+docker run 固定模板（side_effects=filesystem 的落实）：
+- `--rm`：跑完即删，host 不留容器残骸（退出码经 run.exit 文件持久化，见下）；
+- `--name <前缀>-<随机 hex>`：可定位、可取消、可按前缀清理；
+- `--network none`（默认）：仿真不需要网络，直接断网——manifest 声明
+  side_effects=filesystem 就真的只有文件系统一条副作用通道；
+- 只挂工作目录（绝对路径 → /work，rw）：容器能读写的 host 文件面收敛到
+  这一个目录，物料进、产物出都走它。
+
+为什么退出码走 run.exit 文件而不是 docker inspect：`--rm` 让容器退出后自动
+消失，inspect 会扑空。所以 launch 把后端模板包一层 `; echo $? > run.exit`
+（照 python-ml 后端 run.exit 落盘的既有约定），poll 先问 inspect（容器还在 =
+running / 刚退出），容器没了就读工作目录里的 run.exit 定终态。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import uuid
+from pathlib import Path
+
+from app.services.runners.contract import RunnerError, RunStatus
+from app.services.ssh_exec import SSHPathViolationError, _validate_relpath
+
+# 镜像引用白名单（与 voyage/runner.py 的 _IMAGE_RE 同款）：镜像名可来自 plan
+# （LLM 产出），是唯一进 CLI 的 plan 字段，必须过正则才收。
+_IMAGE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/:@-]*$")
+# 容器名前缀：由后端模块写死（如 "polaris-ngspice"），仍校验兜一道
+_NAME_PREFIX_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+
+_CONTAINER_WORKDIR = "/work"  # 工作目录在容器内的固定挂载点（与 ContainerRunner 一致）
+RUN_EXIT_FILE = "run.exit"  # 退出码落盘文件（--rm 后 inspect 扑空时的终态依据）
+
+_DOCKER_TIMEOUT = 60.0  # inspect/rm 等管理命令
+_LAUNCH_TIMEOUT = 900.0  # docker run（镜像未预拉时含拉取；openfoam 镜像大，给足）
+
+
+async def _run_docker(*argv: str, timeout: float = _DOCKER_TIMEOUT) -> tuple[int, str, str]:
+    """执行一条 docker 命令（argv 直传，不过 host shell），返回 (exit, stdout, stderr)。"""
+    proc = await asyncio.create_subprocess_exec(
+        "docker",
+        *argv,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        out, err = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except TimeoutError:
+        proc.kill()
+        raise RunnerError(f"docker {argv[0]} 超时（>{timeout:.0f}s）") from None
+    return proc.returncode or 0, out.decode(errors="replace"), err.decode(errors="replace")
+
+
+class ContainerSubstrate:
+    """一次 run 的本机容器底座：工作目录 + 拉起/查询/取消/读产物。
+
+    实例绑定一个工作目录（绝对路径），不跨 run 复用。所有文件读写都限定在
+    工作目录内（相对路径过 _validate_relpath 白名单，与 SSH 底座同款约束）。
+    """
+
+    def __init__(self, workdir: str | Path, *, name_prefix: str = "polaris-run") -> None:
+        if not _NAME_PREFIX_RE.match(name_prefix):
+            raise RunnerError(f"容器名前缀不合法：{name_prefix!r}")
+        self._workdir = Path(workdir).resolve()  # docker -v 要绝对路径
+        self._name_prefix = name_prefix
+
+    @property
+    def workdir(self) -> Path:
+        return self._workdir
+
+    # ---- 物料落盘（纯数据通道：LLM 产出的文件内容只走这里，不进命令行） ----
+
+    def write_materials(self, files: dict[str, str]) -> None:
+        """把物料（相对路径 → 文本内容）写进工作目录；路径过白名单防越界。"""
+        self._workdir.mkdir(parents=True, exist_ok=True)
+        for name, content in files.items():
+            try:
+                rel = _validate_relpath(name)
+            except SSHPathViolationError as e:
+                raise RunnerError(str(e)) from e
+            target = self._workdir / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content, encoding="utf-8")
+
+    # ---- 生命周期 ----
+
+    def _new_name(self) -> str:
+        return f"{self._name_prefix}-{uuid.uuid4().hex[:12]}"
+
+    async def launch(self, *, image: str, command: str) -> str:
+        """按固定模板 docker run，返回容器名句柄。
+
+        ``command`` 必须是后端模块里的字符串常量模板（可变段只有白名单枚举），
+        由容器内 `sh -c` 执行；底座统一追加 `; echo $? > run.exit` 保证退出码
+        在 --rm 之后仍可读。``image`` 过 _IMAGE_RE 白名单。
+        """
+        if not _IMAGE_RE.match(image or ""):
+            raise RunnerError(f"容器镜像名不合白名单：{image!r}")
+        if not self._workdir.is_dir():
+            raise RunnerError(f"工作目录不存在（先 prepare）：{self._workdir}")
+        name = self._new_name()
+        # 固定模板：--rm 即跑即删 / 只挂工作目录 / 默认断网。参数没有一个来自自由文本。
+        code, _out, err = await _run_docker(
+            "run",
+            "-d",
+            "--rm",
+            "--name",
+            name,
+            "--network",
+            "none",
+            "-v",
+            f"{self._workdir}:{_CONTAINER_WORKDIR}",
+            "-w",
+            _CONTAINER_WORKDIR,
+            image,
+            "sh",
+            "-c",
+            f"{command}; echo $? > {RUN_EXIT_FILE}",
+            timeout=_LAUNCH_TIMEOUT,
+        )
+        if code != 0:
+            raise RunnerError(f"docker run 启动失败：{err.strip()[:300]}")
+        return name
+
+    async def poll(self, handle: str) -> RunStatus:
+        """inspect 在场容器；容器已被 --rm 收走则读工作目录 run.exit 定终态。"""
+        code, out, _err = await _run_docker(
+            "inspect", "-f", "{{.State.Running}} {{.State.ExitCode}}", handle
+        )
+        if code == 0:
+            running, _, exit_str = out.strip().partition(" ")
+            if running == "true":
+                return RunStatus(state="running")
+            # 已退出但尚未被 --rm 收走的小窗口：直接用 inspect 的退出码
+            try:
+                exit_code: int | None = int(exit_str)
+            except ValueError:
+                exit_code = None
+            if exit_code == 0:
+                return RunStatus(state="succeeded", exit_code=0)
+            return RunStatus(state="failed", exit_code=exit_code)
+        # 容器不在了（--rm 已收走，或被 cancel）：run.exit 是唯一可信终态
+        exit_code = self.read_exit_code()
+        if exit_code is None:
+            return RunStatus(
+                state="failed",
+                detail="容器已消失且未落盘 run.exit（启动即崩、被强杀或已取消）",
+            )
+        if exit_code == 0:
+            return RunStatus(state="succeeded", exit_code=0)
+        return RunStatus(state="failed", exit_code=exit_code)
+
+    async def cancel(self, handle: str) -> None:
+        """docker rm -f：尽力而为、幂等（容器已结束/已删除都是 no-op）。"""
+        await _run_docker("rm", "-f", handle)
+
+    # ---- 产物读取（host 侧直读工作目录；不进容器） ----
+
+    def read_exit_code(self) -> int | None:
+        text = self.read_text(RUN_EXIT_FILE)
+        if text is None:
+            return None
+        try:
+            return int(text.strip())
+        except ValueError:
+            return None
+
+    def read_text(self, relpath: str, *, max_bytes: int = 4 * 1024 * 1024) -> str | None:
+        """读工作目录内文件（路径过白名单）；不存在返回 None，超长截断取前段。"""
+        try:
+            rel = _validate_relpath(relpath)
+        except SSHPathViolationError as e:
+            raise RunnerError(str(e)) from e
+        target = self._workdir / rel
+        if not target.is_file():
+            return None
+        return target.read_bytes()[:max_bytes].decode("utf-8", errors="replace")
+
+    def tail(self, relpath: str, *, max_chars: int = 2000) -> str:
+        """日志尾部（人读的收尾说明用）；文件不存在返回空串。"""
+        text = self.read_text(relpath)
+        return (text or "")[-max_chars:].strip()
+
+
+def metric_point(name: str, step: int, value: float) -> dict[str, object]:
+    """标量指标点，NaN 带 flag 记录而不丢弃。
+
+    设计报告拍板（polaris-2.0 设计报告「实验执行后端」节 / p3 计划 R4）：
+    仿真里 NaN 是**发散信号**，静默丢弃会把「解发散了」伪装成「没有数据」；
+    记为 value=None + flag="nan"（NaN 进不了 JSON，用 None 占位、flag 定性）。
+    """
+    if value != value:  # NaN 唯一不等于自身
+        return {"name": name, "step": step, "value": None, "flag": "nan"}
+    return {"name": name, "step": step, "value": value}
+
+
+def parse_float_table(text: str) -> tuple[list[str], list[list[float]]]:
+    """解析空白分隔的数值表（wrdata 输出 / OpenFOAM postProcessing 的 dat/csv）。
+
+    - ``#`` 开头的行是注释头；**最后一行**注释头当列名（OpenFOAM 惯例：
+      ``# Time  p  U`` 紧贴数据）；无注释头则列名为空列表；
+    - 数据行逐 token float()；含非标量 token 的行（如 OpenFOAM 向量列
+      ``(0 0 0)``）整行跳过——本期只收标量列，向量场解析待后续后端需要再加；
+    - ``nan``/``inf`` 是合法 float，**保留**进表（NaN 语义由 metric_point 定性）。
+    """
+    header: list[str] = []
+    rows: list[list[float]] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("#"):
+            fields = stripped.lstrip("#").replace(",", " ").split()
+            if fields:
+                header = fields
+            continue
+        tokens = stripped.replace(",", " ").split()
+        try:
+            rows.append([float(t) for t in tokens])
+        except ValueError:
+            continue  # 向量列/文字行：跳过（见 docstring）
+    return header, rows
+
+
+class ContainerBackendBase:
+    """容器后端的公共生命周期（prepare/poll/cancel/cleanup/dry_run）。
+
+    子类提供 manifest 并实现 validate/launch/collect；launch 必须把容器名
+    句柄同时记入 ``ctx.scratch["container"]``（cleanup 兜底取消用）。
+    """
+
+    def __init__(self, substrate: ContainerSubstrate | None = None) -> None:
+        self._substrate = substrate
+
+    @classmethod
+    def create(cls, *, substrate: ContainerSubstrate | None = None, **_: object):
+        """注册表工厂入口（多余的底座关键字忽略：python-ml 等收的是 runner=）。"""
+        return cls(substrate=substrate)
+
+    def _require_substrate(self) -> ContainerSubstrate:
+        if self._substrate is None:
+            raise RunnerError("容器后端未绑定执行底座（resolve_backend 需传 substrate=…）")
+        return self._substrate
+
+    async def prepare(self, ctx) -> None:
+        """备环境 = 建工作目录 + 物料落盘（纯数据通道）。
+
+        TODO(#680 接线)：manifest.resources 已声明 cpu/mem 需求，这里应在落盘前
+        对 docker host 对应的 Resource 走 resource_leases.acquire（wait=True 排队），
+        cleanup 里 release——等动作层切到 v2 分派（R4 后半）连同 run_id 一起接入；
+        本 PR 先把需求声明进 manifest，租约获取暂缺不影响单机语义。
+        """
+        substrate = self._require_substrate()
+        if ctx.files:
+            substrate.write_materials(ctx.files)
+        else:
+            substrate.workdir.mkdir(parents=True, exist_ok=True)
+
+    async def poll(self, handle: str) -> RunStatus:
+        return await self._require_substrate().poll(handle)
+
+    async def cancel(self, handle: str) -> None:
+        await self._require_substrate().cancel(handle)
+
+    async def cleanup(self, ctx) -> None:
+        """善后：兜底删掉可能还在跑的容器（幂等）。工作目录**有意**保留——
+        与 python-ml 同理，用户复查产物、失败诊断都要它。"""
+        handle = ctx.scratch.get("container")
+        if handle and self._substrate is not None:
+            await self._substrate.cancel(str(handle))
+
+    async def dry_run(self, ctx) -> RunStatus:
+        raise NotImplementedError("容器后端暂无 dry_run（契约占位，§13 暂缓启用）")

--- a/src/backend/app/services/runners/ngspice.py
+++ b/src/backend/app/services/runners/ngspice.py
@@ -1,0 +1,222 @@
+"""ngspice 后端：零 license 电路仿真容器（#681，R4；p3 计划的第一档验证后端）。
+
+为什么选它打头阵：ngspice 开源零 license、镜像体积小（CI 拉得动）、批处理
+模式一条命令跑完——正好用最小代价验证 v2 的物料契约与结果文件通道。
+
+物料契约：一个 SPICE netlist ``circuit.cir``（LLM 产出**文件内容**，经纯数据
+通道落盘）。执行：固定模板 ``ngspice -b circuit.cir -o run.log``（-b 批处理，
+-o 全部输出进 run.log），模板是本模块字符串常量，plan 只可能改**镜像名**
+（过白名单正则）——LLM 自由文本永不进 CLI（铁律见 container_substrate.py）。
+
+结果双通道：
+- run.log 里的 ``name = value`` 行（.meas 测量结果 / .op 工作点）→ 标量指标；
+- netlist 里 ``wrdata <file> <vec…>`` 声明的数据文件 → 指标序列 + 结果文件。
+NaN 带 flag 记录不丢弃（发散信号，见 metric_point 的 docstring）。
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from app.services.runners.container_substrate import (
+    ContainerBackendBase,
+    ContainerSubstrate,
+    metric_point,
+    parse_float_table,
+)
+from app.services.runners.contract import (
+    Issue,
+    MaterialSpec,
+    ResourceNeeds,
+    ResultBundle,
+    ResultFile,
+    RunContext,
+    RunHandle,
+    RunnerManifest,
+)
+
+NGSPICE_BACKEND = "ngspice"
+
+NETLIST = "circuit.cir"
+RUN_LOG = "run.log"
+
+# 默认镜像：平台自维护的公共 ngspice 镜像（docker hub 上没有官方/权威镜像，
+# 不能默认信任个人镜像；构建配方就是 alpine + apk add ngspice，见 #681）。
+# plan.image 可覆盖（过 _IMAGE_RE 白名单），CI/本地冒烟用本地构建的 tag。
+DEFAULT_IMAGE = "polaris/ngspice:latest"
+
+# 固定模板命令（唯一进容器 sh -c 的内容；无任何 plan/LLM 插值）
+LAUNCH_TEMPLATE = f"ngspice -b {NETLIST} -o {RUN_LOG}"
+
+# run.log 里的标量结果行：.meas 打印 "vmax = 4.99e+00 at= …"、.op 打印
+# "v(out) = 2.5e+00"。名字收字母开头的标识符（可含括号/点），值交给 float()
+# 判定（nan/inf 也是合法 float——发散要记下来，不是丢掉）。
+_SCALAR_LINE_RE = re.compile(r"^\s*([A-Za-z_][\w().\[\]#]*)\s*=\s*([-+\w.]+)")
+# netlist 里的 wrdata 声明：wrdata <文件名> <向量…>（.control 块内，大小写不敏感）
+_WRDATA_RE = re.compile(r"^\s*wrdata\s+(\S+)\s+(.+?)\s*$", re.IGNORECASE | re.MULTILINE)
+
+# 单个序列的指标点上限：长瞬态几十万行全进 DB 没有意义，等步长抽稀到上限内
+# （首尾保留由抽稀步长自然覆盖不了尾点的场景可接受——曲线形态是目的）。
+_MAX_SERIES_POINTS = 2000
+
+NGSPICE_MANIFEST = RunnerManifest(
+    backend=NGSPICE_BACKEND,
+    interaction="batch",
+    side_effects="filesystem",  # 容器 --network none + 只挂工作目录，声明与落实一致
+    materials=(
+        MaterialSpec(
+            NETLIST,
+            required=True,
+            description="SPICE netlist（首行必须是标题行；.control 块内可用 wrdata 导出序列）",
+        ),
+    ),
+    io_schema={
+        "inputs": {
+            NETLIST: "LLM 产出的电路 netlist",
+            "plan.image": f"可选容器镜像（白名单校验；默认 {DEFAULT_IMAGE}）",
+        },
+        "outputs": {
+            RUN_LOG: "ngspice 批处理全部输出（.meas/.op 标量在此解析）",
+            "wrdata 文件": "netlist 里 wrdata 声明的数据表 → 指标序列 + 结果文件",
+        },
+    },
+    # 单进程 CPU 仿真的保守声明；#680 租约接线见 ContainerBackendBase.prepare 的 TODO
+    resources=ResourceNeeds(cpu=1, mem_gb=2.0, walltime_min=60),
+    licenses=(),  # 零 license 正是选它的原因
+    credential_kinds=(),  # 本机 docker，无需连接凭据
+    prompt_pack=NGSPICE_BACKEND,
+)
+
+
+class NgspiceRunner(ContainerBackendBase):
+    """ngspice 批处理容器后端（生命周期公共部分见 ContainerBackendBase）。"""
+
+    manifest = NGSPICE_MANIFEST
+
+    async def validate(self, plan: dict[str, Any]) -> list[Issue]:
+        """netlist 静态检查：存在、非空、首行是标题行（ngspice 无条件把首行当
+        标题——首行若是 ``.`` 指令会被整行吞掉，仿真悄悄错，必须挡在这里）。"""
+        files = plan.get("files") if isinstance(plan, dict) else None
+        if not isinstance(files, dict) or NETLIST not in files:
+            return [
+                Issue(
+                    code="materials.missing",
+                    message=f"缺少必需物料 {NETLIST}（SPICE netlist）",
+                    path=NETLIST,
+                )
+            ]
+        netlist = files[NETLIST]
+        lines = [ln for ln in str(netlist).splitlines() if ln.strip()]
+        if not lines:
+            return [
+                Issue(
+                    code="materials.empty",
+                    message=f"{NETLIST} 为空（netlist 至少要有标题行与 .end）",
+                    path=NETLIST,
+                )
+            ]
+        issues: list[Issue] = []
+        first = lines[0].strip()
+        if first.startswith("."):
+            issues.append(
+                Issue(
+                    code="materials.invalid",
+                    message=(
+                        f"{NETLIST} 首行是 {first.split()[0]} 指令——ngspice 会把首行"
+                        "当标题吞掉，该指令不会生效；请在首行加一行标题"
+                    ),
+                    path=NETLIST,
+                )
+            )
+        if not any(ln.strip().lower().startswith(".end") for ln in lines):
+            issues.append(
+                Issue(
+                    code="materials.suspicious",
+                    message=f"{NETLIST} 未见 .end——ngspice 可能报 netlist 不完整",
+                    path=NETLIST,
+                    severity="warning",
+                )
+            )
+        return issues
+
+    async def launch(self, ctx: RunContext) -> RunHandle:
+        """固定模板拉起批处理容器；镜像名是 plan 唯一可变项（底座白名单校验）。"""
+        substrate = self._require_substrate()
+        image = str(ctx.plan.get("image") or "").strip() or DEFAULT_IMAGE
+        handle = await substrate.launch(image=image, command=LAUNCH_TEMPLATE)
+        ctx.scratch["container"] = handle  # cleanup 兜底取消用
+        ctx.scratch["launch_command"] = LAUNCH_TEMPLATE  # 审计留档（照 python-ml 惯例）
+        return handle
+
+    async def collect(self, ctx: RunContext) -> ResultBundle:
+        """收结果：run.log 标量行 + wrdata 序列 + 结果文件登记（失败的 run 也尽量收）。"""
+        substrate = self._require_substrate()
+        metrics: list[dict[str, Any]] = []
+        files: list[ResultFile] = []
+
+        log_text = substrate.read_text(RUN_LOG)
+        if log_text is not None:
+            files.append(ResultFile(name=RUN_LOG, path=RUN_LOG))
+            # 标量结果（.meas/.op）没有时间轴，step 恒 0（一次 run 一个值）
+            for line in log_text.splitlines():
+                m = _SCALAR_LINE_RE.match(line)
+                if not m:
+                    continue
+                try:
+                    value = float(m.group(2))
+                except ValueError:
+                    continue  # "= 号后不是数"的普通文案行（如 ngspice 的提示语）
+                metrics.append(metric_point(m.group(1), 0, value))
+
+        # wrdata 声明来自 netlist 物料本身（确定性解析，不是 LLM 再猜一遍）
+        netlist = ctx.files.get(NETLIST) or substrate.read_text(NETLIST) or ""
+        for m in _WRDATA_RE.finditer(netlist):
+            filename, names = m.group(1), m.group(2).split()
+            table_text = substrate.read_text(filename)
+            if table_text is None:
+                continue  # 仿真中途失败可能没写出来；标量通道照收
+            _, rows = parse_float_table(table_text)
+            metrics.extend(self._series_points(names, rows))
+            files.append(
+                ResultFile(
+                    name=filename,
+                    path=filename,
+                    parser="table",
+                    summary={"rows": len(rows), "columns": len(rows[0]) if rows else 0},
+                )
+            )
+        return ResultBundle(metrics=metrics, files=files, notes=substrate.tail(RUN_LOG))
+
+    @staticmethod
+    def _series_points(names: list[str], rows: list[list[float]]) -> list[dict[str, Any]]:
+        """wrdata 表 → 指标序列。列布局按 ngspice 约定判定：
+
+        - 默认每个向量带自己的横轴：2N 列 = (scale, value) 对，取奇数列；
+        - ``set wr_singlescale`` 时 N+1 列 = 共享横轴 + N 个值列；
+        - 其余布局（手工文件等）退化为「首列横轴、其余按序配名」。
+        step 用行号（横轴数值是物理时间，指标点契约的 step 是 int 序号）。
+        """
+        if not rows or not names:
+            return []
+        ncols = len(rows[0])
+        if ncols == 2 * len(names):
+            cols = [2 * i + 1 for i in range(len(names))]
+        elif ncols == len(names) + 1:
+            cols = list(range(1, ncols))
+        else:
+            cols = list(range(1, min(ncols, len(names) + 1)))
+        stride = max(1, -(-len(rows) // _MAX_SERIES_POINTS))  # ceil，抽稀到上限内
+        points: list[dict[str, Any]] = []
+        for step, row in enumerate(rows):
+            if step % stride:
+                continue
+            for name, col in zip(names, cols, strict=False):
+                if col < len(row):
+                    points.append(metric_point(name, step, row[col]))
+        return points
+
+
+def create_substrate(workdir: str, **kwargs: Any) -> ContainerSubstrate:
+    """便捷工厂：给动作层/冒烟测试建一个带 ngspice 前缀的底座。"""
+    return ContainerSubstrate(workdir, name_prefix=f"polaris-{NGSPICE_BACKEND}", **kwargs)

--- a/src/backend/app/services/runners/openfoam.py
+++ b/src/backend/app/services/runners/openfoam.py
@@ -1,0 +1,241 @@
+"""OpenFOAM 后端：零 license CFD 容器（#681，R4；与 ngspice 同属第一档验证后端）。
+
+它验证的是 v2 物料契约的**目录形态**：不是单文件 netlist，而是一整个 case
+目录（``system/`` 数值格式与求解控制、``constant/`` 物性与网格、``0/`` 初始
+边界条件）——LLM 产出的仍然只是**文件内容**，目录结构由相对路径表达。
+
+求解器选择是「plan 参数但必须过白名单」的范本：plan.solver 只能命中
+``ALLOWED_SOLVERS`` 里的键，容器里执行的命令取自按白名单**预生成**的模板
+字典——plan 挑键，不拼串；白名单外直接拒绝（validate 报 error、launch 抛
+RunnerError 双保险）。起步收 icoFoam/simpleFoam/pimpleFoam 三个最常用的
+不可压求解器，扩清单 = 改这一个元组。
+
+结果双通道：
+- 求解器日志的残差行（``Solving for p … Final residual = 1e-06``）→
+  按迭代序的残差指标（NaN 带 flag 记录：残差 nan 是发散的直接证据）；
+- ``postProcessing/`` 下功能对象输出的 dat/csv 数值表 → 指标序列 + 结果文件。
+
+镜像默认 opencfd 官方公共镜像（体积大：CI 只跑 fixture 单测，真容器冒烟
+仅本地手动跑，见 tests 的 docker_integration 标记）。
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from app.services.runners.container_substrate import (
+    ContainerBackendBase,
+    ContainerSubstrate,
+    metric_point,
+    parse_float_table,
+)
+from app.services.runners.contract import (
+    Issue,
+    MaterialSpec,
+    ResourceNeeds,
+    ResultBundle,
+    ResultFile,
+    RunContext,
+    RunHandle,
+    RunnerError,
+    RunnerManifest,
+)
+
+OPENFOAM_BACKEND = "openfoam"
+
+SOLVER_LOG = "solver.log"
+POSTPROCESSING_DIR = "postProcessing"
+
+# 求解器白名单：plan.solver 的唯一合法取值域（起步三件套，扩充改这里）
+ALLOWED_SOLVERS = ("icoFoam", "simpleFoam", "pimpleFoam")
+
+# 默认镜像：OpenCFD 官方公共镜像（自带全部标准求解器；入口脚本负责 source
+# OpenFOAM 环境后再执行我们的命令）。plan.image 可覆盖（白名单正则校验）。
+DEFAULT_IMAGE = "opencfd/openfoam-default:latest"
+
+# 按白名单预生成的固定模板命令：plan 只能挑键，永远拼不进串（铁律范本）。
+# 前置 blockMesh：OpenFOAM 求解器要求 constant/polyMesh 网格在场，标准工作流是
+# 由 system/blockMeshDict 生成——物料里带了 dict 就先建网格（失败即整体失败，
+# && 短路），没带就默认网格已随物料给出。整段仍是常量模板，无任何插值来自 plan。
+LAUNCH_TEMPLATES = {
+    solver: (
+        "if [ -f system/blockMeshDict ]; then blockMesh -case /work > blockMesh.log 2>&1"
+        f" || exit $?; fi && {solver} -case /work > {SOLVER_LOG} 2>&1"
+    )
+    for solver in ALLOWED_SOLVERS
+}
+
+# 残差行（OpenFOAM 求解器日志逐迭代打印）；residual 交 float() 判定，nan 合法
+_RESIDUAL_RE = re.compile(r"Solving for (\w+).*?Final residual = ([-+\w.]+)")
+
+_MAX_SERIES_POINTS = 2000  # 与 ngspice 同款抽稀上限（长算例的残差/序列行数很大）
+
+OPENFOAM_MANIFEST = RunnerManifest(
+    backend=OPENFOAM_BACKEND,
+    interaction="batch",
+    side_effects="filesystem",  # --network none + 只挂工作目录
+    materials=(
+        # case 目录的三个必需 system 文件；0/ 与 constant/ 是目录约定，
+        # MaterialSpec 只表达文件，目录结构检查在 validate 里补
+        MaterialSpec("system/controlDict", required=True, description="求解控制（时间步/输出）"),
+        MaterialSpec("system/fvSchemes", required=True, description="离散格式"),
+        MaterialSpec("system/fvSolution", required=True, description="线性求解器与松弛"),
+    ),
+    io_schema={
+        "inputs": {
+            "case 目录": "system/ + constant/ + 0/ 的完整 OpenFOAM case（LLM 产文件内容）",
+            "plan.solver": f"求解器名，必须 ∈ {list(ALLOWED_SOLVERS)}",
+            "plan.image": f"可选容器镜像（白名单校验；默认 {DEFAULT_IMAGE}）",
+        },
+        "outputs": {
+            SOLVER_LOG: "求解器日志（残差指标在此解析）",
+            f"{POSTPROCESSING_DIR}/": "功能对象输出的 dat/csv → 指标序列 + 结果文件",
+        },
+    },
+    # CFD 单机保守声明；#680 租约接线见 ContainerBackendBase.prepare 的 TODO
+    resources=ResourceNeeds(cpu=4, mem_gb=8.0, walltime_min=240),
+    licenses=(),
+    credential_kinds=(),  # 本机 docker，无需连接凭据
+    prompt_pack=OPENFOAM_BACKEND,
+)
+
+
+class OpenFOAMRunner(ContainerBackendBase):
+    """OpenFOAM 批处理容器后端（生命周期公共部分见 ContainerBackendBase）。"""
+
+    manifest = OPENFOAM_MANIFEST
+
+    async def validate(self, plan: dict[str, Any]) -> list[Issue]:
+        """case 目录结构 + 求解器白名单的静态检查。"""
+        files = plan.get("files") if isinstance(plan, dict) else None
+        files = files if isinstance(files, dict) else {}
+        issues = [
+            Issue(
+                code="materials.missing",
+                message=f"缺少必需物料 {m.path}（{m.description}）",
+                path=m.path,
+            )
+            for m in self.manifest.materials
+            if m.required and m.path not in files
+        ]
+        # 目录约定：0/ 至少一个初始场、constant/ 至少一个文件（物性或网格描述）
+        for prefix, why in (
+            ("0/", "初始/边界条件场（如 0/p、0/U）"),
+            ("constant/", "物性/网格（如 constant/transportProperties）"),
+        ):
+            if not any(name.startswith(prefix) for name in files):
+                issues.append(
+                    Issue(
+                        code="materials.missing",
+                        message=f"case 缺少 {prefix} 下的文件（{why}）",
+                        path=prefix,
+                    )
+                )
+        solver = str(plan.get("solver") or "").strip() if isinstance(plan, dict) else ""
+        if solver not in ALLOWED_SOLVERS:
+            issues.append(
+                Issue(
+                    code="plan.solver_not_allowed",
+                    message=(
+                        f"plan.solver={solver!r} 不在白名单 {list(ALLOWED_SOLVERS)} 内"
+                        "（求解器名会进容器命令行，只认白名单）"
+                    ),
+                )
+            )
+        return issues
+
+    async def launch(self, ctx: RunContext) -> RunHandle:
+        """按白名单模板字典取命令拉起容器（launch 再验一遍白名单：双保险）。"""
+        substrate = self._require_substrate()
+        solver = str(ctx.plan.get("solver") or "").strip()
+        command = LAUNCH_TEMPLATES.get(solver)
+        if command is None:
+            raise RunnerError(
+                f"求解器 {solver!r} 不在白名单 {list(ALLOWED_SOLVERS)} 内，拒绝启动"
+            )
+        image = str(ctx.plan.get("image") or "").strip() or DEFAULT_IMAGE
+        handle = await substrate.launch(image=image, command=command)
+        ctx.scratch["container"] = handle
+        ctx.scratch["launch_command"] = command  # 审计留档
+        return handle
+
+    async def collect(self, ctx: RunContext) -> ResultBundle:
+        """收结果：残差序列 + postProcessing 数值表 + 结果文件登记。"""
+        substrate = self._require_substrate()
+        metrics: list[dict[str, Any]] = []
+        files: list[ResultFile] = []
+
+        log_text = substrate.read_text(SOLVER_LOG)
+        if log_text is not None:
+            files.append(ResultFile(name=SOLVER_LOG, path=SOLVER_LOG))
+            metrics.extend(self._residual_points(log_text))
+        if substrate.read_text("blockMesh.log") is not None:  # 建网格日志也登记（诊断用）
+            files.append(ResultFile(name="blockMesh.log", path="blockMesh.log"))
+
+        # postProcessing/：功能对象各自建目录（<func>/<time>/<file>.dat），
+        # 确定性扫描 dat/csv；指标名冠功能对象目录名，同名文件不同时间段不串
+        pp_root = substrate.workdir / POSTPROCESSING_DIR
+        if pp_root.is_dir():
+            for path in sorted(pp_root.rglob("*")):
+                if not (path.is_file() and path.suffix in (".dat", ".csv")):
+                    continue
+                rel = path.relative_to(substrate.workdir).as_posix()
+                text = substrate.read_text(rel) or ""
+                header, rows = parse_float_table(text)
+                func = rel.split("/")[1] if len(rel.split("/")) > 2 else path.stem
+                metrics.extend(self._table_points(func, header, rows))
+                files.append(
+                    ResultFile(
+                        name=rel,
+                        path=rel,
+                        parser="table",
+                        summary={"rows": len(rows), "columns": len(rows[0]) if rows else 0},
+                    )
+                )
+        return ResultBundle(metrics=metrics, files=files, notes=substrate.tail(SOLVER_LOG))
+
+    @staticmethod
+    def _residual_points(log_text: str) -> list[dict[str, Any]]:
+        """残差行 → 指标序列：每个场自己的迭代序号做 step；nan 带 flag 记录
+        （残差 nan = 解发散，这正是要暴露给上层看的信号）。"""
+        counters: dict[str, int] = {}
+        points: list[dict[str, Any]] = []
+        for m in _RESIDUAL_RE.finditer(log_text):
+            field, raw = m.group(1), m.group(2)
+            try:
+                value = float(raw)
+            except ValueError:
+                continue
+            step = counters.get(field, 0)
+            counters[field] = step + 1
+            points.append(metric_point(f"residual.{field}", step, value))
+        return points
+
+    @staticmethod
+    def _table_points(
+        func: str, header: list[str], rows: list[list[float]]
+    ) -> list[dict[str, Any]]:
+        """postProcessing 数值表 → 指标序列：首列是时间轴（OpenFOAM 惯例），
+        其余列按表头命名（无表头用列号）；step 用行号（契约要求 int 序号）。"""
+        if not rows:
+            return []
+        ncols = len(rows[0])
+        names = [
+            header[i] if i < len(header) else f"col{i}"
+            for i in range(1, ncols)
+        ]
+        stride = max(1, -(-len(rows) // _MAX_SERIES_POINTS))
+        points: list[dict[str, Any]] = []
+        for step, row in enumerate(rows):
+            if step % stride:
+                continue
+            for i, name in enumerate(names, start=1):
+                if i < len(row):
+                    points.append(metric_point(f"{func}.{name}", step, row[i]))
+        return points
+
+
+def create_substrate(workdir: str, **kwargs: Any) -> ContainerSubstrate:
+    """便捷工厂：给动作层/冒烟测试建一个带 openfoam 前缀的底座。"""
+    return ContainerSubstrate(workdir, name_prefix=f"polaris-{OPENFOAM_BACKEND}", **kwargs)

--- a/src/backend/app/services/runners/registry.py
+++ b/src/backend/app/services/runners/registry.py
@@ -16,6 +16,8 @@ from collections.abc import Callable
 from typing import Any
 
 from app.services.runners.contract import RunnerPlugin
+from app.services.runners.ngspice import NGSPICE_BACKEND, NgspiceRunner
+from app.services.runners.openfoam import OPENFOAM_BACKEND, OpenFOAMRunner
 from app.services.runners.python_ml import PYTHON_ML_BACKEND, PythonMLRunner
 
 DEFAULT_BACKEND = PYTHON_ML_BACKEND  # 缺省后端：兼容全部存量实验
@@ -76,3 +78,5 @@ def resolve_backend(plan: Any, **substrate: Any) -> RunnerPlugin:
 
 # —— 内建后端注册（新后端在各自模块里定义工厂，在这里挂进注册表）——
 register(PYTHON_ML_BACKEND, PythonMLRunner.create)
+register(NGSPICE_BACKEND, NgspiceRunner.create)  # R4 零 license 容器后端（#681）
+register(OPENFOAM_BACKEND, OpenFOAMRunner.create)  # 同上：case 目录物料形态的范本

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -76,3 +76,8 @@ known-first-party = ["app", "worker"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+# 真容器冒烟默认不选（需要本机 docker 与镜像）；单独跑：pytest -m docker_integration
+addopts = "-m 'not docker_integration'"
+markers = [
+    "docker_integration: 真 docker 容器冒烟（本机 docker + 镜像在场才跑，CI/默认 deselect）",
+]

--- a/src/backend/tests/test_container_backends.py
+++ b/src/backend/tests/test_container_backends.py
@@ -1,0 +1,481 @@
+"""容器后端测试（#681，R4）：ngspice / openfoam 的 manifest、validate 边界、
+collect 解析器（fixture 日志/数据表，不碰 docker），加真容器冒烟（docker_integration
+标记，默认 deselect；见 pyproject 的 addopts）。
+
+铁律的测试面：docker run 的 argv 模板逐项断言（--rm/--network none/只挂工作目录/
+sh -c 固定模板）、白名单外求解器与非法镜像名的拒绝、物料路径越界拒绝。
+"""
+
+import os
+import shutil
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.experiment import ExperimentParams
+from app.services.runners import container_substrate, registry
+from app.services.runners.container_substrate import (
+    ContainerSubstrate,
+    metric_point,
+    parse_float_table,
+)
+from app.services.runners.contract import RunContext, RunnerError, RunStatus
+from app.services.runners.ngspice import NGSPICE_MANIFEST, NgspiceRunner
+from app.services.runners.openfoam import (
+    ALLOWED_SOLVERS,
+    LAUNCH_TEMPLATES,
+    OPENFOAM_MANIFEST,
+    OpenFOAMRunner,
+)
+
+# ---- fixture 物料与产物 ----
+
+RC_NETLIST = """* rc transient smoke
+V1 in 0 PULSE(0 5 0 1u 1u 4m 8m)
+R1 in out 1k
+C1 out 0 1u
+.tran 10u 5m
+.control
+run
+meas tran vmax MAX v(out)
+wrdata rc_out.dat v(out)
+.endc
+.end
+"""
+
+NGSPICE_LOG = """Note: No compatibility mode selected!
+
+Circuit: * rc transient smoke
+
+Doing analysis at TEMP = 27.000000 and TNOM = 27.000000
+
+No. of Data Rows : 501
+vmax                =  4.996717e+00 at=  2.060000e-03
+idiv                =  nan
+"""
+
+# wrdata 默认布局：每个向量 (scale, value) 成对 → 1 个向量 = 2 列；含一个 NaN 值行
+RC_WRDATA = """ 0.000000e+00  0.000000e+00
+ 1.000000e-05  4.700000e-02
+ 2.000000e-05  nan
+ 3.000000e-05  1.370000e-01
+"""
+
+OPENFOAM_LOG = """Time = 0.001
+
+Courant Number mean: 0.1 max: 0.5
+smoothSolver:  Solving for Ux, Initial residual = 1, Final residual = 8.5e-07, No Iterations 3
+DICPCG:  Solving for p, Initial residual = 1, Final residual = 0.01, No Iterations 20
+
+Time = 0.002
+
+smoothSolver:  Solving for Ux, Initial residual = 0.1, Final residual = 2.1e-07, No Iterations 2
+DICPCG:  Solving for p, Initial residual = 0.5, Final residual = nan, No Iterations 1000
+"""
+
+PROBES_DAT = """# Probe 0 (0.05 0.05 0.005)
+#       Time            p
+        0.001           2.5
+        0.002           nan
+        0.003           2.75
+"""
+
+GOOD_CASE = {
+    "system/controlDict": "FoamFile {} application icoFoam;",
+    "system/fvSchemes": "FoamFile {}",
+    "system/fvSolution": "FoamFile {}",
+    "system/blockMeshDict": "FoamFile {}",
+    "0/p": "FoamFile {}",
+    "0/U": "FoamFile {}",
+    "constant/transportProperties": "nu 0.01;",
+}
+
+
+def _substrate(tmp_path, prefix="polaris-test") -> ContainerSubstrate:
+    return ContainerSubstrate(tmp_path / "work", name_prefix=prefix)
+
+
+# ---- manifest 与注册表分派 ----
+
+
+def test_manifests_declare_batch_filesystem_zero_license():
+    for m in (NGSPICE_MANIFEST, OPENFOAM_MANIFEST):
+        assert m.interaction == "batch"
+        assert m.side_effects == "filesystem"  # --network none + 只挂工作目录的声明面
+        assert m.licenses == ()  # 零 license 正是 R4 选型标准
+        assert m.credential_kinds == ()  # 本机 docker，无连接凭据
+    assert [mat.path for mat in NGSPICE_MANIFEST.materials] == ["circuit.cir"]
+    assert [mat.path for mat in OPENFOAM_MANIFEST.materials] == [
+        "system/controlDict",
+        "system/fvSchemes",
+        "system/fvSolution",
+    ]
+
+
+def test_registry_dispatches_both_backends():
+    known = registry.known_backends()
+    assert "ngspice" in known and "openfoam" in known
+    assert isinstance(registry.resolve_backend({"backend": "ngspice"}), NgspiceRunner)
+    assert isinstance(registry.resolve_backend({"backend": "openfoam"}), OpenFOAMRunner)
+    # python-ml 默认分派不受影响（存量实验行为不变）
+    assert registry.resolve_backend({}).manifest.backend == "python-ml"
+
+
+def test_experiment_params_accept_new_backends():
+    assert ExperimentParams(backend="ngspice").backend == "ngspice"
+    assert ExperimentParams(backend="openfoam").backend == "openfoam"
+    with pytest.raises(ValidationError):
+        ExperimentParams(backend="hfss")  # 商业 EDA 不在本期
+
+
+# ---- ngspice validate 边界 ----
+
+
+async def test_ngspice_validate_missing_and_empty_netlist():
+    issues = await NgspiceRunner().validate({"files": {"other.txt": "x"}})
+    assert [(i.code, i.path) for i in issues] == [("materials.missing", "circuit.cir")]
+    issues = await NgspiceRunner().validate({"files": {"circuit.cir": "  \n\n"}})
+    assert [i.code for i in issues] == ["materials.empty"]
+    issues = await NgspiceRunner().validate({})  # plan 没给物料 = 缺失
+    assert [i.code for i in issues] == ["materials.missing"]
+
+
+async def test_ngspice_validate_title_line_and_end():
+    # 首行是 .tran 指令：ngspice 会把它当标题吞掉，必须报 error
+    bad = ".tran 10u 5m\nR1 in 0 1k\n.end\n"
+    issues = await NgspiceRunner().validate({"files": {"circuit.cir": bad}})
+    assert [i.code for i in issues] == ["materials.invalid"]
+    assert ".tran" in issues[0].message
+    # 缺 .end 只是 warning（不阻断，交给仿真器自己报）
+    issues = await NgspiceRunner().validate({"files": {"circuit.cir": "* t\nR1 a 0 1k\n"}})
+    assert [(i.code, i.severity) for i in issues] == [("materials.suspicious", "warning")]
+    assert await NgspiceRunner().validate({"files": {"circuit.cir": RC_NETLIST}}) == []
+
+
+# ---- ngspice collect 解析器 ----
+
+
+async def test_ngspice_collect_parses_log_scalars_and_wrdata_series(tmp_path):
+    substrate = _substrate(tmp_path)
+    plugin = NgspiceRunner(substrate=substrate)
+    ctx = RunContext(plan={}, files={"circuit.cir": RC_NETLIST}, substrate=substrate)
+    await plugin.prepare(ctx)
+    (substrate.workdir / "run.log").write_text(NGSPICE_LOG)
+    (substrate.workdir / "rc_out.dat").write_text(RC_WRDATA)
+
+    bundle = await plugin.collect(ctx)
+
+    scalars = [p for p in bundle.metrics if p["name"] in ("vmax", "idiv")]
+    assert scalars[0]["name"] == "vmax" and scalars[0]["step"] == 0
+    assert scalars[0]["value"] == pytest.approx(4.996717)
+    # NaN 带 flag 记录不丢弃（发散信号，设计报告拍板）
+    assert scalars[1] == {"name": "idiv", "step": 0, "value": None, "flag": "nan"}
+
+    series = [p for p in bundle.metrics if p["name"] == "v(out)"]
+    assert [p["step"] for p in series] == [0, 1, 2, 3]
+    assert series[0]["value"] == 0.0
+    assert series[1]["value"] == pytest.approx(0.047)
+    assert series[2] == {"name": "v(out)", "step": 2, "value": None, "flag": "nan"}
+    assert series[3]["value"] == pytest.approx(0.137)
+
+    assert [(f.name, f.parser) for f in bundle.files] == [
+        ("run.log", None),
+        ("rc_out.dat", "table"),
+    ]
+    assert bundle.files[1].summary == {"rows": 4, "columns": 2}
+    assert "idiv" in bundle.notes  # notes = run.log 尾部
+
+
+async def test_ngspice_collect_survives_missing_outputs(tmp_path):
+    """失败的 run 也要尽量收：run.log/wrdata 都没写出来 → 空 bundle 而非异常。"""
+    substrate = _substrate(tmp_path)
+    plugin = NgspiceRunner(substrate=substrate)
+    ctx = RunContext(files={"circuit.cir": RC_NETLIST}, substrate=substrate)
+    await plugin.prepare(ctx)
+    bundle = await plugin.collect(ctx)
+    assert bundle.metrics == [] and bundle.files == [] and bundle.notes == ""
+
+
+# ---- openfoam validate 边界与白名单 ----
+
+
+async def test_openfoam_validate_good_case_with_whitelisted_solver():
+    plugin = OpenFOAMRunner()
+    assert await plugin.validate({"files": GOOD_CASE, "solver": "icoFoam"}) == []
+
+
+async def test_openfoam_validate_reports_missing_structure():
+    plugin = OpenFOAMRunner()
+    files = {"system/controlDict": "x"}  # 缺 fvSchemes/fvSolution/0/constant
+    issues = await plugin.validate({"files": files, "solver": "icoFoam"})
+    assert [i.path for i in issues if i.code == "materials.missing"] == [
+        "system/fvSchemes",
+        "system/fvSolution",
+        "0/",
+        "constant/",
+    ]
+
+
+async def test_openfoam_rejects_solver_outside_whitelist():
+    plugin = OpenFOAMRunner()
+    issues = await plugin.validate({"files": GOOD_CASE, "solver": "rm -rf /; icoFoam"})
+    assert [i.code for i in issues] == ["plan.solver_not_allowed"]
+    issues = await plugin.validate({"files": GOOD_CASE})  # 不给 solver 同样拒绝
+    assert [i.code for i in issues] == ["plan.solver_not_allowed"]
+    # launch 双保险：白名单外直接 RunnerError，绝不进命令行
+    plugin = OpenFOAMRunner(substrate=ContainerSubstrate("/nonexistent"))
+    with pytest.raises(RunnerError, match="白名单"):
+        await plugin.launch(RunContext(plan={"solver": "sonicFoam"}))
+
+
+def test_openfoam_templates_are_fixed_strings_per_whitelist():
+    """模板字典按白名单预生成：plan 只能挑键；模板本体不含任何插值痕迹。"""
+    assert set(LAUNCH_TEMPLATES) == set(ALLOWED_SOLVERS)
+    for solver, cmd in LAUNCH_TEMPLATES.items():
+        assert f"{solver} -case /work" in cmd
+        assert "blockMesh" in cmd  # 建网格前置（物料带 blockMeshDict 才执行）
+
+
+# ---- openfoam collect 解析器 ----
+
+
+async def test_openfoam_collect_parses_residuals_and_postprocessing(tmp_path):
+    substrate = _substrate(tmp_path)
+    plugin = OpenFOAMRunner(substrate=substrate)
+    ctx = RunContext(plan={"solver": "icoFoam"}, files=GOOD_CASE, substrate=substrate)
+    await plugin.prepare(ctx)
+    (substrate.workdir / "solver.log").write_text(OPENFOAM_LOG)
+    probes = substrate.workdir / "postProcessing" / "probes" / "0"
+    probes.mkdir(parents=True)
+    (probes / "p.dat").write_text(PROBES_DAT)
+
+    bundle = await plugin.collect(ctx)
+
+    ux = [p for p in bundle.metrics if p["name"] == "residual.Ux"]
+    assert [(p["step"], p["value"]) for p in ux] == [(0, 8.5e-07), (1, 2.1e-07)]
+    p_res = [p for p in bundle.metrics if p["name"] == "residual.p"]
+    assert p_res[0] == {"name": "residual.p", "step": 0, "value": 0.01}
+    # 残差 nan = 发散，flag 记录不丢弃
+    assert p_res[1] == {"name": "residual.p", "step": 1, "value": None, "flag": "nan"}
+
+    probe_p = [p for p in bundle.metrics if p["name"] == "probes.p"]
+    assert [(pt["step"], pt["value"]) for pt in probe_p] == [(0, 2.5), (1, None), (2, 2.75)]
+    assert probe_p[1]["flag"] == "nan"
+
+    assert [(f.name, f.parser) for f in bundle.files] == [
+        ("solver.log", None),
+        ("postProcessing/probes/0/p.dat", "table"),
+    ]
+    assert bundle.files[1].summary == {"rows": 3, "columns": 2}
+    assert "Solving for p" in bundle.notes
+
+
+# ---- 底座：模板 argv、路径白名单、run.exit 终态回退 ----
+
+
+async def test_docker_run_argv_is_the_fixed_template(tmp_path, monkeypatch):
+    """铁律的落地断言：进 docker CLI 的 argv 逐项来自固定模板与白名单字段。"""
+    calls = []
+
+    async def fake_run_docker(*argv, timeout=None):
+        calls.append(list(argv))
+        return 0, "container-id\n", ""
+
+    monkeypatch.setattr(container_substrate, "_run_docker", fake_run_docker)
+    substrate = _substrate(tmp_path, prefix="polaris-ngspice")
+    plugin = NgspiceRunner(substrate=substrate)
+    ctx = RunContext(plan={}, files={"circuit.cir": RC_NETLIST}, substrate=substrate)
+    await plugin.prepare(ctx)
+    handle = await plugin.launch(ctx)
+
+    assert handle.startswith("polaris-ngspice-")
+    assert ctx.scratch["container"] == handle
+    (argv,) = calls
+    assert argv[:5] == ["run", "-d", "--rm", "--name", handle]
+    assert argv[5:9] == ["--network", "none", "-v", f"{substrate.workdir}:/work"]
+    assert argv[9:12] == ["-w", "/work", "polaris/ngspice:latest"]
+    # 容器内命令 = 模块常量模板 + 底座统一追加的退出码落盘；无任何自由文本
+    assert argv[12:] == ["sh", "-c", "ngspice -b circuit.cir -o run.log; echo $? > run.exit"]
+
+
+async def test_substrate_rejects_bad_image_and_missing_workdir(tmp_path):
+    substrate = _substrate(tmp_path)
+    substrate.workdir.mkdir(parents=True)
+    with pytest.raises(RunnerError, match="镜像名"):
+        await substrate.launch(image="evil; rm -rf /", command="true")
+    with pytest.raises(RunnerError, match="工作目录"):
+        await ContainerSubstrate(tmp_path / "nope").launch(image="alpine:3.20", command="true")
+
+
+def test_substrate_rejects_material_path_escape(tmp_path):
+    substrate = _substrate(tmp_path)
+    for bad in ("../evil.sh", "/etc/passwd", "~/x", "a/../../b"):
+        with pytest.raises(RunnerError, match="越界"):
+            substrate.write_materials({bad: "boom"})
+
+
+async def test_poll_falls_back_to_run_exit_after_rm(tmp_path, monkeypatch):
+    """--rm 收走容器后 inspect 扑空：run.exit 文件是终态唯一依据。"""
+
+    async def inspect_gone(*argv, timeout=None):
+        return 1, "", "Error: No such object"
+
+    monkeypatch.setattr(container_substrate, "_run_docker", inspect_gone)
+    substrate = _substrate(tmp_path)
+    substrate.workdir.mkdir(parents=True)
+    (substrate.workdir / "run.exit").write_text("0\n")
+    assert await substrate.poll("gone") == RunStatus(state="succeeded", exit_code=0)
+    (substrate.workdir / "run.exit").write_text("42\n")
+    assert (await substrate.poll("gone")).exit_code == 42
+    (substrate.workdir / "run.exit").unlink()
+    status = await substrate.poll("gone")
+    assert status.state == "failed" and "run.exit" in status.detail
+
+
+def test_metric_point_flags_nan_and_parse_float_table():
+    assert metric_point("m", 3, 1.5) == {"name": "m", "step": 3, "value": 1.5}
+    assert metric_point("m", 3, float("nan")) == {
+        "name": "m", "step": 3, "value": None, "flag": "nan",
+    }
+    header, rows = parse_float_table("# Time p\n0.1 2.5\n(0 0 0) 1\n0.2 3.5\n")
+    assert header == ["Time", "p"]
+    assert rows == [[0.1, 2.5], [0.2, 3.5]]  # 向量行整行跳过（本期只收标量列）
+
+
+async def test_unbound_plugin_allows_validate_but_refuses_lifecycle():
+    plugin = registry.resolve_backend({"backend": "ngspice"})
+    assert await plugin.validate({"files": {"circuit.cir": RC_NETLIST}}) == []
+    with pytest.raises(RunnerError, match="底座"):
+        await plugin.prepare(RunContext())
+    with pytest.raises(NotImplementedError):  # dry_run 契约占位（§13 暂缓）
+        await plugin.dry_run(RunContext())
+
+
+# ---- 真容器冒烟（默认 deselect；本机 docker + 镜像在场才有意义） ----
+
+NGSPICE_SMOKE_IMAGE = os.environ.get("POLARIS_NGSPICE_IMAGE", "polaris/ngspice:local")
+
+needs_docker = pytest.mark.skipif(shutil.which("docker") is None, reason="需要本机 docker")
+
+
+@pytest.mark.docker_integration
+@needs_docker
+async def test_ngspice_rc_transient_smoke_end_to_end(tmp_path):
+    """真跑一个 RC 电路瞬态分析到 collect（镜像小：alpine + apk add ngspice）。
+
+    镜像默认取本地构建的 polaris/ngspice:local（POLARIS_NGSPICE_IMAGE 可覆盖）：
+    printf 'FROM alpine:3.20\\nRUN apk add --no-cache ngspice\\n' \\
+      | docker build -t polaris/ngspice:local -
+    """
+    import asyncio
+
+    substrate = _substrate(tmp_path, prefix="polaris-ngspice")
+    plugin = NgspiceRunner(substrate=substrate)
+    plan = {"image": NGSPICE_SMOKE_IMAGE, "files": {"circuit.cir": RC_NETLIST}}
+    assert await plugin.validate(plan) == []
+
+    ctx = RunContext(plan=plan, files={"circuit.cir": RC_NETLIST}, substrate=substrate)
+    await plugin.prepare(ctx)
+    handle = await plugin.launch(ctx)
+    try:
+        for _ in range(120):
+            status = await plugin.poll(handle)
+            if status.state != "running":
+                break
+            await asyncio.sleep(1)
+        assert status.state == "succeeded", f"仿真未成功：{status}"
+
+        bundle = await plugin.collect(ctx)
+        by_name = {p["name"]: p for p in bundle.metrics if p["step"] == 0}
+        assert "vmax" in by_name, f"run.log 未解析出 vmax；notes 尾部：{bundle.notes[-500:]}"
+        # 脉宽 4tau（tau=RC=1ms）：峰值 ~5*(1-e^-4)=4.91V
+        assert 4.5 < by_name["vmax"]["value"] <= 5.05
+        series = [p for p in bundle.metrics if p["name"] == "v(out)"]
+        assert len(series) > 100  # .tran 10u/5m ≈ 500 点的序列进了指标通道
+        assert {f.name for f in bundle.files} >= {"run.log", "rc_out.dat"}
+    finally:
+        await plugin.cleanup(ctx)
+
+
+@pytest.mark.docker_integration
+@needs_docker
+@pytest.mark.skipif(
+    not os.environ.get("POLARIS_RUN_OPENFOAM_SMOKE"),
+    reason="openfoam 镜像大（GB 级），设 POLARIS_RUN_OPENFOAM_SMOKE=1 才真跑",
+)
+async def test_openfoam_cavity_smoke_end_to_end(tmp_path):
+    """icoFoam 顶盖驱动方腔（OpenFOAM 教程最小算例）：blockMesh 建网格 → 求解 →
+    collect 残差。写好但默认不跑（镜像体积原因，见 skipif）。"""
+    import asyncio
+
+    cavity = {
+        "system/controlDict": (
+            "FoamFile { version 2.0; format ascii; class dictionary; object controlDict; }\n"
+            "application icoFoam; startFrom startTime; startTime 0; stopAt endTime;\n"
+            "endTime 0.1; deltaT 0.005; writeControl timeStep; writeInterval 20;\n"
+        ),
+        "system/fvSchemes": (
+            "FoamFile { version 2.0; format ascii; class dictionary; object fvSchemes; }\n"
+            "ddtSchemes { default Euler; } gradSchemes { default Gauss linear; }\n"
+            "divSchemes { default none; div(phi,U) Gauss linear; }\n"
+            "laplacianSchemes { default Gauss linear orthogonal; }\n"
+            "interpolationSchemes { default linear; } snGradSchemes { default orthogonal; }\n"
+        ),
+        "system/fvSolution": (
+            "FoamFile { version 2.0; format ascii; class dictionary; object fvSolution; }\n"
+            "solvers { p { solver PCG; preconditioner DIC; tolerance 1e-06; relTol 0.05; }\n"
+            "  pFinal { $p; relTol 0; }\n"
+            "  U { solver smoothSolver; smoother symGaussSeidel; tolerance 1e-05; relTol 0; } }\n"
+            "PISO { nCorrectors 2; nNonOrthogonalCorrectors 0;\n"
+            "  pRefCell 0; pRefValue 0; }\n"
+        ),
+        "system/blockMeshDict": (
+            "FoamFile { version 2.0; format ascii; class dictionary; object blockMeshDict; }\n"
+            "scale 0.1;\n"
+            "vertices ( (0 0 0) (1 0 0) (1 1 0) (0 1 0)"
+            " (0 0 0.1) (1 0 0.1) (1 1 0.1) (0 1 0.1) );\n"
+            "blocks ( hex (0 1 2 3 4 5 6 7) (20 20 1) simpleGrading (1 1 1) );\n"
+            "boundary (\n"
+            "  movingWall { type wall; faces ( (3 7 6 2) ); }\n"
+            "  fixedWalls { type wall; faces ( (0 4 7 3) (2 6 5 1) (1 5 4 0) ); }\n"
+            "  frontAndBack { type empty; faces ( (0 3 2 1) (4 5 6 7) ); }\n"
+            ");\n"
+        ),
+        "0/p": (
+            "FoamFile { version 2.0; format ascii; class volScalarField; object p; }\n"
+            "dimensions [0 2 -2 0 0 0 0]; internalField uniform 0;\n"
+            "boundaryField { movingWall { type zeroGradient; }\n"
+            "  fixedWalls { type zeroGradient; } frontAndBack { type empty; } }\n"
+        ),
+        "0/U": (
+            "FoamFile { version 2.0; format ascii; class volVectorField; object U; }\n"
+            "dimensions [0 1 -1 0 0 0 0]; internalField uniform (0 0 0);\n"
+            "boundaryField { movingWall { type fixedValue; value uniform (1 0 0); }\n"
+            "  fixedWalls { type noSlip; } frontAndBack { type empty; } }\n"
+        ),
+        "constant/transportProperties": (
+            "FoamFile { version 2.0; format ascii; class dictionary;"
+            " object transportProperties; }\n"
+            "nu [0 2 -1 0 0 0 0] 0.01;\n"
+        ),
+    }
+    substrate = _substrate(tmp_path, prefix="polaris-openfoam")
+    plugin = OpenFOAMRunner(substrate=substrate)
+    plan = {"solver": "icoFoam", "files": cavity}
+    assert await plugin.validate(plan) == []
+    ctx = RunContext(plan=plan, files=cavity, substrate=substrate)
+    await plugin.prepare(ctx)
+    handle = await plugin.launch(ctx)
+    try:
+        for _ in range(300):
+            status = await plugin.poll(handle)
+            if status.state != "running":
+                break
+            await asyncio.sleep(2)
+        tail = substrate.tail("solver.log")
+        assert status.state == "succeeded", f"求解未成功：{status}；日志尾：{tail}"
+        bundle = await plugin.collect(ctx)
+        residuals = [p for p in bundle.metrics if p["name"].startswith("residual.")]
+        assert residuals, "求解器日志未解析出残差序列"
+    finally:
+        await plugin.cleanup(ctx)


### PR DESCRIPTION
Closes #681. Part of #674 (P3 wave 3, item R4); design report §14 tier 1 — the first non-ML backends, validating the materials contract and the result-file channel with zero license friction.

## Container substrate
One-shot local-docker batch form (`--rm`, random name, `--network none`, workdir-only mount — `side_effects=filesystem` made real). The `--rm`-vs-poll conflict is solved with the existing `run.exit` convention: the template appends the exit code to disk, `poll` inspects first and falls back to the file once the container is gone. Safety invariant enforced structurally: host argv goes through exec (no shell), the image name is regex-whitelisted (the only plan-supplied CLI field), in-container commands are module string constants, and material writes reuse the path-traversal guard.

## Backends
- **ngspice**: netlist materials contract (first-line-title and `.end` checks), `ngspice -b` template, collect parses `.meas`/`.op` scalars from the log plus `wrdata` output tables declared in the netlist (paired-column layout, downsampling beyond 2k points). NaN becomes a flagged point, never dropped — divergence is signal. Default image left as a documented build recipe rather than trusting an unofficial personal image
- **openfoam**: case-directory contract (`system/` trio, `0/`, `constant/`), solver strictly from a whitelist with the template pre-generated per solver — the plan can only pick a key, never splice a string; `blockMesh` runs when a dict is present; collect extracts per-field residual series from the solver log and parses `postProcessing/` tables
- both register with manifests declaring resource needs; lease wiring at prepare is a documented TODO until the action layer flips to v2 dispatch

## Real smoke (ngspice, local docker)
RC circuit transient through the full v2 lifecycle: succeeded/exit 0 in 0.19s, `vmax = 4.908471` against the theoretical 5·(1−e⁻⁴) = 4.908 V, 529-point series in the metric channel, log + data table registered as result files. The openfoam smoke (icoFoam lid-driven cavity) ships behind a double gate (marker + env) — the image is GB-scale.

Verification: clean baseline 1620 passed / 3 pre-existing failures; branch 1638 passed / same 3 / 2 deselected (the integration markers, excluded by default addopts) — zero new, +18 exactly the new unit tests; goldens untouched; no frontend changes.