### PR TITLE
feat: derive daily feed relevance from the user's libraries

### DIFF
--- a/src/backend/app/api/daily.py
+++ b/src/backend/app/api/daily.py
@@ -81,7 +81,7 @@ async def list_days(
 @router.get("/papers", response_model=DailyPage)
 async def list_papers(
     date: dt.date | None = Query(default=None),
-    sort: str = Query(default="likes", pattern="^(likes|date)$"),
+    sort: str = Query(default="likes", pattern="^(likes|date|relevance)$"),
     mode: str = Query(default="keyword", pattern="^(keyword|semantic)$"),
     page: int = Query(default=1, ge=1),
     size: int = Query(default=20, ge=1, le=100),
@@ -99,6 +99,8 @@ async def list_papers(
 ) -> DailyPage:
     """池内列表 / 检索。
 
+    sort=relevance 按「与你的文献库的相关性 × 新近度」融合排序（没有文献库时与
+    sort=date 一致）；条目附带「与你的库相关」徽章数据（related_library_id/name）。
     mode=semantic 且有 q 时走论文向量检索（结果按相关度排序、不分页）；数据库不是
     postgres 或 provider 不支持嵌入时回退关键词，响应里 mode_used 如实反映。
     池论文默认不建向量（管理员开关），语义结果可能不全，覆盖度见 vector_ready/total。
@@ -144,6 +146,7 @@ async def list_papers(
         items, total = await daily_service.list_papers(
             session,
             user_id=user.id,
+            user=user,
             date=date,
             sort=sort,
             page=page,

--- a/src/backend/app/schemas/daily.py
+++ b/src/backend/app/schemas/daily.py
@@ -52,6 +52,9 @@ class DailyPaperItem(BaseModel):
     likers_preview: list[DailyLiker] = []
     # 仅「我赞过的」列表返回
     liked_at: datetime | None = None
+    # 「与你的库相关」徽章（#623）：最像的那个文献库；低于阈值/没有库时为空
+    related_library_id: uuid.UUID | None = None
+    related_library_name: str | None = None
 
     @field_validator("authors", mode="before")
     @classmethod

--- a/src/backend/app/services/daily_feed.py
+++ b/src/backend/app/services/daily_feed.py
@@ -19,7 +19,7 @@ import re
 import uuid
 from typing import Any
 
-from sqlalchemy import String, case, cast, delete, func, select, text
+from sqlalchemy import Date, Float, String, case, cast, delete, func, literal, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.embedding_space import EmbeddingSpace, active_space
@@ -681,6 +681,7 @@ async def list_papers(
     session: AsyncSession,
     *,
     user_id: uuid.UUID,
+    user: User | None = None,
     date: dt.date | None = None,
     sort: str = "likes",
     page: int = 1,
@@ -693,6 +694,21 @@ async def list_papers(
     library_id: uuid.UUID | None = None,
     collected: bool = False,
 ) -> tuple[list[dict[str, Any]], int]:
+    """池内列表。``sort`` 还支持 ``relevance``：按「与你的文献库的相关性 × 新近度」
+    融合排序（#623，需要 ``user`` 来圈定可见库）；没有任何可用的库锚点时退回按时间，
+    与没有这个功能时的行为完全一致。传了 ``user`` 时，无论哪种排序都会给条目补
+    「与你的库相关」徽章数据（related_library_id/name）。
+    """
+    # 延迟 import 与 papers 服务同因（见 cleanup_expired）——daily_relevance 依赖 papers
+    from app.services import daily_relevance
+
+    anchors: list[daily_relevance.LibraryAnchor] = []
+    if user is not None:
+        anchors = await daily_relevance.library_anchors(session, user=user)
+    if sort == "relevance" and not anchors:
+        # 一个库都没有（或都空得没法当锚）：行为与现状一致，按时间排
+        sort = "date"
+
     stmt = select(DailyFeedEntry, Paper).join(Paper, Paper.id == DailyFeedEntry.paper_id)
     if collected:
         # 「已收录」：被**任意**文献库真正收进去的（候选/回收站不算）。与 library_id
@@ -760,25 +776,129 @@ async def list_papers(
     )
     # 同分类里，新工作排在交叉提交（更新）前面：新工作才是当天真正的新东西
     announce_rank = case((DailyFeedEntry.announce_type == "new", 0), else_=1)
-    if sort == "likes":
-        stmt = stmt.order_by(
-            category_rank,
-            announce_rank,
-            likes_sq.desc(),
-            DailyFeedEntry.feed_date.desc(),
-            DailyFeedEntry.created_at.desc(),
-        )
-    else:  # date
-        stmt = stmt.order_by(
-            category_rank,
-            announce_rank,
-            DailyFeedEntry.feed_date.desc(),
-            DailyFeedEntry.created_at.desc(),
-        )
-    stmt = stmt.offset((page - 1) * size).limit(size)
+    if sort == "relevance":
+        rows = await _relevance_page(session, stmt, anchors=anchors, page=page, size=size)
+    else:
+        if sort == "likes":
+            stmt = stmt.order_by(
+                category_rank,
+                announce_rank,
+                likes_sq.desc(),
+                DailyFeedEntry.feed_date.desc(),
+                DailyFeedEntry.created_at.desc(),
+            )
+        else:  # date
+            stmt = stmt.order_by(
+                category_rank,
+                announce_rank,
+                DailyFeedEntry.feed_date.desc(),
+                DailyFeedEntry.created_at.desc(),
+            )
+        stmt = stmt.offset((page - 1) * size).limit(size)
+        rows = list((await session.execute(stmt)).all())
 
-    rows = (await session.execute(stmt)).all()
-    return await entry_items(session, list(rows), user_id=user_id), total
+    items = await entry_items(session, list(rows), user_id=user_id)
+    await _annotate_library_relevance(session, items, list(rows), anchors)
+    return items, total
+
+
+async def _relevance_page(
+    session: AsyncSession,
+    stmt: Any,
+    *,
+    anchors: list[Any],
+    page: int,
+    size: int,
+) -> list[tuple[DailyFeedEntry, Paper]]:
+    """带筛选的池条目按「新近度 × 库相关性」融合分取一页（#623）。
+
+    公式与 daily_relevance.fused_score 一致：recency 按保留窗口线性归一，
+    权重 RELEVANCE_WEIGHT 给相关性、其余给新近度；平分时新日期在前。
+
+    postgres 在 SQL 里算（窗口内几千条、每条要对若干个 1024 维质心做余弦，把向量
+    搬出来在 Python 算每次请求要传几十 MB）；其余方言（测试的 sqlite）把筛选后的行
+    全取出来在 Python 打分排序——那种部署数据量本来就小。两条路径必须同公式。
+    """
+    from app.services import daily_relevance
+
+    today = _today_utc()
+    window = await get_retention_days(session)
+    weight = daily_relevance.RELEVANCE_WEIGHT
+
+    if session.get_bind().dialect.name == "postgresql":
+        from pgvector.sqlalchemy import Vector as PgVector
+
+        space = await active_space(session)
+        join_vec = space is not None and any(a.centroid is not None for a in anchors)
+        if join_vec:
+            stmt = stmt.outerjoin(
+                PaperVector,
+                (PaperVector.paper_id == Paper.id) & (PaperVector.space == space.key),
+            )
+        score_exprs: list[Any] = []
+        for anchor in anchors:
+            kw_expr = None
+            if anchor.keywords:
+                hits = [
+                    Paper.title.ilike(f"%{kw}%") | Paper.abstract.ilike(f"%{kw}%")
+                    for kw in anchor.keywords
+                ]
+                kw_expr = case((or_(*hits), daily_relevance.KEYWORD_HIT_SCORE), else_=0.0)
+            if anchor.centroid is not None and join_vec:
+                cos = 1.0 - PaperVector.embedding.op("<=>", return_type=Float)(
+                    cast(literal(anchor.centroid, PgVector()), PgVector())
+                )
+                # 论文缺向量（嵌入失败的兜底）→ 该锚点退回关键词，与 anchor_score 同口径
+                score_exprs.append(
+                    func.coalesce(cos, kw_expr if kw_expr is not None else 0.0)
+                )
+            elif kw_expr is not None:
+                score_exprs.append(kw_expr)
+        # 余弦可为负；Python 侧只保留正分（负相关不该把论文压到窗口底），SQL 用 0 兜底对齐
+        rel = func.greatest(0.0, *score_exprs) if score_exprs else literal(0.0)
+        days = cast(literal(today, Date()) - DailyFeedEntry.feed_date, Float)
+        recency = func.greatest(0.0, 1.0 - days / float(window))
+        fused = (1.0 - weight) * recency + weight * rel
+        stmt = stmt.order_by(
+            fused.desc(), DailyFeedEntry.feed_date.desc(), DailyFeedEntry.created_at.desc()
+        )
+        stmt = stmt.offset((page - 1) * size).limit(size)
+        return list((await session.execute(stmt)).all())
+
+    rows = list((await session.execute(stmt)).all())
+    scores = await daily_relevance.relevance_for_papers(session, [p for _, p in rows], anchors)
+
+    def sort_key(row: tuple[DailyFeedEntry, Paper]) -> tuple[float, int, float]:
+        entry, paper = row
+        rel_score = scores.get(paper.id, (0.0, None))[0]
+        fused = daily_relevance.fused_score(rel_score, (today - entry.feed_date).days, window)
+        return (-fused, -entry.feed_date.toordinal(), -entry.created_at.timestamp())
+
+    rows.sort(key=sort_key)
+    return rows[(page - 1) * size : (page - 1) * size + size]
+
+
+async def _annotate_library_relevance(
+    session: AsyncSession,
+    items: list[dict[str, Any]],
+    rows: list[tuple[DailyFeedEntry, Paper]],
+    anchors: list[Any],
+) -> None:
+    """给这页条目补「与你的库相关」徽章数据（命中库的 id/名）。
+
+    只标最像的那个库；低于 MATCH_THRESHOLD 的不标——徽章的意义是「值得点进去看」，
+    而排序融合用的是原始分，不受这个阈值影响。
+    """
+    if not anchors or not rows:
+        return
+    from app.services import daily_relevance
+
+    scores = await daily_relevance.relevance_for_papers(session, [p for _, p in rows], anchors)
+    for item, (_, paper) in zip(items, rows, strict=False):
+        hit = scores.get(paper.id)
+        if hit is not None and hit[0] >= daily_relevance.MATCH_THRESHOLD:
+            item["related_library_id"] = hit[1].library_id
+            item["related_library_name"] = hit[1].name
 
 
 async def semantic_search_daily(

--- a/src/backend/app/services/daily_relevance.py
+++ b/src/backend/app/services/daily_relevance.py
@@ -1,0 +1,253 @@
+"""每日论文池 × 用户文献库的相关性（#623）。
+
+每日池从订阅分类整体抓取，但真正值得用户先看的，是和**他自己的文献库**方向相近的
+那部分。本模块把「相关不相关」量化成分数：
+
+- 锚点 = 每个可见库的代表向量：库内论文（真正收录的成员，status 组 ``library``）
+  论文级向量的质心。质心缓存在 system_settings（``daily_library_anchor:<id>``），
+  用「空间 + 成员数 + 成员行最后更新时间」做指纹，库一变（收录/删除/状态流转都会
+  碰成员行的 updated_at）指纹就变，下次读取自动重算——不用在每条写路径上挂失效钩子。
+- 库还没有任何成员向量（或平台没有激活空间）时降级为关键词匹配：收录设置里的
+  关键词 chips（definition.keywords.include）命中即给一个固定分。关键词是用户
+  亲手列的方向意图，比没有强得多。
+- 条目得分 = max over 库（这篇最像哪个库就按哪个库算），并带上来源库标注——
+  前端徽章「与你的库相关 · 某库」要能点回那个库。
+
+确定性逻辑，不走 LLM；嵌入向量是既有产物（每日同步已无条件建论文级向量）。
+"""
+
+import json
+import logging
+import math
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy import func, select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.embedding_space import EmbeddingSpace, active_space
+from app.models.library_direction import DirectionLibrary, LibraryPaper
+from app.models.paper import Paper
+from app.models.system_setting import SystemSetting
+from app.models.user import User
+from app.models.vectors import PaperVector
+from app.services.libraries import library_visible_to
+from app.services.papers import PAPER_STATUS_GROUPS
+from app.services.relevance import _include_keywords
+
+logger = logging.getLogger(__name__)
+
+#: 质心缓存的 system_settings 键前缀（每库一行）。
+ANCHOR_SETTING_PREFIX = "daily_library_anchor:"
+
+#: 排序融合里库相关性的权重（其余给新近度）。故意温和：每日页的主线是「今天有什么
+#: 新东西」，权重给大了列表就会长期被旧兴趣的近亲霸榜，用户再也刷不到方向之外的
+#: 新苗头——推荐系统里经典的兴趣过拟合。0.3 的效果是：相关性满分大约能把一篇论文
+#: 「抬」半个保留窗口的新近度（0.3 ≈ 0.7 × 6/14），足够让三五天前的高相关论文
+#: 排到今天的无关论文前面，但压不过今天同样相关的。
+RELEVANCE_WEIGHT = 0.3
+
+#: 徽章阈值：得分低于它就不标「与你的库相关」。质心余弦对同领域论文通常落在
+#: 0.6 以上、无关领域在 0.5 以下（bge 系模型的经验区间）；排序不看这个阈值
+#: （原始分参与融合），它只管徽章别乱贴。
+MATCH_THRESHOLD = 0.55
+
+#: 关键词降级命中给的固定分。取在阈值之上（命中了就该出徽章），又低于「向量高度
+#: 相似」的典型区间——关键词命中只是字面证据，不该压过真正的语义近邻。
+KEYWORD_HIT_SCORE = 0.6
+
+#: 参与质心的成员状态：真正收进库的（与「已收录」列表口径一致，候选/回收站不算）。
+MEMBER_STATUSES = PAPER_STATUS_GROUPS["library"]
+
+
+@dataclass
+class LibraryAnchor:
+    """一个库的相关性锚点：优先质心向量，没有则关键词。"""
+
+    library_id: uuid.UUID
+    name: str
+    centroid: list[float] | None
+    keywords: list[str]
+
+
+def _anchor_setting_key(library_id: uuid.UUID) -> str:
+    return f"{ANCHOR_SETTING_PREFIX}{library_id}"
+
+
+async def library_anchors(session: AsyncSession, *, user: User) -> list[LibraryAnchor]:
+    """请求者可见的库各出一个锚点；质心和关键词都没有的库不出（无从比较）。"""
+    libraries = (await session.execute(select(DirectionLibrary))).scalars().all()
+    visible = [lib for lib in libraries if library_visible_to(lib, user)]
+    if not visible:
+        return []
+    space = await active_space(session)
+    anchors: list[LibraryAnchor] = []
+    for lib in visible:
+        definition = lib.definition if isinstance(lib.definition, dict) else {}
+        keywords = _include_keywords(definition)
+        centroid = await _library_centroid(session, lib.id, space) if space else None
+        if centroid is None and not keywords:
+            continue
+        anchors.append(
+            LibraryAnchor(library_id=lib.id, name=lib.name, centroid=centroid, keywords=keywords)
+        )
+    return anchors
+
+
+async def _library_centroid(
+    session: AsyncSession, library_id: uuid.UUID, space: EmbeddingSpace
+) -> list[float] | None:
+    """库内成员论文向量的质心（带指纹缓存）；一条成员向量都没有时为 None。"""
+    count, max_updated = (
+        await session.execute(
+            select(func.count(), func.max(LibraryPaper.updated_at)).where(
+                LibraryPaper.library_id == library_id,
+                LibraryPaper.status.in_(MEMBER_STATUSES),
+            )
+        )
+    ).one()
+    if not count:
+        return None
+    # 指纹三要素：空间（换嵌入模型必须重算）、成员数、成员行最后更新时间。任何收录/
+    # 删除/状态流转都会动其中至少一项。不用「成员 id 列表哈希」是因为那要每次请求
+    # 全量拉 id——大库几千行，而这里一条聚合就够。
+    fingerprint = f"{space.key}|{count}|{max_updated.isoformat() if max_updated else '-'}"
+    key = _anchor_setting_key(library_id)
+    row = await session.get(SystemSetting, key)
+    if (
+        row is not None
+        and isinstance(row.value, dict)
+        and row.value.get("fingerprint") == fingerprint
+    ):
+        cached = row.value.get("centroid")
+        return [float(x) for x in cached] if cached else None
+    centroid = await _compute_centroid(session, library_id, space)
+    value: dict[str, Any] = {"fingerprint": fingerprint, "space": space.key, "centroid": centroid}
+    if row is None:
+        session.add(SystemSetting(key=key, value=value))
+    else:
+        row.value = value
+    await session.commit()
+    return centroid
+
+
+async def _compute_centroid(
+    session: AsyncSession, library_id: uuid.UUID, space: EmbeddingSpace
+) -> list[float] | None:
+    """成员向量取均值。postgres 让数据库聚合（几千条向量不搬出来）；其余方言（测试的
+    sqlite，向量是 JSON 列）在 Python 里算——那种部署本来就没有大库。"""
+    dialect = session.get_bind().dialect.name
+    if dialect == "postgresql":
+        row = (
+            await session.execute(
+                text(
+                    "SELECT CAST(AVG(v.embedding) AS text) FROM paper_vectors v "
+                    "WHERE v.space = :space AND v.paper_id IN ("
+                    "SELECT lp.paper_id FROM library_papers lp "
+                    "WHERE lp.library_id = :library_id "
+                    "AND lp.status = ANY(CAST(:statuses AS varchar[])))"
+                ),
+                {
+                    "space": space.key,
+                    "library_id": str(library_id),
+                    "statuses": list(MEMBER_STATUSES),
+                },
+            )
+        ).scalar_one_or_none()
+        if not row:
+            return None
+        return [float(x) for x in json.loads(row)]  # pgvector 的文本形式就是 JSON 数组
+    member_sq = select(LibraryPaper.paper_id).where(
+        LibraryPaper.library_id == library_id, LibraryPaper.status.in_(MEMBER_STATUSES)
+    )
+    vectors = (
+        (
+            await session.execute(
+                select(PaperVector.embedding).where(
+                    PaperVector.space == space.key, PaperVector.paper_id.in_(member_sq)
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if not vectors:
+        return None
+    dim = len(vectors[0])
+    acc = [0.0] * dim
+    for vec in vectors:
+        for i, x in enumerate(vec):
+            acc[i] += float(x)
+    return [x / len(vectors) for x in acc]
+
+
+# ---- 打分 ----
+
+
+def _cosine(a: list[float], b: list[float]) -> float:
+    dot = na = nb = 0.0
+    for x, y in zip(a, b, strict=False):
+        dot += x * y
+        na += x * x
+        nb += y * y
+    if na <= 0.0 or nb <= 0.0:
+        return 0.0
+    return dot / (math.sqrt(na) * math.sqrt(nb))
+
+
+def keyword_score(keywords: list[str], text_: str) -> float:
+    """关键词降级：任一收录关键词字面命中标题/摘要即给固定分（大小写不敏感）。"""
+    if not keywords or not text_:
+        return 0.0
+    lowered = text_.lower()
+    return KEYWORD_HIT_SCORE if any(kw.lower() in lowered for kw in keywords) else 0.0
+
+
+def anchor_score(anchor: LibraryAnchor, vector: list[float] | None, text_: str) -> float:
+    """一篇论文对一个锚点的得分。质心与论文向量都在才用余弦；论文缺向量（嵌入失败的
+    兜底）或库没质心时退回关键词——降级路径必须有，否则这些论文永远排在最后。"""
+    if anchor.centroid is not None and vector is not None:
+        return _cosine(anchor.centroid, vector)
+    return keyword_score(anchor.keywords, text_)
+
+
+async def relevance_for_papers(
+    session: AsyncSession, papers: list[Paper], anchors: list[LibraryAnchor]
+) -> dict[uuid.UUID, tuple[float, LibraryAnchor]]:
+    """每篇论文取所有锚点里的最高分及其来源库；零分的不出现在结果里。"""
+    if not papers or not anchors:
+        return {}
+    space = await active_space(session)
+    vectors: dict[uuid.UUID, list[float]] = {}
+    if space is not None:
+        rows = await session.execute(
+            select(PaperVector.paper_id, PaperVector.embedding).where(
+                PaperVector.space == space.key,
+                PaperVector.paper_id.in_([p.id for p in papers]),
+            )
+        )
+        vectors = {pid: [float(x) for x in emb] for pid, emb in rows.all()}
+    out: dict[uuid.UUID, tuple[float, LibraryAnchor]] = {}
+    for paper in papers:
+        text_ = f"{paper.title or ''}\n{paper.abstract or ''}"
+        vector = vectors.get(paper.id)
+        best: tuple[float, LibraryAnchor] | None = None
+        for anchor in anchors:
+            score = anchor_score(anchor, vector, text_)
+            if score > 0.0 and (best is None or score > best[0]):
+                best = (score, anchor)
+        if best is not None:
+            out[paper.id] = best
+    return out
+
+
+def fused_score(relevance: float, days_ago: int, window: int) -> float:
+    """新近度与库相关性的加权融合（排序键，越大越靠前）。
+
+    新近度按保留窗口线性归一（今天 1.0，掉出窗口 0.0）；权重见
+    :data:`RELEVANCE_WEIGHT` 的注释。postgres 侧的 SQL 表达式
+    （services/daily_feed 的相关性分支）必须与这里同公式。
+    """
+    recency = max(0.0, 1.0 - days_ago / float(max(window, 1)))
+    return (1.0 - RELEVANCE_WEIGHT) * recency + RELEVANCE_WEIGHT * relevance

--- a/src/backend/tests/test_daily_library_relevance.py
+++ b/src/backend/tests/test_daily_library_relevance.py
@@ -1,0 +1,253 @@
+"""每日论文池按用户文献库派生相关性（#623）。
+
+覆盖：质心计算与指纹缓存/失效、相关性×新近度融合排序（fake 向量，确定性）、
+无库时与按时间完全一致、无向量库的关键词降级、列表条目的「与你的库相关」徽章数据。
+"""
+
+import datetime as dt
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from app.core.db import get_sessionmaker
+from app.core.llm.fake import EMBEDDING_DIM
+from app.models.daily_feed import DailyFeedEntry
+from app.models.library_direction import DirectionLibrary
+from app.models.system_setting import SystemSetting
+from app.models.user import User
+from app.services import daily_relevance
+from tests.conftest import add_paper, ensure_project_library, register_and_login
+from tests.vector_helpers import set_paper_vector
+
+pytestmark = pytest.mark.asyncio
+
+
+def _vec(axis: int) -> list[float]:
+    """单位基向量：不同 axis 互相正交（余弦 0），同 axis 余弦 1——分数完全可控。"""
+    v = [0.0] * EMBEDDING_DIM
+    v[axis] = 1.0
+    return v
+
+
+def _today() -> dt.date:
+    return dt.datetime.now(dt.UTC).date()
+
+
+async def _setup_library(client, *, member_axes: list[int]):
+    """注册（首个用户）→ 建课题（隐式建库）→ 塞成员论文并落向量。"""
+    token = await register_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = await client.post(
+        "/api/projects",
+        json={"name": "agents", "statement": "LLM agent planning"},
+        headers=headers,
+    )
+    assert resp.status_code in (200, 201), resp.text
+    project_id = uuid.UUID(resp.json()["id"])
+    async with get_sessionmaker()() as session:
+        for i, axis in enumerate(member_axes):
+            await add_paper(
+                session,
+                project_id=project_id,
+                title=f"member {i}",
+                status="scored",
+                embedding=_vec(axis),
+            )
+        await session.commit()
+    libs = (await client.get("/api/libraries", headers=headers)).json()
+    rows = libs if isinstance(libs, list) else libs["items"]
+    return headers, uuid.UUID(rows[0]["id"]), rows[0]["name"]
+
+
+async def _add_entry(
+    title: str,
+    *,
+    axis: int | None = None,
+    feed_date: dt.date | None = None,
+    abstract: str | None = None,
+) -> uuid.UUID:
+    """直接塞一条每日池条目（可选带论文向量）。"""
+    from app.models.paper import new_paper
+
+    async with get_sessionmaker()() as session:
+        paper = new_paper(
+            source="arxiv", dedup_key=uuid.uuid4().hex, title=title, abstract=abstract
+        )
+        session.add(paper)
+        await session.flush()
+        session.add(
+            DailyFeedEntry(
+                paper_id=paper.id,
+                feed_date=feed_date or _today(),
+                primary_category="cs.AI",
+            )
+        )
+        await session.commit()
+        paper_id = paper.id
+    if axis is not None:
+        async with get_sessionmaker()() as session:
+            await set_paper_vector(session, paper_id, _vec(axis))
+    return paper_id
+
+
+async def _first_user() -> User:
+    async with get_sessionmaker()() as session:
+        return (await session.execute(select(User).limit(1))).scalars().one()
+
+
+# ---- 质心：计算 + 指纹缓存 + 失效重算 ----
+
+
+async def test_centroid_cached_and_invalidated(client):
+    _headers, library_id, _name = await _setup_library(client, member_axes=[0, 0])
+    user = await _first_user()
+
+    async with get_sessionmaker()() as session:
+        anchors = await daily_relevance.library_anchors(session, user=user)
+        assert len(anchors) == 1
+        assert anchors[0].centroid is not None
+        assert anchors[0].centroid[0] == pytest.approx(1.0)
+
+        # 缓存行已落 system_settings
+        row = await session.get(SystemSetting, f"daily_library_anchor:{library_id}")
+        assert row is not None and row.value["centroid"][0] == pytest.approx(1.0)
+
+    # 指纹没变时读缓存：篡改缓存值，再读必须读到篡改后的（证明没有重算）
+    async with get_sessionmaker()() as session:
+        row = await session.get(SystemSetting, f"daily_library_anchor:{library_id}")
+        tampered = _vec(5)
+        row.value = dict(row.value, centroid=tampered)
+        await session.commit()
+    async with get_sessionmaker()() as session:
+        anchors = await daily_relevance.library_anchors(session, user=user)
+        assert anchors[0].centroid[5] == pytest.approx(1.0)
+
+    # 库一变（再收一篇）指纹变 → 自动重算，篡改值被真质心覆盖
+    async with get_sessionmaker()() as session:
+        project_id = (
+            (await session.execute(select(DirectionLibrary.project_id))).scalars().one()
+        )
+        await add_paper(
+            session, project_id=project_id, title="member 2", status="scored", embedding=_vec(1)
+        )
+        await session.commit()
+    async with get_sessionmaker()() as session:
+        anchors = await daily_relevance.library_anchors(session, user=user)
+        centroid = anchors[0].centroid
+        assert centroid[0] == pytest.approx(2 / 3)
+        assert centroid[1] == pytest.approx(1 / 3)
+        assert centroid[5] == pytest.approx(0.0)
+
+
+# ---- 相关性排序 + 徽章 ----
+
+
+async def test_relevance_sort_orders_related_first_and_badges(client):
+    _headers, library_id, library_name = await _setup_library(client, member_axes=[0, 0])
+    related = await _add_entry("Related agent paper", axis=0)
+    unrelated = await _add_entry("Unrelated topology paper", axis=7)
+
+    headers = _headers
+    resp = await client.get("/api/daily/papers?sort=relevance&size=10", headers=headers)
+    assert resp.status_code == 200, resp.text
+    items = resp.json()["items"]
+    ids = [row["paper_id"] for row in items]
+    assert ids == [str(related), str(unrelated)]
+
+    by_id = {row["paper_id"]: row for row in items}
+    hit = by_id[str(related)]
+    assert hit["related_library_id"] == str(library_id)
+    assert hit["related_library_name"] == library_name
+    # 正交向量余弦 0，低于阈值 → 不贴徽章
+    assert by_id[str(unrelated)]["related_library_id"] is None
+    assert by_id[str(unrelated)]["related_library_name"] is None
+
+
+async def test_badges_present_even_when_sorted_by_date(client):
+    _headers, _library_id, library_name = await _setup_library(client, member_axes=[0])
+    related = await _add_entry("Related agent paper", axis=0)
+
+    resp = await client.get("/api/daily/papers?sort=date&size=10", headers=_headers)
+    assert resp.status_code == 200
+    by_id = {row["paper_id"]: row for row in resp.json()["items"]}
+    assert by_id[str(related)]["related_library_name"] == library_name
+
+
+async def test_fusion_is_gentle_recency_still_matters(client):
+    """权重 0.3 的对账：昨天之前的高相关能压过今天的无关，但太旧就压不过。
+
+    fused = 0.7 × recency + 0.3 × relevance，窗口 14 天：
+    - 3 天前的相关：0.7×(1-3/14) + 0.3 = 0.85
+    - 今天的无关：  0.7×1              = 0.70
+    - 7 天前的相关：0.7×(1-7/14) + 0.3 = 0.65
+    """
+    _headers, _library_id, _name = await _setup_library(client, member_axes=[0])
+    today = _today()
+    mid_related = await _add_entry(
+        "Mid related", axis=0, feed_date=today - dt.timedelta(days=3)
+    )
+    new_unrelated = await _add_entry("New unrelated", axis=7, feed_date=today)
+    old_related = await _add_entry(
+        "Old related", axis=0, feed_date=today - dt.timedelta(days=7)
+    )
+
+    resp = await client.get("/api/daily/papers?sort=relevance&size=10", headers=_headers)
+    assert resp.status_code == 200
+    ids = [row["paper_id"] for row in resp.json()["items"]]
+    assert ids == [str(mid_related), str(new_unrelated), str(old_related)]
+
+
+# ---- 无库降级：与按时间完全一致 ----
+
+
+async def test_relevance_without_libraries_matches_date_sort(client):
+    token = await register_and_login(client)  # 不建课题：一个库都没有
+    headers = {"Authorization": f"Bearer {token}"}
+    today = _today()
+    await _add_entry("Yesterday paper", feed_date=today - dt.timedelta(days=1))
+    await _add_entry("Today paper", feed_date=today)
+
+    by_rel = await client.get("/api/daily/papers?sort=relevance&size=10", headers=headers)
+    by_date = await client.get("/api/daily/papers?sort=date&size=10", headers=headers)
+    assert by_rel.status_code == by_date.status_code == 200
+    rel_ids = [row["entry_id"] for row in by_rel.json()["items"]]
+    date_ids = [row["entry_id"] for row in by_date.json()["items"]]
+    assert rel_ids == date_ids
+    # 徽章字段存在但为空：没有库就没有「与你的库相关」
+    assert all(row["related_library_id"] is None for row in by_rel.json()["items"])
+
+
+# ---- 无向量库：关键词降级 ----
+
+
+async def test_keyword_fallback_when_library_has_no_vectors(client):
+    token = await register_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = await client.post(
+        "/api/projects",
+        json={"name": "diffusion", "statement": "diffusion models"},
+        headers=headers,
+    )
+    project_id = uuid.UUID(resp.json()["id"])
+    # 库空着（没有成员向量），只有收录关键词。建课题不建库，库随首次写入才出现，
+    # 这里直接用测试助手把隐式库建出来再填关键词。
+    async with get_sessionmaker()() as session:
+        library = await ensure_project_library(session, project_id)
+        library.definition = dict(
+            library.definition or {}, keywords={"include": ["diffusion"]}
+        )
+        library_name = library.name
+        await session.commit()
+
+    matched = await _add_entry("Diffusion transformers at scale")
+    other = await _add_entry("Sparse graph pruning")
+
+    resp = await client.get("/api/daily/papers?sort=relevance&size=10", headers=headers)
+    assert resp.status_code == 200
+    items = resp.json()["items"]
+    ids = [row["paper_id"] for row in items]
+    assert ids == [str(matched), str(other)]
+    by_id = {row["paper_id"]: row for row in items}
+    assert by_id[str(matched)]["related_library_name"] == library_name
+    assert by_id[str(other)]["related_library_name"] is None

--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -126,6 +126,7 @@ function DailyRow({
   onClick: () => void;
   onToggleCheck: () => void;
 }) {
+  const navigate = useNavigate();
   return (
     <div
       onClick={onClick}
@@ -185,6 +186,38 @@ function DailyRow({
               </span>
             )}
           </div>
+          {/* 「与你的库相关」：后端按库质心/关键词算出来的最像的那个库；没命中不占行 */}
+          {p.related_library_name && (
+            <div style={{ marginTop: 4 }}>
+              <span
+                className="pill sm"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (p.related_library_id) navigate(`/libraries/${p.related_library_id}`);
+                }}
+                title={tr(
+                  `和你的文献库「${p.related_library_name}」方向相近，点击打开该库`,
+                  `Close to your library “${p.related_library_name}” — click to open it`,
+                )}
+                style={{
+                  background: 'var(--accent-soft)',
+                  color: 'var(--accent-text)',
+                  cursor: 'pointer',
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 4,
+                  maxWidth: '100%',
+                }}
+              >
+                <Icon name="book" size={10} />
+                <span
+                  style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                >
+                  {tr('与你的库相关', 'Relevant to')} · {p.related_library_name}
+                </span>
+              </span>
+            </div>
+          )}
         </div>
       </div>
     </div>
@@ -574,10 +607,11 @@ type AnnounceFilter = 'collected' | 'all' | 'new';
 // 类型筛选默认值：只看已收录的（进了文献库的才值得先看；「恢复默认」也回到这个值）
 const DEFAULT_ANNOUNCE: AnnounceFilter = 'collected';
 
-// 列表固定按点赞排序（没有排序切换 UI）；语义检索时后端按相关度排，忽略这个值
-// 时间倒排：最新的在最前。按点赞排会让一篇被点过的旧论文压在当天新论文前面，
-// 而「每日新论文」这个页面的主线本来就是时间。
-const DAILY_SORT: DailySort = 'date';
+// 排序默认按时间：最新的在最前（按点赞排会让一篇被点过的旧论文压在当天新论文前面，
+// 而「每日新论文」这个页面的主线本来就是时间）。用户可切到「按相关性」：后端按
+// 「与你的文献库的相关性 × 新近度」融合排（没有文献库时两种排法一样）。
+// 语义检索时后端按检索相关度排，忽略这个值。
+type DailySortMode = Extract<DailySort, 'date' | 'relevance'>;
 
 /** 每日池的同步状况。池子是所有文献库的唯一供给——抓取失败会让全实验室当天颗粒无收，
     所以状态要摆在页面上，而不是只躺在任务日志里等人去翻。 */
@@ -678,6 +712,8 @@ export function DailyPage() {
   // 高级条件是否偏离默认（决定高级检索按钮上的小圆点）
   // 分类/类型已上工具栏；高级检索只剩作者与机构
   const advActive = !!author || !!affiliation;
+  // 排序：按时间（默认）/ 按相关性（与自己的文献库方向相近的靠前）
+  const [sortMode, setSortMode] = useState<DailySortMode>('date');
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [collectPaper, setCollectPaper] = useState<CollectPaperRef | null>(null);
   const [collectOpen, setCollectOpen] = useState(false);
@@ -768,12 +804,12 @@ export function DailyPage() {
   const listQuery = useInfiniteQuery({
     queryKey: [
       'daily-papers',
-      semanticOn, q, category, announce, author, affiliation, showAll, day,
+      semanticOn, q, category, announce, author, affiliation, showAll, day, sortMode,
     ],
     initialPageParam: 1,
     queryFn: ({ pageParam }) =>
       api.listDailyPapers({
-        sort: semantic ? undefined : DAILY_SORT,
+        sort: semantic ? undefined : sortMode,
         page: semantic ? undefined : pageParam,
         size: PAGE_SIZE,
         q: q || undefined,
@@ -1006,6 +1042,28 @@ export function DailyPage() {
                 <span className={`chip${announce === 'new' ? ' on' : ''}`} onClick={() => setAnnounce('new')}>
                   {tr('新工作', 'New')}
                 </span>
+                {/* 排序切换：语义检索时后端按检索相关度排，这两个开关不起作用，藏起来少个矛盾 */}
+                {!semantic && (
+                  <div className="row gap6" style={{ marginLeft: 'auto' }}>
+                    <span
+                      className={`chip${sortMode === 'date' ? ' on' : ''}`}
+                      onClick={() => setSortMode('date')}
+                      title={tr('最新公告的排最前', 'Newest announcements first')}
+                    >
+                      {tr('按时间', 'By time')}
+                    </span>
+                    <span
+                      className={`chip${sortMode === 'relevance' ? ' on' : ''}`}
+                      onClick={() => setSortMode('relevance')}
+                      title={tr(
+                        '和你的文献库方向相近的排前面（还没有文献库时与按时间一样）',
+                        'Papers close to your libraries come first (same as by time if you have no libraries)',
+                      )}
+                    >
+                      {tr('按相关性', 'By relevance')}
+                    </span>
+                  </div>
+                )}
               </div>
 
               {/* 高级检索面板：作者 / 机构（分类与类型已上工具栏） */}
@@ -1156,9 +1214,11 @@ export function DailyPage() {
                 />
               ) : (
                 items.map((p, i) => {
-                  // 与上一条日期不同 → 插入粘性日期头
+                  // 与上一条日期不同 → 插入粘性日期头。按相关性排时日期是交错的，
+                  // 分组头会每隔几行冒一个，反而添乱——不分组。
                   const prev = items[i - 1];
-                  const newDay = i === 0 || prev?.feed_date !== p.feed_date;
+                  const newDay =
+                    sortMode !== 'relevance' && (i === 0 || prev?.feed_date !== p.feed_date);
                   return (
                     <Fragment key={p.entry_id}>
                       {newDay && (

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -3262,7 +3262,7 @@ export interface DailyLikeState {
   likers_preview: DailyLiker[];
 }
 
-export type DailySort = 'likes' | 'date';
+export type DailySort = 'likes' | 'date' | 'relevance';
 
 export interface DailyPaperItem {
   entry_id: string;
@@ -3288,6 +3288,9 @@ export interface DailyPaperItem {
   likers_preview: DailyLiker[];
   /** 仅「我赞过的」列表返回 */
   liked_at?: string | null;
+  /** 「与你的库相关」徽章：最像的那个文献库（低于阈值/没有库时为空） */
+  related_library_id?: string | null;
+  related_library_name?: string | null;
 }
 
 export interface DailyPaperDetail extends DailyPaperItem {


### PR DESCRIPTION
Closes #623.

The daily pool keeps its arXiv-subscription ingestion; relevance to the user's own libraries now shapes ranking, computed at read time — no migration, never stale.

- anchor = the centroid of each visible library's member paper vectors; libraries without vectors (or an active embedding space) degrade to inclusion-keyword matching, and vectorless entries take the same keyword path — one contract on both sides
- entry score = max over library anchors, carrying the source library for the badge; fused ranking = 0.7·recency + 0.3·relevance (a deliberately mild weight so old interests can't smother exploration — a full-relevance hit lifts about half the retention window); with no anchors at all, `sort=relevance` falls back to the `date` path byte-identically
- two dialects, one formula: postgres scores fully in SQL (centroid aggregate, `<=>` cosine, fused ORDER BY — no shipping megabytes of vectors per request; smoke-verified end to end against a real pgvector scratch database), sqlite scores in Python for tests/small libraries
- centroid cache in system settings keyed by a fingerprint (space | member count | max member updated_at) — inclusion, removal, status flow, and embedding-model switches all invalidate it on read with zero write-path hooks
- frontend: a plain-language time/relevance sort toggle (hidden during semantic search), a "related to your library" badge linking to the library (threshold-gated; ranking uses the raw score)

6 new tests: centroid + fingerprint invalidation, deterministic ranking, fusion-weight ordering (relevant-3-days-ago > irrelevant-today > relevant-7-days-ago), no-library fallback equality, keyword degradation, badge endpoint.

Verification: clean baseline 1670 passed / 3 pre-existing #581 failures; branch 1676 = baseline + exactly the 6 new tests, same failures — zero new; goldens untouched (daily is outside the golden chains); frontend tsc/build/vitest 158 green.