### PR TITLE
feat: BYO runner tier 1 with agent version pinning

### DIFF
--- a/docs/byo-runner.md
+++ b/docs/byo-runner.md
@@ -1,0 +1,117 @@
+# BYO Runner（自带执行机）
+
+> Part of the P3 autonomous-experiments track (#674 · #685). Design source:
+> [Polaris 2.0 design report §15](rfcs/2026-09-02-polaris-2.0-design-report.zh.md).
+
+Polaris 把「在哪跑实验」交给用户：实验室 GPU 机、云主机、家里的工作站，
+只要能连上就能当 runner。接入分两档：
+
+| Tier | 接入方式 | 状态 |
+| --- | --- | --- |
+| 1 | SSH 可达（平台主动连出去） | **已实现**（本页上半部分） |
+| 2 | 出站 WebSocket agent（机器主动连回来，适合 NAT/内网机） | **未实现**，协议草案见下 |
+
+## Tier 1：SSH 直连（已实现）
+
+### 使用步骤
+
+1. **录入 SSH 凭据**：设置页添加主机地址 + 用户名 + 私钥
+   （`POST /api/ssh-credentials`，私钥 Fernet 加密入库，绝不回传、不进日志）。
+2. **注册 runner 主机**（可选但推荐）：`POST /api/resources/runner-hosts`
+   `{"name": "lab-a100", "credential_id": "…"}` —— 生成一个 `host` 类 Resource，
+   进入资源/租约体系：同一台机器默认互斥（同一时刻一个实验），可 PATCH 调整
+   容量与并发语义。
+3. **创建实验**：`POST /projects/{id}/experiments` 时二选一——
+   传 `resource_id` 指定跑在哪台注册机器上，或按老路径直接传 `credential_id`。
+
+### Runner agent 版本钉定
+
+学 VS Code Remote-SSH：用户只给地址，安装/升级全自动。每次建立 SSH 连接时，
+平台比对远端 `~/.polaris-runner/VERSION` 与当前 `AGENT_VERSION`
+（`app/services/byo_runner.py`）：
+
+- 首连（无版本文件）→ 自动推送 agent 载荷（一组远端辅助脚本：环境探测
+  `probe.sh`、工作区管理 `workdir.sh`、`run.exit` 退出码约定 `run-status.sh`）；
+- 版本一致 → 一条 `cat` 即跳过；
+- 版本过期 → 整包重推（VERSION 最后原子写入，中断不会留下半新半旧状态）。
+
+推送失败不阻塞实验执行（agent 目前是辅助契约，执行路径仍走固定模板命令）。
+
+### Ephemeral 执行（默认推荐）
+
+GitHub self-hosted runner 的教训：非 ephemeral 环境的残留物会变成后门。因此：
+
+- **容器化路径（推荐，ephemeral 方向）**：实验计划声明 `plan.container`
+  （镜像/GPU/挂载白名单校验）后在 docker 容器内执行，主机侧只落 bind 挂载的
+  工作目录。注册 runner 主机时 `ephemeral` 默认 `true` 即指向此路径。
+- **裸机路径（non-ephemeral，显式保留）**：不声明 container 时在主机 venv 直跑，
+  产物与虚拟环境留在 `~/polaris_runs/<exp_id>`（复查产物依赖这一点）。
+  注册时显式传 `"ephemeral": false` 表示接受该语义。
+
+默认值只影响新注册的主机；已有实验与 run 的行为不变。
+
+### 凭据吊销
+
+删除凭据（`DELETE /api/ssh-credentials/{id}` 或
+`DELETE /api/connection-credentials/{id}`）即吊销：
+
+- 仍有未终态实验引用该凭据 → **409 `CREDENTIAL_IN_USE`**（不做级联取消：
+  替用户杀正在跑的实验副作用太大，先处置活跃实验再吊销）；
+- 吊销成功后，关联的 `host` Resource 标记 `config.unavailable=true`
+  （资源与租约历史保留，换绑新凭据即可恢复）。
+
+### 密钥安全边界
+
+- 私钥/口令 Fernet 加密入库，任何 API 响应不含密钥字段；
+- 解密后的私钥只进 asyncssh 连接参数，不进日志、不进 Activity、不进异常文本
+  （连接失败的 detail 会先过 `scrub_secrets` 抹除，测试钉住该行为）。
+
+## Tier 2：出站 WebSocket agent（未实现，协议草案）
+
+> Not implemented. 本节是设计笔记，落地前以此为讨论基线；实现时另立 RFC。
+
+场景：内网/NAT 后的机器，平台连不进去。方案学 GitHub self-hosted runner：
+机器上跑一个常驻 agent，**出站**长连接拉任务，永不要求开入站端口；
+复杂 NAT 场景文档化 Tailscale，不自研穿透。
+
+### 注册（短时效 token）
+
+```
+POST /api/resources/runner-hosts/registration-token   （用户，Web 端）
+  → {"token": "prt_…", "expires_in": 3600}            （一次性、短命）
+
+$ polaris-runner register --url https://polaris.example --token prt_…
+```
+
+agent 用 token 换取长期凭据（仅限该机器身份），token 立即作废。注册成功 =
+服务端自动创建 `host` 类 Resource（与 tier-1 同一张表，租约语义共用），
+`config.transport = "websocket"`。
+
+### 任务拉取（出站 WS 长连接）
+
+```
+agent → wss://polaris.example/api/runner-agent/ws     （Authorization: 机器凭据）
+  ← {"kind": "hello", "agent_version": "…"}            agent 自述版本/硬件（probe 结果）
+  → {"kind": "upgrade", "payload_url": …}              版本过期时先升级（同 tier-1 钉定语义）
+  → {"kind": "task", "run_id": …, "spec": {…}}         派发：流程包 + 物料 + container spec
+  ← {"kind": "ack", "run_id": …}
+```
+
+- 派发以 run 为单位（voyage run 整体交给 runner，携带组件清单）；
+- 无任务时心跳保活；断线重连后按 run_id 对账续传（桌面/服务端离线不炸 run）。
+
+### 事件回传
+
+```
+  ← {"kind": "event", "run_id": …, "seq": N, "event": {…}}   日志/指标/状态，seq 单调
+  ← {"kind": "artifact", "run_id": …, "name": …}             产物分块上传
+  → {"kind": "ack_event", "run_id": …, "seq": N}             服务端确认位点
+```
+
+seq + ack 位点保证断线重连后从确认点续传，不丢不重。
+
+### Ephemeral 承诺
+
+tier-2 的任务**一律**容器内执行（tier-1 的裸机路径不下放）：agent 收到任务后
+`docker run` 一次性容器，结束即销毁，工作区产物先回传再删除。机器凭据可随时
+吊销（同 tier-1 语义），吊销后 WS 连接被服务端主动断开、Resource 标记不可用。

--- a/src/backend/app/agents/voyage/runner.py
+++ b/src/backend/app/agents/voyage/runner.py
@@ -116,6 +116,9 @@ class Runner(Protocol):
 
 
 # 现有实现：在 SSH 主机上跑裸机 venv 环境（即目前的全部行为）。
+# ⚠ non-ephemeral（#685）：裸机直跑会在主机留下 venv/产物/进程痕迹。BYO runner
+# 语义下**推荐默认走容器化路径**（ContainerRunner，任务结束不残留）；裸机路径
+# 保留给「用户明确接受残留」的场景（复查产物本就依赖 workdir 留存）。
 RemoteHostRunner = SSHExecutor
 
 
@@ -179,7 +182,13 @@ def parse_container_spec(data: Any) -> ContainerSpec | None:
 
 
 class ContainerRunner(SSHExecutor):
-    """在 SSH 主机的 docker 容器里跑实验。文件原语继承（host 侧），执行原语包一层 docker exec。"""
+    """在 SSH 主机的 docker 容器里跑实验。文件原语继承（host 侧），执行原语包一层 docker exec。
+
+    BYO runner（#685）语境下这是**默认推荐**的执行形态（ephemeral 方向）：执行环境
+    整体在容器里，主机侧只落 bind 挂载的 workdir。注册 runner 主机时
+    config.ephemeral 默认 true 即指向此路径；分派开关本身仍是 plan.container
+    （不改现有 run 行为，默认值只影响新注册的主机）。
+    """
 
     CONTAINER_START_TIMEOUT = 600.0  # docker run（镜像已预拉时很快；给足冗余）
 

--- a/src/backend/app/api/experiments.py
+++ b/src/backend/app/api/experiments.py
@@ -171,6 +171,11 @@ async def create_experiment(
         raise HTTPException(status.HTTP_409_CONFLICT, detail="IDEA_NOT_PROMOTED") from e
     except experiments_service.CredentialNotFoundError as e:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="CREDENTIAL_NOT_FOUND") from e
+    except experiments_service.RunnerHostNotFoundError as e:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="RESOURCE_NOT_FOUND") from e
+    except experiments_service.RunnerHostUnavailableError as e:
+        # 凭据被吊销/资源没绑凭据：请求本身合法但资源当前用不了 → 409
+        raise HTTPException(status.HTTP_409_CONFLICT, detail="RESOURCE_UNAVAILABLE") from e
     await queue.enqueue("run_voyage", str(voyage.id))
     return experiments_service.to_read(experiment, idea_title)
 

--- a/src/backend/app/api/resources.py
+++ b/src/backend/app/api/resources.py
@@ -21,7 +21,9 @@ from app.schemas.resource import (
     ResourceCreate,
     ResourceRead,
     ResourceUpdate,
+    RunnerHostRegister,
 )
+from app.services import byo_runner as byo_runner_service
 from app.services import resources as resources_service
 
 router = APIRouter(prefix="/resources", tags=["resources"])
@@ -70,6 +72,31 @@ async def create_resource(
         resource = await resources_service.create_resource(session, owner_id=user.id, data=data)
     except resources_service.ResourceConfigError as exc:
         raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)) from exc
+    return ResourceRead.model_validate(resource)
+
+
+@router.post("/runner-hosts", response_model=ResourceRead, status_code=status.HTTP_201_CREATED)
+async def register_runner_host(
+    data: RunnerHostRegister,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> ResourceRead:
+    """注册 BYO runner 主机（#685）：host 类 Resource + SSH 凭据关联，
+    config.ephemeral 默认 true（推荐容器化执行不残留）。"""
+    merged = dict(data.config or {})
+    merged["ephemeral"] = data.ephemeral
+    try:
+        resource = await byo_runner_service.register_runner_host(
+            session,
+            owner_id=user.id,
+            name=data.name,
+            credential_id=data.credential_id,
+            config=merged,
+        )
+    except byo_runner_service.RunnerHostCredentialError as e:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="CREDENTIAL_NOT_FOUND") from e
+    except byo_runner_service.RunnerHostKindError as e:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e)) from e
     return ResourceRead.model_validate(resource)
 
 
@@ -152,4 +179,8 @@ async def delete_credential(
     )
     if credential is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="CREDENTIAL_NOT_FOUND")
-    await resources_service.delete_connection_credential(session, credential)
+    # 删除 = 吊销（#685）：有未终态实验引用 → 409；host 资源联动标记不可用
+    try:
+        await byo_runner_service.revoke_connection_credential(session, credential)
+    except byo_runner_service.CredentialInUseError as e:
+        raise HTTPException(status.HTTP_409_CONFLICT, detail="CREDENTIAL_IN_USE") from e

--- a/src/backend/app/api/ssh_credentials.py
+++ b/src/backend/app/api/ssh_credentials.py
@@ -14,6 +14,7 @@ from app.core.db import get_session
 from app.models.ssh_credential import SSHCredential
 from app.models.user import User
 from app.schemas.ssh_credential import SSHCredentialCreate, SSHCredentialRead, SSHTestResult
+from app.services import byo_runner as byo_runner_service
 from app.services import ssh_credentials as credentials_service
 from app.services import ssh_exec
 
@@ -54,8 +55,12 @@ async def delete_credential(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> None:
+    """删除 = 吊销（#685）：有未终态实验引用 → 409；host 资源联动标记不可用。"""
     credential = await _get_owned(session, credential_id, user)
-    await credentials_service.delete_credential(session, credential)
+    try:
+        await byo_runner_service.revoke_connection_credential(session, credential)
+    except byo_runner_service.CredentialInUseError as e:
+        raise HTTPException(status.HTTP_409_CONFLICT, detail="CREDENTIAL_IN_USE") from e
 
 
 @router.post("/{credential_id}/test", response_model=SSHTestResult)

--- a/src/backend/app/schemas/experiment.py
+++ b/src/backend/app/schemas/experiment.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class ExperimentBudget(BaseModel):
@@ -88,8 +88,18 @@ class ExperimentIntakeRequest(BaseModel):
 
 class ExperimentCreate(BaseModel):
     idea_id: uuid.UUID
-    credential_id: uuid.UUID
+    # 二选一（至少给一个）：resource_id 指定跑在哪台已注册的 runner 主机上
+    # （#685，凭据从资源上取）；不给则按老路径直接给 credential_id——存量前端
+    # 只传 credential_id，行为零变化。
+    credential_id: uuid.UUID | None = None
+    resource_id: uuid.UUID | None = None
     params: ExperimentParams | None = None
+
+    @model_validator(mode="after")
+    def _one_of_credential_or_resource(self) -> "ExperimentCreate":
+        if self.credential_id is None and self.resource_id is None:
+            raise ValueError("either credential_id or resource_id is required")
+        return self
 
 
 class ExperimentRead(BaseModel):

--- a/src/backend/app/schemas/resource.py
+++ b/src/backend/app/schemas/resource.py
@@ -45,6 +45,19 @@ class ResourceRead(BaseModel):
     updated_at: datetime
 
 
+class RunnerHostRegister(BaseModel):
+    """注册 BYO runner 主机（#685）：一台机器 = host 类 Resource + SSH 凭据关联。
+
+    ephemeral 默认 True = 推荐容器化执行不残留；显式 False = 接受裸机直跑
+    （non-ephemeral，产物留在主机）。只影响新注册的主机。"""
+
+    name: str = Field(min_length=1, max_length=255)
+    credential_id: uuid.UUID
+    ephemeral: bool = True
+    # 其余非敏感配置（workdir/gpus 等，语义见 app/models/resource.py）
+    config: dict[str, Any] | None = None
+
+
 class ConnectionCredentialCreate(BaseModel):
     """通用凭据创建（各 kind 载荷约定见 app/models/ssh_credential.py docstring）。
 

--- a/src/backend/app/services/byo_runner.py
+++ b/src/backend/app/services/byo_runner.py
@@ -1,0 +1,241 @@
+"""BYO runner tier-1（#685，设计报告 §15）：SSH 主机的形式化接入。
+
+三件事（不 import fastapi）：
+
+1. **runner agent 版本钉定**（学 VS Code Remote-SSH：用户只给地址，安装/升级自动）。
+   ``ensure_agent`` 首连比对远端 ``~/.polaris-runner/VERSION``，不符则推送 agent 载荷。
+   现状取舍：仓库里原本**没有**独立的 agent 推送逻辑——远端辅助命令散落在
+   ssh_exec 的固定模板里（探测/workdir/run.exit 约定各一摊）。本 PR 把这些约定
+   收敛成一小组远端脚本作为 agent 载荷推上去并钉版本；**执行路径本期不切换**
+   （固定模板命令继续直跑，行为零变化），脚本先作为版本化的远端契约落位，
+   tier-2 的常驻 agent 与后续「命令走脚本」的收敛都在这个目录上迭代。
+
+2. **runner 主机注册**：注册一台 runner 机器 = 建一个 host 类 Resource（#680），
+   credential_id 关联 SSH 凭据——租约互斥/容量计数天然生效。新建主机默认
+   ``config.ephemeral=true``（容器化执行不残留，GitHub runner 事故教训）；
+   只影响新建，存量资源与现有 run 行为不动。
+
+3. **凭据吊销联动**：删除 connection_credential 前先查活跃引用——有未终态实验
+   引用则拒绝（API 层转 409）。选 409 而非级联 cancel：吊销是安全操作，但替用户
+   杀正在跑的实验副作用太大，让用户先自己处置活跃 run 再吊销，语义最保守。
+   吊销时对应 host Resource 标记不可用（config.unavailable，不删资源——
+   租约历史与配置留着，换绑新凭据即可复活）。
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Protocol
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.experiment import EXPERIMENT_TERMINAL_STATUSES, Experiment
+from app.models.resource import Resource
+from app.models.ssh_credential import ConnectionCredential
+
+logger = logging.getLogger("polaris.byo_runner")
+
+# ---------------------------------------------------------------------------
+# Agent 版本钉定
+# ---------------------------------------------------------------------------
+
+# agent 载荷版本：脚本内容变了就 +1（远端按整包重推，不做逐文件 diff——载荷极小，
+# 整包幂等重推比精细比对更不容易出「半新半旧」状态）。
+AGENT_VERSION = "1"
+AGENT_DIR_SHELL = "~/.polaris-runner"  # shell 命令用（~ 由远端展开）
+AGENT_DIR_SFTP = ".polaris-runner"  # SFTP 相对 home 目录
+_VERSION_PATH = f"{AGENT_DIR_SHELL}/VERSION"
+_CMD_TIMEOUT = 60.0
+
+# agent 载荷 = 一组远端辅助脚本：把 ssh_exec 散落固定模板里的三类约定
+# （环境探测 / workdir 管理 / run.exit 落盘约定）收敛成可版本化的脚本。
+# 内容全部是固定文本（无任何运行期拼接），不构成新的注入面。
+AGENT_SCRIPTS: dict[str, str] = {
+    # 环境探测：与 ssh_exec.probe_sysinfo 的四条探测命令同源（CPU/内存/磁盘/GPU），
+    # 单脚本一次拿全，供 tier-2 agent 注册时自述硬件、也供人肉登录排查。
+    "probe.sh": (
+        "#!/usr/bin/env bash\n"
+        "# polaris-runner agent: environment probe (fixed template, no arguments)\n"
+        "echo '== cpu =='\n"
+        "nproc 2>/dev/null; cat /proc/loadavg 2>/dev/null\n"
+        "echo '== mem =='\n"
+        "LC_ALL=C free -m 2>/dev/null\n"
+        "echo '== disk =='\n"
+        "LC_ALL=C df -PB1M -x tmpfs -x devtmpfs -x overlay -x squashfs 2>/dev/null"
+        " | tail -n +2\n"
+        "echo '== gpu =='\n"
+        "nvidia-smi --query-gpu=index,memory.total,memory.free"
+        " --format=csv,noheader,nounits 2>/dev/null || true\n"
+    ),
+    # workdir 管理：实验工作区固定在 ~/polaris_runs/<uuid>；参数强校验 UUID 前缀，
+    # 与 ssh_exec.validate_exp_id 的白名单口径一致。
+    "workdir.sh": (
+        "#!/usr/bin/env bash\n"
+        "# polaris-runner agent: workdir management under ~/polaris_runs\n"
+        "# usage: workdir.sh ensure|clean <experiment-uuid>\n"
+        "set -e\n"
+        "action=$1; exp=$2\n"
+        "case $exp in\n"
+        "  [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]-*) ;;\n"
+        "  *) echo 'invalid experiment id' >&2; exit 64;;\n"
+        "esac\n"
+        "case $action in\n"
+        "  ensure) mkdir -p ~/polaris_runs/$exp;;\n"
+        "  clean) rm -rf ~/polaris_runs/$exp;;\n"
+        "  *) echo 'unknown action' >&2; exit 64;;\n"
+        "esac\n"
+    ),
+    # run.exit 约定：入口命令的退出码落 <workdir>/run.exit（依赖安装同理 setup.exit），
+    # 轮询端只认这两个文件——脚本把该约定固化下来供 tier-2 复用。
+    "run-status.sh": (
+        "#!/usr/bin/env bash\n"
+        "# polaris-runner agent: read the run.exit/setup.exit convention\n"
+        "# usage: run-status.sh <experiment-uuid> [run|setup]\n"
+        "exp=$1; kind=${2:-run}\n"
+        "case $kind in run|setup) ;; *) echo 'unknown kind' >&2; exit 64;; esac\n"
+        "cat ~/polaris_runs/$exp/$kind.exit 2>/dev/null\n"
+    ),
+}
+
+
+class _SSHSessionLike(Protocol):
+    """ensure_agent 只需要「跑命令 + SFTP 写文件」两个原语（避免反向 import ssh_exec）。"""
+
+    async def run(self, command: str, timeout: float | None = None): ...
+
+    async def write_file(self, path: str, content: str) -> None: ...
+
+
+async def ensure_agent(session: _SSHSessionLike) -> bool:
+    """远端 agent 就位保证：VERSION 一致则跳过；缺失/过期则整包重推。
+
+    返回是否发生了推送。首连（无 VERSION 文件）自动装；后续连接一条 ``cat``
+    比对即返回，代价可忽略。VERSION 最后写（tmp+mv 原子落盘）：推送中途断连
+    只会留下无版本号的半成品，下次连接必然重推，不会出现「版本号新、脚本旧」。
+    """
+    probe = await session.run(f"cat {_VERSION_PATH} 2>/dev/null", timeout=_CMD_TIMEOUT)
+    lines = (probe.stdout or "").strip().splitlines()
+    if probe.exit_status == 0 and lines and lines[-1].strip() == AGENT_VERSION:
+        return False
+    await session.run(f"mkdir -p {AGENT_DIR_SHELL}/agent", timeout=_CMD_TIMEOUT)
+    for name, content in AGENT_SCRIPTS.items():
+        await session.write_file(f"{AGENT_DIR_SFTP}/agent/{name}", content)
+    await session.run(f"chmod 700 {AGENT_DIR_SHELL}/agent/*.sh", timeout=_CMD_TIMEOUT)
+    await session.run(
+        f"printf '%s\\n' {AGENT_VERSION} > {_VERSION_PATH}.tmp"
+        f" && mv {_VERSION_PATH}.tmp {_VERSION_PATH}",
+        timeout=_CMD_TIMEOUT,
+    )
+    logger.info("byo_runner.agent pushed version=%s", AGENT_VERSION)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# runner 主机注册（host 类 Resource）
+# ---------------------------------------------------------------------------
+
+
+class RunnerHostCredentialError(Exception):
+    """凭据不存在/不属于该用户（API 层转 404，不泄露存在性）。"""
+
+
+class RunnerHostKindError(Exception):
+    """凭据 kind 不是 ssh（tier-1 只吃 SSH 直连；API 层转 422）。"""
+
+
+async def register_runner_host(
+    session: AsyncSession,
+    *,
+    owner_id: uuid.UUID,
+    name: str,
+    credential_id: uuid.UUID,
+    config: dict | None = None,
+) -> Resource:
+    """注册一台 BYO runner 机器 = 建 host 类 Resource 并关联 SSH 凭据。
+
+    - 默认 exclusive=True：一台裸机同一时刻只跑一个实验（租约互斥，#680）；
+      要并发席位的用户走 PATCH /resources 调 capacity/exclusive；
+    - config.ephemeral 默认 True = 推荐容器化执行不残留（plan.container 路径）；
+      显式传 False 表示接受裸机 venv 直跑（non-ephemeral，产物留在主机上）。
+      该默认值只作用于新注册的主机，不改任何现有 run 的行为。
+    """
+    credential = await session.get(ConnectionCredential, credential_id)
+    if credential is None or credential.user_id != owner_id:
+        raise RunnerHostCredentialError(str(credential_id))
+    if credential.kind != "ssh":
+        raise RunnerHostKindError(
+            f"runner host requires an ssh credential, got kind={credential.kind!r}"
+        )
+    merged: dict = {"ephemeral": True}
+    merged.update(config or {})
+    resource = Resource(
+        owner_id=owner_id,
+        name=name,
+        kind="host",
+        capacity=1,
+        exclusive=True,
+        credential_id=credential.id,
+        config=merged,
+    )
+    session.add(resource)
+    await session.commit()
+    await session.refresh(resource)
+    return resource
+
+
+# ---------------------------------------------------------------------------
+# 凭据吊销联动
+# ---------------------------------------------------------------------------
+
+
+class CredentialInUseError(Exception):
+    """有未终态实验仍引用该凭据（API 层转 409）。"""
+
+    def __init__(self, active_count: int) -> None:
+        self.active_count = active_count
+        super().__init__(f"credential referenced by {active_count} active experiment(s)")
+
+
+async def revoke_connection_credential(
+    session: AsyncSession, credential: ConnectionCredential
+) -> None:
+    """吊销（删除）连接凭据：活跃引用拒绝，host Resource 联动标记不可用。
+
+    为什么 409 而非级联 cancel：见模块 docstring。资源上显式清 credential_id
+    而不只靠 FK 的 SET NULL——sqlite（dev/测试）默认不开外键级联，显式写一遍
+    两种库行为才一致。
+    """
+    active = (
+        await session.execute(
+            select(func.count())
+            .select_from(Experiment)
+            .where(
+                Experiment.credential_id == credential.id,
+                Experiment.status.notin_(EXPERIMENT_TERMINAL_STATUSES),
+            )
+        )
+    ).scalar_one()
+    if int(active):
+        raise CredentialInUseError(int(active))
+
+    resources = (
+        (await session.execute(select(Resource).where(Resource.credential_id == credential.id)))
+        .scalars()
+        .all()
+    )
+    for resource in resources:
+        merged = dict(resource.config or {})
+        merged["unavailable"] = True
+        merged["unavailable_reason"] = "credential_revoked"
+        resource.config = merged
+        resource.credential_id = None
+    if resources:
+        logger.info(
+            "byo_runner.credential_revoked credential=%s resources_marked=%d",
+            credential.id,
+            len(resources),
+        )
+    await session.delete(credential)
+    await session.commit()

--- a/src/backend/app/services/experiments.py
+++ b/src/backend/app/services/experiments.py
@@ -27,6 +27,7 @@ from app.models.experiment import (
 )
 from app.models.idea import Idea
 from app.models.project import Project
+from app.models.resource import Resource
 from app.models.ssh_credential import SSHCredential
 from app.models.voyage import TERMINAL_STATUSES, VoyageRun
 from app.schemas.experiment import (
@@ -56,6 +57,14 @@ class IdeaNotPromotedError(Exception):
 
 class CredentialNotFoundError(Exception):
     """SSH 凭据不存在或不属于当前用户。"""
+
+
+class RunnerHostNotFoundError(Exception):
+    """指定的 runner 主机资源不存在/不属于当前用户/不是 host 类（#685）。"""
+
+
+class RunnerHostUnavailableError(Exception):
+    """runner 主机不可用：凭据已吊销（config.unavailable）或未关联凭据（#685）。"""
 
 
 class ExperimentAlreadyFinishedError(Exception):
@@ -151,11 +160,22 @@ async def create_experiment(
         raise IdeaNotFoundError(str(data.idea_id))
     if idea.status != "promoted":
         raise IdeaNotPromotedError(str(idea.id))
-    credential = await session.get(SSHCredential, data.credential_id)
+    # 执行目标二选一（#685）：resource_id 指定已注册的 runner 主机（凭据从资源上取，
+    # 顺带吃到租约/吊销联动那套语义）；不给则按老路径直接用 credential_id——
+    # 存量前端只传 credential_id，行为零变化。
+    credential_id = data.credential_id
+    if data.resource_id is not None:
+        resource = await session.get(Resource, data.resource_id)
+        if resource is None or resource.owner_id != user_id or resource.kind != "host":
+            raise RunnerHostNotFoundError(str(data.resource_id))
+        if (resource.config or {}).get("unavailable") or resource.credential_id is None:
+            raise RunnerHostUnavailableError(str(data.resource_id))
+        credential_id = resource.credential_id
+    credential = await session.get(SSHCredential, credential_id)
     # kind 校验（#677 凭据多态化后）：实验直跑只吃 ssh 凭据，别的 kind 私钥列为空，
     # 放进来会在 ssh_exec 解密时炸得不知所云——这里当不存在处理
     if credential is None or credential.user_id != user_id or credential.kind != "ssh":
-        raise CredentialNotFoundError(str(data.credential_id))
+        raise CredentialNotFoundError(str(credential_id))
 
     params = data.params
     budget = dict(DEFAULT_BUDGET)
@@ -199,6 +219,9 @@ async def create_experiment(
                 "backend": params.backend if params else "python-ml",
                 # 流程包（#678）：非空时 navigator 按包生成计划；None = 原路径
                 "process_pack": params.process_pack if params else None,
+                # runner 主机资源（#685）：非空 = 用户指定跑在哪台注册机器上；
+                # 现阶段只作记录（租约获取由 R2 的 prepare 阶段接管时消费）
+                "resource_id": str(data.resource_id) if data.resource_id else None,
             }
         },
         budget=None,

--- a/src/backend/app/services/resources.py
+++ b/src/backend/app/services/resources.py
@@ -168,8 +168,4 @@ async def list_connection_credentials(
     return (await session.execute(stmt)).scalars().all()
 
 
-async def delete_connection_credential(
-    session: AsyncSession, credential: ConnectionCredential
-) -> None:
-    await session.delete(credential)
-    await session.commit()
+# 删除已升级为「吊销」语义（#685）：见 app/services/byo_runner.revoke_connection_credential。

--- a/src/backend/app/services/ssh_credentials.py
+++ b/src/backend/app/services/ssh_credentials.py
@@ -50,9 +50,8 @@ async def get_owned_credential(
     return credential
 
 
-async def delete_credential(session: AsyncSession, credential: SSHCredential) -> None:
-    await session.delete(credential)
-    await session.commit()
+# 删除已升级为「吊销」语义（#685）：活跃引用拒绝 + host 资源联动标记不可用，
+# 统一走 app/services/byo_runner.revoke_connection_credential，此处不再留裸删。
 
 
 async def mark_verified(session: AsyncSession, credential: SSHCredential) -> SSHCredential:

--- a/src/backend/app/services/ssh_exec.py
+++ b/src/backend/app/services/ssh_exec.py
@@ -65,6 +65,22 @@ class SSHPathViolationError(SSHExecError):
     """路径越界：目标不在 ~/polaris_runs/<exp_id> 之下。"""
 
 
+def scrub_secrets(text: str, *secrets: str | None) -> str:
+    """把密钥/口令内容从要出 API 或进日志的文本里抹掉（#685 密钥不出库审计）。
+
+    解密后的私钥只该进 asyncssh 的连接参数；但连接失败时我们会把异常文本转成
+    detail 返回给前端——底层库异常**理论上**可能携带输入片段，这里按行扫一遍
+    兜底（整段 replace 不够：异常可能只嵌了 PEM 的某一行）。"""
+    for secret in secrets:
+        if not secret:
+            continue
+        for line in secret.splitlines():
+            line = line.strip()
+            if len(line) > 4 and line in text:
+                text = text.replace(line, "[REDACTED]")
+    return text
+
+
 def is_connection_error(exc: BaseException) -> bool:
     """判定异常是否为「SSH 连接/通道断开」这类可重连的瞬时故障。
 
@@ -269,6 +285,15 @@ async def open_executor(
         private_key=private_key,
         passphrase=passphrase,
     )
+    # BYO runner tier-1（#685）：连上后保证远端 agent 载荷就位（首连推送、
+    # 后续一条 cat 比对即跳过）。推送失败不拦执行——现网行为在没有 agent 的
+    # 年代就成立，agent 缺位只损失辅助脚本，不该让实验连坐。
+    try:
+        from app.services.byo_runner import ensure_agent
+
+        await ensure_agent(session)
+    except Exception:  # noqa: BLE001 — 尽力而为，失败只记日志
+        logger.warning("byo agent push failed host=%s (continuing)", credential.host)
     return SSHExecutor(
         session,
         exp_id=exp_id,
@@ -280,6 +305,7 @@ async def open_executor(
 
 async def test_credential(credential: SSHCredential) -> tuple[bool, str]:
     """凭据连通性验证：连接 + ``echo ok``（固定模板）。返回 (ok, detail)。"""
+    private_key = passphrase = None  # except 分支要引用，先落空值
     try:
         private_key = decrypt_secret(credential.private_key_encrypted)
         passphrase = (
@@ -295,14 +321,15 @@ async def test_credential(credential: SSHCredential) -> tuple[bool, str]:
             passphrase=passphrase,
         )
     except Exception as e:  # noqa: BLE001 — 连接失败要转成 {ok: false} 而非 500
-        return False, f"{type(e).__name__}: {e}"
+        # detail 会出 API：异常文本过一遍密钥抹除（#685 审计）
+        return False, scrub_secrets(f"{type(e).__name__}: {e}", private_key, passphrase)
     try:
         result = await session.run("echo ok", timeout=DEFAULT_CMD_TIMEOUT_SECONDS)
         if result.exit_status == 0 and "ok" in result.stdout:
             return True, "ok"
         return False, f"echo 测试失败：exit={result.exit_status} stderr={result.stderr[:200]}"
     except Exception as e:  # noqa: BLE001
-        return False, f"{type(e).__name__}: {e}"
+        return False, scrub_secrets(f"{type(e).__name__}: {e}", private_key, passphrase)
     finally:
         await session.close()
 
@@ -372,6 +399,7 @@ async def probe_sysinfo(credential: SSHCredential) -> dict[str, Any]:
     固定模板命令 + 容错解析（确定性探测，非 LLM）；连接失败 → {ok: False, detail}；
     单项探测失败该项缺省（尽力而为，不因一项失败整体报错）。
     """
+    private_key = passphrase = None  # except 分支要引用，先落空值
     try:
         private_key = decrypt_secret(credential.private_key_encrypted)
         passphrase = (
@@ -387,7 +415,9 @@ async def probe_sysinfo(credential: SSHCredential) -> dict[str, Any]:
             passphrase=passphrase,
         )
     except Exception as e:  # noqa: BLE001 — 连接失败转 {ok: false} 而非 500
-        return {"ok": False, "detail": f"{type(e).__name__}: {e}"}
+        # detail 会出 API：异常文本过一遍密钥抹除（#685 审计）
+        detail = scrub_secrets(f"{type(e).__name__}: {e}", private_key, passphrase)
+        return {"ok": False, "detail": detail}
     info: dict[str, Any] = {"ok": True, "host": credential.host}
     probes = (
         ("cpu", "nproc 2>/dev/null; cat /proc/loadavg 2>/dev/null", parse_loadavg_block),

--- a/src/backend/tests/fake_ssh.py
+++ b/src/backend/tests/fake_ssh.py
@@ -129,6 +129,14 @@ class FakeSSHSession:
             if exit_status is not None:
                 server.managed_files[f"{prefix}.exit"] = str(exit_status)
             return SSHResult(0, f"{pid}\n", "")
+        # BYO agent（#685）：VERSION 原子落盘（printf tmp && mv）。存进 host_files，
+        # 与读取端 `cat ~/.polaris-runner/VERSION` 的分支（下方通用 cat host_files）对齐，
+        # 这样「首连推送、后连比对跳过」在 fake 上可观测。
+        if command.startswith("printf") and ".polaris-runner/VERSION" in command:
+            m = re.search(r"printf '%s\\n' (\S+) >", command)
+            if m:
+                server.host_files["~/.polaris-runner/VERSION"] = m.group(1) + "\n"
+            return SSHResult(0, "", "")
         if command.startswith("printf ") and "/operations/" in command and "/current" in command:
             match = re.search(
                 r"printf '%s\\n' ([0-9a-f-]+) > (\S+)\.tmp && mv \S+ (\S+)", command

--- a/src/backend/tests/test_byo_runner.py
+++ b/src/backend/tests/test_byo_runner.py
@@ -1,0 +1,348 @@
+"""BYO runner tier-1（#685）：agent 版本钉定 / 主机注册与租约 / 凭据吊销 / 密钥不出库。"""
+
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.core.security import encrypt_secret
+from app.models.experiment import Experiment
+from app.models.idea import Idea
+from app.models.resource import Resource
+from app.models.ssh_credential import SSHCredential
+from app.models.voyage import VoyageRun
+from app.services import byo_runner, resource_leases, ssh_exec
+from tests.conftest import register_and_login
+from tests.fake_ssh import FakeSSHConnector, FakeSSHServer, FakeSSHSession
+from tests.test_ssh_credentials import PAYLOAD as CRED_PAYLOAD
+
+FAKE_PEM = CRED_PAYLOAD["private_key"]
+
+
+@pytest_asyncio.fixture
+async def fake_ssh(app):
+    server = FakeSSHServer()
+    ssh_exec.set_connector_factory(lambda: FakeSSHConnector(server))
+    yield server
+    ssh_exec.set_connector_factory(None)
+
+
+async def _auth(client, email="alice@example.com"):
+    token = await register_and_login(client, email)
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _create_credential(client, headers) -> str:
+    resp = await client.post("/api/ssh-credentials", json=CRED_PAYLOAD, headers=headers)
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+def _agent_file_count(server: FakeSSHServer) -> int:
+    return sum(1 for path in server.files if path.startswith(".polaris-runner/"))
+
+
+# ---- agent 版本钉定 ----
+
+
+async def test_ensure_agent_pushes_then_skips(app):
+    server = FakeSSHServer()
+    session = FakeSSHSession(server)
+
+    # 首连：无 VERSION → 整包推送（脚本 + 版本号）
+    assert await byo_runner.ensure_agent(session) is True
+    for name in byo_runner.AGENT_SCRIPTS:
+        assert f".polaris-runner/agent/{name}" in server.files
+    assert server.host_files["~/.polaris-runner/VERSION"].strip() == byo_runner.AGENT_VERSION
+    pushed = _agent_file_count(server)
+
+    # 后连：版本一致 → 一条 cat 即跳过，不再写文件
+    commands_before = len(server.commands)
+    assert await byo_runner.ensure_agent(session) is False
+    assert len(server.commands) == commands_before + 1  # 只有 cat VERSION
+    assert _agent_file_count(server) == pushed
+
+
+async def test_ensure_agent_repushes_on_stale_version(app):
+    server = FakeSSHServer()
+    server.host_files["~/.polaris-runner/VERSION"] = "0\n"  # 过期版本
+    session = FakeSSHSession(server)
+    assert await byo_runner.ensure_agent(session) is True
+    assert server.host_files["~/.polaris-runner/VERSION"].strip() == byo_runner.AGENT_VERSION
+
+
+async def test_open_executor_auto_ensures_agent(fake_ssh):
+    """open_executor 连上即保证 agent 就位（首连推送）；agent 脚本是固定文本。"""
+    credential = SSHCredential(
+        user_id=uuid.uuid4(),
+        name="box",
+        host="gpu1.lab",
+        port=22,
+        username="polaris",
+        private_key_encrypted=encrypt_secret(FAKE_PEM),
+    )
+    executor = await ssh_exec.open_executor(
+        credential=credential, exp_id=str(uuid.uuid4()), project_id=uuid.uuid4()
+    )
+    assert _agent_file_count(fake_ssh) == len(byo_runner.AGENT_SCRIPTS)
+    await executor.close()
+
+
+# ---- runner 主机注册（host 类 Resource）与租约 ----
+
+
+async def test_register_runner_host_api(client):
+    headers = await _auth(client)
+    cred_id = await _create_credential(client, headers)
+
+    resp = await client.post(
+        "/api/resources/runner-hosts",
+        json={"name": "lab-a100", "credential_id": cred_id},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["kind"] == "host" and body["exclusive"] is True
+    assert body["credential_id"] == cred_id
+    assert body["config"]["ephemeral"] is True  # 默认推荐容器化 ephemeral 执行
+
+    # 显式接受 non-ephemeral（裸机直跑）
+    resp = await client.post(
+        "/api/resources/runner-hosts",
+        json={"name": "bare-box", "credential_id": cred_id, "ephemeral": False},
+        headers=headers,
+    )
+    assert resp.status_code == 201
+    assert resp.json()["config"]["ephemeral"] is False
+
+    # 他人凭据 → 404（不泄露存在性）
+    headers_b = await _auth(client, "bob@example.com")
+    resp = await client.post(
+        "/api/resources/runner-hosts",
+        json={"name": "steal", "credential_id": cred_id},
+        headers=headers_b,
+    )
+    assert resp.status_code == 404
+
+    # 非 ssh 凭据 → 422（tier-1 只吃 SSH 直连）
+    resp = await client.post(
+        "/api/connection-credentials",
+        json={"name": "token", "kind": "http", "host": "api.lab", "payload": {"token": "t"}},
+        headers=headers,
+    )
+    http_cred = resp.json()["id"]
+    resp = await client.post(
+        "/api/resources/runner-hosts",
+        json={"name": "not-ssh", "credential_id": http_cred},
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
+async def test_runner_host_lease_mutual_exclusion(client):
+    """注册出来的 host 资源天然进 #680 租约体系：默认独占，第二个 run 拿不到。"""
+    headers = await _auth(client)
+    cred_id = await _create_credential(client, headers)
+    resp = await client.post(
+        "/api/resources/runner-hosts",
+        json={"name": "one-at-a-time", "credential_id": cred_id},
+        headers=headers,
+    )
+    resource_id = uuid.UUID(resp.json()["id"])
+
+    async with get_sessionmaker()() as session:
+        resource = await session.get(Resource, resource_id)
+        run1 = VoyageRun(kind="experiment", goal="r1", status="executing")
+        run2 = VoyageRun(kind="experiment", goal="r2", status="executing")
+        session.add_all([run1, run2])
+        await session.commit()
+        await session.refresh(run1)
+        await session.refresh(run2)
+        lease = await resource_leases.acquire(session, resource, run1)
+        assert lease.released_at is None
+        with pytest.raises(resource_leases.ResourceBusyError):
+            await resource_leases.acquire(session, resource, run2)
+
+
+# ---- 凭据吊销联动 ----
+
+
+async def _seed_active_experiment(client, headers, credential_id: str) -> uuid.UUID:
+    """直接落一行非终态实验引用凭据（不跑完整创建流程，吊销联动只看引用）。"""
+    resp = await client.post("/api/projects", json={"name": "revoke-proj"}, headers=headers)
+    project_id = uuid.UUID(resp.json()["id"])
+    async with get_sessionmaker()() as session:
+        idea = Idea(project_id=project_id, title="idea", summary="s", status="promoted")
+        session.add(idea)
+        await session.flush()
+        experiment = Experiment(
+            project_id=project_id,
+            idea_id=idea.id,
+            credential_id=uuid.UUID(credential_id),
+            status="running",
+        )
+        session.add(experiment)
+        await session.commit()
+        return experiment.id
+
+
+async def test_revoke_credential_with_active_run_conflicts(client):
+    headers = await _auth(client)
+    cred_id = await _create_credential(client, headers)
+    resp = await client.post(
+        "/api/resources/runner-hosts",
+        json={"name": "box", "credential_id": cred_id},
+        headers=headers,
+    )
+    resource_id = uuid.UUID(resp.json()["id"])
+    exp_id = await _seed_active_experiment(client, headers, cred_id)
+
+    # 活跃引用：老端点与通用端点都 409，凭据仍在
+    for url in (f"/api/ssh-credentials/{cred_id}", f"/api/connection-credentials/{cred_id}"):
+        resp = await client.delete(url, headers=headers)
+        assert resp.status_code == 409, resp.text
+        assert resp.json()["detail"] == "CREDENTIAL_IN_USE"
+    resp = await client.get("/api/ssh-credentials", headers=headers)
+    assert [c["id"] for c in resp.json()] == [cred_id]
+
+    # 实验进终态后可吊销；host 资源标记不可用且脱钩凭据（资源本身保留）
+    async with get_sessionmaker()() as session:
+        experiment = await session.get(Experiment, exp_id)
+        experiment.status = "done"
+        await session.commit()
+    resp = await client.delete(f"/api/ssh-credentials/{cred_id}", headers=headers)
+    assert resp.status_code == 204, resp.text
+    async with get_sessionmaker()() as session:
+        resource = await session.get(Resource, resource_id)
+        assert resource is not None
+        assert resource.credential_id is None
+        assert resource.config["unavailable"] is True
+        assert resource.config["unavailable_reason"] == "credential_revoked"
+        assert resource.config["ephemeral"] is True  # 原有配置保留
+
+
+# ---- 实验创建：resource_id 指定 runner 主机 ----
+
+
+async def _seed_promoted_idea(client, headers) -> tuple[str, str]:
+    resp = await client.post("/api/projects", json={"name": "byo-proj"}, headers=headers)
+    project_id = resp.json()["id"]
+    async with get_sessionmaker()() as session:
+        idea = Idea(
+            project_id=uuid.UUID(project_id), title="byo idea", summary="s", status="promoted"
+        )
+        session.add(idea)
+        await session.commit()
+        return project_id, str(idea.id)
+
+
+async def test_experiment_create_with_resource_id(client, queue_stub):
+    headers = await _auth(client)
+    cred_id = await _create_credential(client, headers)
+    resp = await client.post(
+        "/api/resources/runner-hosts",
+        json={"name": "target-box", "credential_id": cred_id},
+        headers=headers,
+    )
+    resource_id = resp.json()["id"]
+    project_id, idea_id = await _seed_promoted_idea(client, headers)
+
+    resp = await client.post(
+        f"/api/projects/{project_id}/experiments",
+        json={"idea_id": idea_id, "resource_id": resource_id},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    exp_id = uuid.UUID(resp.json()["id"])
+    async with get_sessionmaker()() as session:
+        experiment = await session.get(Experiment, exp_id)
+        # 凭据从资源上解析而来；resource_id 记入 voyage checkpoint 供后续租约消费
+        assert str(experiment.credential_id) == cred_id
+        voyage = await session.get(VoyageRun, experiment.voyage_id)
+        assert voyage.checkpoint["params"]["resource_id"] == resource_id
+
+
+async def test_experiment_create_resource_id_errors(client, queue_stub):
+    headers = await _auth(client)
+    cred_id = await _create_credential(client, headers)
+    project_id, idea_id = await _seed_promoted_idea(client, headers)
+
+    # 两者都不给 → 422（schema 校验）
+    resp = await client.post(
+        f"/api/projects/{project_id}/experiments", json={"idea_id": idea_id}, headers=headers
+    )
+    assert resp.status_code == 422
+
+    # 不存在的资源 → 404
+    resp = await client.post(
+        f"/api/projects/{project_id}/experiments",
+        json={"idea_id": idea_id, "resource_id": str(uuid.uuid4())},
+        headers=headers,
+    )
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "RESOURCE_NOT_FOUND"
+
+    # 凭据吊销后的资源（unavailable）→ 409
+    resp = await client.post(
+        "/api/resources/runner-hosts",
+        json={"name": "will-revoke", "credential_id": cred_id},
+        headers=headers,
+    )
+    resource_id = resp.json()["id"]
+    resp = await client.delete(f"/api/ssh-credentials/{cred_id}", headers=headers)
+    assert resp.status_code == 204
+    resp = await client.post(
+        f"/api/projects/{project_id}/experiments",
+        json={"idea_id": idea_id, "resource_id": resource_id},
+        headers=headers,
+    )
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "RESOURCE_UNAVAILABLE"
+
+
+# ---- 密钥不出库：连接失败的异常文本不得携带私钥 ----
+
+
+class LeakyConnector:
+    """模拟「底层库把输入私钥嵌进异常文本」的最坏情况（asyncssh 实际不会）。"""
+
+    async def connect(self, *, host, port, username, private_key, passphrase=None):
+        raise ConnectionError(f"handshake rejected, offending key: {private_key}")
+
+
+async def test_connect_failure_detail_never_contains_private_key(client):
+    headers = await _auth(client)
+    cred_id = await _create_credential(client, headers)
+    async with get_sessionmaker()() as session:
+        credential = (
+            await session.execute(
+                select(SSHCredential).where(SSHCredential.id == uuid.UUID(cred_id))
+            )
+        ).scalar_one()
+        # 触发 lazy 属性加载后脱离会话使用（test_credential 只读属性）
+        assert credential.private_key_encrypted
+
+    ssh_exec.set_connector_factory(LeakyConnector)
+    try:
+        ok, detail = await ssh_exec.test_credential(credential)
+        assert ok is False
+        assert "fake-key-material" not in detail
+        assert "PRIVATE KEY" not in detail
+        assert "[REDACTED]" in detail
+
+        info = await ssh_exec.probe_sysinfo(credential)
+        assert info["ok"] is False
+        assert "fake-key-material" not in info["detail"]
+        assert "PRIVATE KEY" not in info["detail"]
+    finally:
+        ssh_exec.set_connector_factory(None)
+
+
+async def test_scrub_secrets_covers_partial_lines():
+    """异常只嵌 PEM 某一行也要被抹掉（整段 replace 不够）。"""
+    text = "error near fake-key-material in input"
+    scrubbed = ssh_exec.scrub_secrets(text, FAKE_PEM, None)
+    assert "fake-key-material" not in scrubbed
+    assert "[REDACTED]" in scrubbed

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -2580,7 +2580,10 @@ export interface ExperimentIntakeQuestion {
 
 export interface CreateExperimentInput {
   idea_id: string;
-  credential_id: string;
+  /** 与 resource_id 二选一（后端要求至少给一个）；现有 UI 只走凭据路径 */
+  credential_id?: string;
+  /** 已注册 runner 主机（host 类 Resource，#685）：指定跑在哪台机器上；本期无 UI */
+  resource_id?: string;
   params?: {
     gpu_hint?: string;
     budget?: ExperimentBudget;


### PR DESCRIPTION
Closes #685. Part of #674 (P3 wave 4, item R6 — final P3 item); design report §15 tier 1.

- **agent version pinning**: the repo had no agent push at all — remote helper logic lived as scattered fixed-template commands. The agent payload is now three versioned remote scripts (probe / workdir / run-status conventions); `ensure_agent()` compares `~/.polaris-runner/VERSION` after connect (first connect pushes, later connects are one `cat`; the version file writes atomically so an interrupted push can't leave new-version-old-scripts). Execution deliberately keeps running the fixed templates this phase — the scripts land as the versioned remote contract first, byte-identical behavior; a push failure warns without blocking (the status quo predates the agent)
- **revocation**: deleting a connection credential with non-terminal experiments referencing it returns `409 CREDENTIAL_IN_USE` (cancelling a user's running experiment as a side effect of credential deletion is the wrong kind of surprise); successful revocation marks the linked host Resource unavailable with the reason and detaches the credential — the resource can be re-bound later
- **registration + ephemeral default**: `POST /resources/runner-hosts` registers a machine as a host Resource (exclusive by default, `ephemeral: true` default = the containerized path; the bare path stays but is labeled non-ephemeral). Experiment creation accepts an optional `resource_id` (resolves the credential, recorded for lease consumption); omitting it changes nothing
- **key audit**: every decryption site feeds asyncssh connection parameters only and logs carry host/fingerprint/command — but two endpoints relayed raw connection-exception text into API details, a theoretical key-material channel. `scrub_secrets()` now strips PEM content line-wise at both sites, pinned by a test whose fake connector embeds the private key into the exception
- tier-2 outbound-WebSocket protocol documented as a design note in `docs/byo-runner.md`, not implemented

Verification: clean baseline 1660 passed / 3 pre-existing failures; branch 1669 passed / same 3 + one known clock flake (8/8 standalone) — zero new real failures; goldens green; no migrations; frontend type-only change, build green.