### PR TITLE
feat: AI-use disclosure statement generator

### DIFF
--- a/src/backend/app/api/manuscripts.py
+++ b/src/backend/app/api/manuscripts.py
@@ -10,6 +10,7 @@ import mimetypes
 import uuid
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime
+from typing import Literal
 from urllib.parse import quote
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
@@ -50,6 +51,7 @@ from app.schemas.manuscript import (
 )
 from app.schemas.review import PaperReviewRequest, PaperReviewSummary
 from app.schemas.voyage import VoyageRead
+from app.services import ai_disclosure as ai_disclosure_service
 from app.services import latex_compile, writing_assist
 from app.services import manuscript_templates as templates_service
 from app.services import manuscript_versions as manuscript_versions_service
@@ -361,6 +363,26 @@ async def get_manuscript(
 ) -> ManuscriptDetail:
     manuscript = await _member_manuscript(session, manuscript_id, user, with_files=True)
     return await _detail(session, manuscript)
+
+
+@router.get("/manuscripts/{manuscript_id}/ai-disclosure")
+async def get_manuscript_ai_disclosure(
+    manuscript_id: uuid.UUID,
+    style: Literal["icmje", "elsevier", "generic"] = "generic",
+    lang: Literal["zh", "en"] = "zh",
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> dict:
+    """AI 使用披露声明（#691）：确定性聚合稿件的 AI 参与留痕并按期刊风格渲染。
+
+    可见性与稿件详情同口径（非本人 404）。零 LLM 调用，facts 一并返回供前端展示。
+    """
+    manuscript = await _member_manuscript(session, manuscript_id, user)
+    facts = await ai_disclosure_service.build_disclosure_facts(
+        session, manuscript_id=manuscript.id
+    )
+    rendered = ai_disclosure_service.render_disclosure(facts, style=style, lang=lang)
+    return {**rendered, "facts": facts}
 
 
 @router.patch("/manuscripts/{manuscript_id}", response_model=ManuscriptRead)

--- a/src/backend/app/api/voyages.py
+++ b/src/backend/app/api/voyages.py
@@ -5,6 +5,7 @@ import json
 import time
 import uuid
 from collections.abc import AsyncIterator
+from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import StreamingResponse
@@ -31,6 +32,7 @@ from app.schemas.voyage import (
     VoyageSkillUse,
     VoyageTerminalLogRead,
 )
+from app.services import ai_disclosure as ai_disclosure_service
 from app.services import experiments as experiments_service
 from app.services import libraries as libraries_service
 from app.services import projects as projects_service
@@ -134,6 +136,24 @@ async def get_voyage(
     if open_ask is not None:
         detail.open_ask = VoyageMessageRead.model_validate(open_ask)
     return detail
+
+
+@router.get("/{voyage_id}/ai-disclosure")
+async def get_voyage_ai_disclosure(
+    voyage_id: uuid.UUID,
+    style: Literal["icmje", "elsevier", "generic"] = "generic",
+    lang: Literal["zh", "en"] = "zh",
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+) -> dict:
+    """AI 使用披露声明（#691）：run 维度的确定性聚合 + 期刊风格渲染。
+
+    可见性与任务详情同口径（can_view_voyage，无权限 404）。
+    """
+    run = await _get_owned_voyage(session, voyage_id, user)
+    facts = await ai_disclosure_service.build_disclosure_facts(session, run_id=run.id)
+    rendered = ai_disclosure_service.render_disclosure(facts, style=style, lang=lang)
+    return {**rendered, "facts": facts}
 
 
 @router.get("/{voyage_id}/logs", response_model=list[VoyageTerminalLogRead])

--- a/src/backend/app/services/ai_disclosure.py
+++ b/src/backend/app/services/ai_disclosure.py
@@ -1,0 +1,510 @@
+"""AI 使用披露声明生成器（#691，设计报告 §18 信任设计③）。
+
+期刊已普遍要求作者披露 AI 使用且禁止 AI 署名——与其让用户凭记忆写声明，不如把
+平台已有的 AI 参与留痕**确定性**聚合成一份可直接粘贴的披露：零 LLM 调用、零新增
+判断，报告说的每一句都能指回一条原始记录（与 discovery_disclosure 同一设计立场）。
+
+数据来源（能取到什么就说什么，取不到的如实标注而不是编造）：
+
+- ``llm_usage``：LLM 路由的持久记账（stage + model + tokens，按 voyage_id 归属）。
+  这是**唯一**能给出真实模型名的持久来源——``llm_call_logs`` 默认关闭且仅留 7 天，
+  不能作披露依据；checkpoint 的 node_usage 只有 token 没有模型名。
+- ``voyage_runs``：run 清单与 kind。稿件与 run 之间没有外键，写作/审稿 run 把
+  manuscript_id 记在 checkpoint.params 里，这里按同一约定反查（含已完结 run——
+  services.manuscripts.find_active_writing_voyage 只查未完结的，不适用于披露）。
+- ``manuscript_file_versions``：origin="pre_ai" 快照是「AI 写入前」的存档，快照数
+  即 AI 写入次数的下界。人工编辑走 CRDT 实时协同、不逐次留版本，因此**无法逐条
+  统计人工编辑**——这一局限直接写进 notes，宁可少说不编造。
+"""
+
+import uuid
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.llm_config import LLMUsage
+from app.models.manuscript import Manuscript, ManuscriptFile, ManuscriptFileVersion
+from app.models.voyage import VoyageRun
+
+FACTS_VERSION = 1
+
+# 与稿件关联的 run kind（都以 checkpoint.params.manuscript_id 回指稿件）
+_MANUSCRIPT_RUN_KINDS = ("paper_writing", "paper_review")
+
+# kind → 生成物类型（确定性映射；未登记的 kind 不猜，outputs 留空）
+_OUTPUTS_BY_KIND: dict[str, tuple[str, ...]] = {
+    "discovery": ("hypothesis_tree", "research_proposal"),
+    "idea_forge": ("research_proposal",),
+    "idea_review": ("research_proposal",),
+    "idea_proposal": ("research_proposal",),
+    "paper_writing": ("manuscript_text",),
+    "paper_review": ("review_feedback",),
+    "presentation": ("slides",),
+    "wiki_bootstrap": ("literature_wiki",),
+    "wiki_ingest": ("literature_wiki",),
+    "daily_feed_sync": ("literature_feed",),
+}
+
+
+async def _runs_for_manuscript(
+    session: AsyncSession, manuscript: Manuscript
+) -> list[VoyageRun]:
+    """稿件关联的全部写作/审稿 run（含已完结；checkpoint.params 回指判归属）。"""
+    stmt = (
+        select(VoyageRun)
+        .where(
+            VoyageRun.project_id == manuscript.project_id,
+            VoyageRun.kind.in_(_MANUSCRIPT_RUN_KINDS),
+        )
+        .order_by(VoyageRun.created_at.asc())
+    )
+    wanted = str(manuscript.id)
+    out: list[VoyageRun] = []
+    for run in (await session.execute(stmt)).scalars().all():
+        params = (run.checkpoint or {}).get("params") or {}
+        if params.get("manuscript_id") == wanted:
+            out.append(run)
+    return out
+
+
+async def _stage_rows_by_run(
+    session: AsyncSession, run_ids: list[uuid.UUID]
+) -> dict[uuid.UUID, list[dict[str, Any]]]:
+    """llm_usage 按 (run, stage, model) 聚合；排序固定保证输出确定性。"""
+    if not run_ids:
+        return {}
+    stmt = (
+        select(
+            LLMUsage.voyage_id,
+            LLMUsage.stage,
+            LLMUsage.model,
+            func.count().label("calls"),
+            func.coalesce(func.sum(LLMUsage.prompt_tokens), 0),
+            func.coalesce(func.sum(LLMUsage.completion_tokens), 0),
+        )
+        .where(LLMUsage.voyage_id.in_(run_ids))
+        .group_by(LLMUsage.voyage_id, LLMUsage.stage, LLMUsage.model)
+        .order_by(LLMUsage.stage.asc(), LLMUsage.model.asc())
+    )
+    out: dict[uuid.UUID, list[dict[str, Any]]] = {}
+    for voyage_id, stage, model, calls, prompt, completion in (
+        await session.execute(stmt)
+    ).all():
+        out.setdefault(voyage_id, []).append(
+            {
+                "stage": stage,
+                "model": model,
+                "calls": int(calls),
+                "prompt_tokens": int(prompt),
+                "completion_tokens": int(completion),
+            }
+        )
+    return out
+
+
+def _run_facts(
+    run: VoyageRun, stage_rows: list[dict[str, Any]], notes: list[str]
+) -> dict[str, Any]:
+    stages = list(stage_rows)
+    if not stages:
+        # 记账明细缺失但 run 累计用量表明确实有 LLM 参与（老 run / 明细被清）：
+        # 模型名取不到就如实标 unknown，绝不猜一个模型名出来
+        usage = run.usage or {}
+        total = int(usage.get("prompt_tokens", 0)) + int(usage.get("completion_tokens", 0))
+        if total > 0:
+            stages = [
+                {
+                    "stage": "unknown",
+                    "model": "unknown",
+                    "calls": 0,
+                    "prompt_tokens": int(usage.get("prompt_tokens", 0)),
+                    "completion_tokens": int(usage.get("completion_tokens", 0)),
+                }
+            ]
+            notes.append(f"model_unrecorded:{run.id}")
+    return {
+        "run_id": str(run.id),
+        "kind": run.kind,
+        "status": run.status,
+        "goal": run.goal,
+        "outputs": list(_OUTPUTS_BY_KIND.get(run.kind, ())),
+        "stages": stages,
+    }
+
+
+async def _editing_facts(
+    session: AsyncSession, manuscript_id: uuid.UUID, notes: list[str]
+) -> dict[str, Any] | None:
+    """稿件版本记录统计。没有任何版本时如实返回 None（notes 记 no_edit_history）。"""
+    stmt = (
+        select(
+            ManuscriptFileVersion.origin,
+            func.count(),
+            func.count(func.distinct(ManuscriptFileVersion.file_id)),
+        )
+        .join(ManuscriptFile, ManuscriptFile.id == ManuscriptFileVersion.file_id)
+        .where(ManuscriptFile.manuscript_id == manuscript_id)
+        .group_by(ManuscriptFileVersion.origin)
+    )
+    rows = {
+        origin: (int(n), int(files))
+        for origin, n, files in (await session.execute(stmt)).all()
+    }
+    if not rows:
+        notes.append("no_edit_history")
+        return None
+    ai_snapshots, ai_files = rows.get("pre_ai", (0, 0))
+    # 人工编辑（CRDT 实时协同）不逐次留版本，只能给出 AI 写入快照数——如实说明
+    notes.append("human_edits_not_itemized")
+    return {
+        "ai_write_snapshots": ai_snapshots,
+        "files_with_ai_writes": ai_files,
+        "compile_snapshots": rows.get("compile", (0, 0))[0],
+        "restore_snapshots": rows.get("pre_restore", (0, 0))[0],
+    }
+
+
+async def build_disclosure_facts(
+    session: AsyncSession,
+    *,
+    manuscript_id: uuid.UUID | None = None,
+    run_id: uuid.UUID | None = None,
+) -> dict[str, Any]:
+    """AI 参与事实的确定性聚合（权限判定在 API 层，这里只管拼事实）。
+
+    manuscript_id / run_id 二选一。同一份数据两次调用输出一致（排序全部固定），
+    供渲染层与前端直接消费。
+    """
+    if (manuscript_id is None) == (run_id is None):
+        raise ValueError("必须且只能提供 manuscript_id 或 run_id 之一")
+
+    notes: list[str] = []
+    editing: dict[str, Any] | None = None
+
+    if manuscript_id is not None:
+        manuscript = await session.get(Manuscript, manuscript_id)
+        if manuscript is None:
+            raise ValueError("manuscript 不存在")
+        subject = {
+            "type": "manuscript",
+            "id": str(manuscript.id),
+            "title": manuscript.title,
+        }
+        runs = await _runs_for_manuscript(session, manuscript)
+        if not runs:
+            notes.append("no_runs_recorded")
+        editing = await _editing_facts(session, manuscript.id, notes)
+    else:
+        run = await session.get(VoyageRun, run_id)
+        if run is None:
+            raise ValueError("voyage run 不存在")
+        subject = {
+            "type": "voyage",
+            "id": str(run.id),
+            "title": run.goal or run.kind,
+        }
+        runs = [run]
+
+    rows_by_run = await _stage_rows_by_run(session, [r.id for r in runs])
+    run_facts = [_run_facts(r, rows_by_run.get(r.id, []), notes) for r in runs]
+
+    models: set[str] = set()
+    stages: set[str] = set()
+    totals = {"prompt_tokens": 0, "completion_tokens": 0, "calls": 0}
+    for rf in run_facts:
+        for row in rf["stages"]:
+            if row["model"] != "unknown":
+                models.add(row["model"])
+            if row["stage"] != "unknown":
+                stages.add(row["stage"])
+            totals["prompt_tokens"] += row["prompt_tokens"]
+            totals["completion_tokens"] += row["completion_tokens"]
+            totals["calls"] += row["calls"]
+
+    ai_used = any(rf["stages"] for rf in run_facts) or bool(
+        editing and editing["ai_write_snapshots"] > 0
+    )
+
+    return {
+        "version": FACTS_VERSION,
+        "subject": subject,
+        "ai_used": ai_used,
+        "runs": run_facts,
+        "models": sorted(models),
+        "stages": sorted(stages),
+        "totals": totals,
+        "editing": editing,
+        "notes": notes,
+    }
+
+
+# ---- 声明渲染（纯函数，模板硬编码） ----
+
+STYLES = ("icmje", "elsevier", "generic")
+LANGS = ("zh", "en")
+
+# 环节 → 用途措辞（未登记的环节直接用环节名，不猜用途）
+_STAGE_PURPOSES: dict[str, dict[str, str]] = {
+    "writing": {"zh": "起草稿件章节文本", "en": "drafting manuscript section text"},
+    "review": {"zh": "生成审稿意见", "en": "generating review feedback"},
+    "discovery_plan": {"zh": "规划文献探索", "en": "planning the literature exploration"},
+    "hyp_generate": {"zh": "生成研究假设", "en": "generating research hypotheses"},
+    "hyp_ground": {"zh": "为假设检索文献依据", "en": "grounding hypotheses in the literature"},
+    "hyp_novelty": {"zh": "评估假设新颖性", "en": "assessing hypothesis novelty"},
+    "hyp_feasibility": {"zh": "评估假设可行性", "en": "assessing hypothesis feasibility"},
+    "hyp_compare": {"zh": "假设两两对比评审", "en": "pairwise comparison of hypotheses"},
+    "proposal": {"zh": "撰写研究方案", "en": "drafting the research proposal"},
+    "librarian": {
+        "zh": "组织演示与资料内容",
+        "en": "organizing presentation and reference content",
+    },
+    "embedding": {"zh": "文献向量化检索", "en": "embedding-based literature retrieval"},
+    "rerank": {"zh": "检索结果重排", "en": "reranking retrieved results"},
+}
+
+_OUTPUT_LABELS: dict[str, dict[str, str]] = {
+    "hypothesis_tree": {"zh": "假设树", "en": "hypothesis tree"},
+    "research_proposal": {"zh": "研究方案", "en": "research proposal"},
+    "manuscript_text": {"zh": "稿件文本", "en": "manuscript text"},
+    "review_feedback": {"zh": "审稿意见", "en": "review feedback"},
+    "slides": {"zh": "演示图文", "en": "presentation slides"},
+    "literature_wiki": {"zh": "文献综述 wiki", "en": "literature wiki"},
+    "literature_feed": {"zh": "文献动态", "en": "literature feed"},
+}
+
+# notes 代码 → 如实说明（进附录，让读者知道口径边界）
+_NOTE_LABELS: dict[str, dict[str, str]] = {
+    "no_runs_recorded": {
+        "zh": "平台未记录到与本稿件关联的 AI 任务。",
+        "en": "No AI runs associated with this manuscript were recorded on the platform.",
+    },
+    "no_edit_history": {
+        "zh": "本稿件没有版本记录，无法统计编辑痕迹。",
+        "en": "This manuscript has no version history; editing traces cannot be reported.",
+    },
+    "human_edits_not_itemized": {
+        "zh": "人工编辑经实时协同进行、不逐次留版本，故仅统计 AI 写入快照数，未逐条统计人工编辑。",
+        "en": (
+            "Human edits happen via real-time collaboration without per-edit versioning; "
+            "only AI-write snapshots are counted, individual human edits are not itemized."
+        ),
+    },
+    "model_unrecorded": {
+        "zh": "部分任务的用量明细缺失，模型名如实标注为 unknown。",
+        "en": (
+            "Usage details are missing for some runs; "
+            "the model name is honestly reported as unknown."
+        ),
+    },
+}
+
+# 三家风格模板。措辞依据：
+# - icmje：ICMJE Recommendations（作者应在投稿时披露是否使用 AI 辅助技术及其用途；
+#   作者对内容负全责；AI 不得署名，因其无法对工作负责）。
+# - elsevier：Elsevier 生成式 AI 作者政策（声明段落置于稿末参考文献前的独立小节，
+#   固定句式 "During the preparation of this work the author(s) used X in order to Y.
+#   After using this tool/service, the author(s) reviewed and edited …"）。
+# - generic：中性措辞，适配未指定风格的场合。
+# {tools} = 模型清单；{purposes} = 用途清单。
+_TEMPLATES: dict[tuple[str, str], dict[str, str]] = {
+    ("icmje", "en"): {
+        "used": (
+            "In accordance with the ICMJE recommendations, the authors disclose the use of "
+            "artificial intelligence (AI)-assisted technologies in the preparation of this work. "
+            "The following tools were used: {tools}. They were used for: {purposes}. "
+            "The authors reviewed and edited the AI-assisted material and take full "
+            "responsibility for the integrity and accuracy of the content of this work. "
+            "No AI tool is listed as an author, as AI cannot be accountable for the work."
+        ),
+        "unused": (
+            "In accordance with the ICMJE recommendations, the authors declare that, based on "
+            "the platform's recorded activity, no artificial intelligence (AI)-assisted "
+            "technologies were used in the preparation of this work."
+        ),
+    },
+    ("icmje", "zh"): {
+        "used": (
+            "按照 ICMJE 建议，作者披露本研究工作在准备过程中使用了人工智能（AI）辅助技术。"
+            "所用工具：{tools}。用途：{purposes}。"
+            "作者已审阅并编辑 AI 辅助生成的内容，对本文内容的完整性与准确性负全部责任；"
+            "未将任何 AI 工具列为作者——AI 无法对研究工作负责。"
+        ),
+        "unused": (
+            "按照 ICMJE 建议，作者声明：根据平台记录，本研究工作的准备过程中"
+            "未使用人工智能（AI）辅助技术。"
+        ),
+    },
+    ("elsevier", "en"): {
+        "used": (
+            "Declaration of generative AI and AI-assisted technologies in the writing process.\n\n"
+            "During the preparation of this work the author(s) used {tools} in order to "
+            "{purposes}. After using these tools/services, the author(s) reviewed and edited "
+            "the content as needed and take(s) full responsibility for the content of the "
+            "published article.\n\n"
+            "(Per Elsevier policy, place this statement in a dedicated section at the end of "
+            "the manuscript, before the references.)"
+        ),
+        "unused": (
+            "Declaration of generative AI and AI-assisted technologies in the writing process.\n\n"
+            "Based on the platform's recorded activity, the author(s) did not use generative AI "
+            "or AI-assisted technologies during the preparation of this work."
+        ),
+    },
+    ("elsevier", "zh"): {
+        "used": (
+            "关于写作过程中使用生成式 AI 与 AI 辅助技术的声明。\n\n"
+            "在本研究工作的准备过程中，作者使用了 {tools}，用于{purposes}。"
+            "使用上述工具/服务后，作者已按需审阅并编辑相关内容，"
+            "并对发表文章的内容负全部责任。\n\n"
+            "（按 Elsevier 政策，本段应置于稿件末尾、参考文献之前的独立小节。）"
+        ),
+        "unused": (
+            "关于写作过程中使用生成式 AI 与 AI 辅助技术的声明。\n\n"
+            "根据平台记录，作者在本研究工作的准备过程中未使用生成式 AI 或 AI 辅助技术。"
+        ),
+    },
+    ("generic", "en"): {
+        "used": (
+            "AI Use Disclosure. Parts of this work were prepared with the assistance of AI "
+            "tools: {tools}. These tools were used for: {purposes}. All AI-assisted output "
+            "was reviewed by the authors, who take full responsibility for the final content."
+        ),
+        "unused": (
+            "AI Use Disclosure. Based on the platform's recorded activity, no AI tools were "
+            "used in the preparation of this work."
+        ),
+    },
+    ("generic", "zh"): {
+        "used": (
+            "AI 使用披露。本研究工作的部分内容在 AI 工具辅助下完成，所用工具：{tools}。"
+            "用途：{purposes}。所有 AI 辅助产出均经作者审阅，作者对最终内容负全部责任。"
+        ),
+        "unused": "AI 使用披露。根据平台记录，本研究工作的准备过程中未使用 AI 工具。",
+    },
+}
+
+
+def _join(items: list[str], lang: str) -> str:
+    return "、".join(items) if lang == "zh" else ", ".join(items)
+
+
+def _tools_clause(facts: dict[str, Any], lang: str) -> str:
+    if facts["models"]:
+        return _join(facts["models"], lang)
+    # 有 AI 参与但模型名没记到账上：如实说「未记录到模型名」而不是编一个
+    if lang == "zh":
+        return "未记录到具体模型名的 AI 模型"
+    return "an AI model whose name was not recorded"
+
+
+def _purposes_clause(facts: dict[str, Any], lang: str) -> str:
+    purposes: list[str] = []
+    for stage in facts["stages"]:
+        label = _STAGE_PURPOSES.get(stage, {}).get(lang)
+        purposes.append(label if label else stage)
+    if not purposes:
+        return "未记录到具体用途" if lang == "zh" else "purposes that were not recorded in detail"
+    return _join(purposes, lang)
+
+
+def _note_label(code: str, lang: str) -> str:
+    # model_unrecorded 带 run_id 后缀，按前缀查文案
+    key = code.split(":", 1)[0]
+    label = _NOTE_LABELS.get(key, {}).get(lang)
+    return label if label else code
+
+
+def _appendix(facts: dict[str, Any], lang: str) -> str:
+    zh = lang == "zh"
+    lines: list[str] = []
+    lines.append("## AI 参与明细" if zh else "## AI participation details")
+    lines.append("")
+    if facts["runs"]:
+        header = (
+            "| 任务 | 类型 | 生成物 | 环节 | 模型 | 调用数 | 输入 tokens | 输出 tokens |"
+            if zh
+            else (
+                "| Run | Kind | Outputs | Stage | Model "
+                "| Calls | Prompt tokens | Completion tokens |"
+            )
+        )
+        lines.append(header)
+        lines.append("|---|---|---|---|---|---|---|---|")
+        for rf in facts["runs"]:
+            outputs = (
+                _join([_OUTPUT_LABELS.get(o, {}).get(lang, o) for o in rf["outputs"]], lang)
+                or "-"
+            )
+            if rf["stages"]:
+                for row in rf["stages"]:
+                    lines.append(
+                        f"| {rf['run_id']} | {rf['kind']} | {outputs} | {row['stage']} "
+                        f"| {row['model']} | {row['calls'] or '-'} "
+                        f"| {row['prompt_tokens']} | {row['completion_tokens']} |"
+                    )
+            else:
+                lines.append(
+                    f"| {rf['run_id']} | {rf['kind']} | {outputs} | - | - | - | - | - |"
+                )
+        totals = facts["totals"]
+        lines.append("")
+        lines.append(
+            f"合计：{totals['calls']} 次调用，输入 {totals['prompt_tokens']} tokens，"
+            f"输出 {totals['completion_tokens']} tokens。"
+            if zh
+            else f"Total: {totals['calls']} calls, {totals['prompt_tokens']} prompt tokens, "
+            f"{totals['completion_tokens']} completion tokens."
+        )
+    else:
+        lines.append(
+            "（未记录到关联的 AI 任务。）" if zh else "(No associated AI runs were recorded.)"
+        )
+
+    editing = facts.get("editing")
+    if editing is not None:
+        lines.append("")
+        lines.append("### 编辑痕迹" if zh else "### Editing traces")
+        lines.append("")
+        if zh:
+            lines.append(
+                f"- AI 写入快照：{editing['ai_write_snapshots']} 次"
+                f"（涉及 {editing['files_with_ai_writes']} 个文件）"
+            )
+            lines.append(f"- 编译快照：{editing['compile_snapshots']} 次")
+            lines.append(f"- 版本回退快照：{editing['restore_snapshots']} 次")
+        else:
+            lines.append(
+                f"- AI-write snapshots: {editing['ai_write_snapshots']} "
+                f"(across {editing['files_with_ai_writes']} files)"
+            )
+            lines.append(f"- Compile snapshots: {editing['compile_snapshots']}")
+            lines.append(f"- Restore snapshots: {editing['restore_snapshots']}")
+
+    if facts["notes"]:
+        lines.append("")
+        lines.append("### 记录口径说明" if zh else "### Notes on data coverage")
+        lines.append("")
+        seen: set[str] = set()
+        for code in facts["notes"]:
+            label = _note_label(code, lang)
+            if label not in seen:
+                seen.add(label)
+                lines.append(f"- {label}")
+    return "\n".join(lines)
+
+
+def render_disclosure(facts: dict[str, Any], style: str, lang: str) -> dict[str, str]:
+    """facts → {statement, appendix}（纯文本段落 + Markdown 附录，纯函数）。"""
+    if style not in STYLES:
+        raise ValueError(f"unknown style: {style}")
+    if lang not in LANGS:
+        raise ValueError(f"unknown lang: {lang}")
+    template = _TEMPLATES[(style, lang)]
+    if facts["ai_used"]:
+        statement = template["used"].format(
+            tools=_tools_clause(facts, lang), purposes=_purposes_clause(facts, lang)
+        )
+    else:
+        statement = template["unused"]
+    return {"statement": statement, "appendix": _appendix(facts, lang)}

--- a/src/backend/tests/test_ai_disclosure.py
+++ b/src/backend/tests/test_ai_disclosure.py
@@ -1,0 +1,330 @@
+"""AI 使用披露声明生成器（#691）：facts 聚合确定性 + 三模板×两语言渲染 + 端点权限。
+
+facts 全部由既有留痕（llm_usage / voyage_runs / manuscript_file_versions）确定性
+拼出，测试据此断言：同一份数据两次聚合逐字节一致；取不到的面（模型名、编辑记录）
+如实标注而不是编造。
+"""
+
+import uuid
+
+import pytest
+
+from app.core.db import get_sessionmaker
+from app.models.llm_config import LLMUsage
+from app.models.manuscript import Manuscript, ManuscriptFile, ManuscriptFileVersion
+from app.models.voyage import VoyageRun
+from app.services import ai_disclosure
+from tests.conftest import register_and_login
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _setup_project(client, email="disclose@example.com"):
+    token = await register_and_login(client, email)
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = await client.post("/api/projects", json={"name": "disclosure-proj"}, headers=headers)
+    assert resp.status_code == 201
+    return resp.json()["id"], headers
+
+
+async def _seed_manuscript(project_id: str, title="Graph Retrieval") -> uuid.UUID:
+    async with get_sessionmaker()() as session:
+        ms = Manuscript(project_id=uuid.UUID(project_id), title=title, template="neurips2026")
+        session.add(ms)
+        await session.commit()
+        return ms.id
+
+
+async def _seed_run(
+    project_id: str,
+    *,
+    kind: str,
+    manuscript_id: uuid.UUID | None = None,
+    usage: dict | None = None,
+    status: str = "done",
+) -> uuid.UUID:
+    checkpoint = (
+        {"params": {"manuscript_id": str(manuscript_id)}} if manuscript_id else {"params": {}}
+    )
+    async with get_sessionmaker()() as session:
+        run = VoyageRun(
+            kind=kind,
+            status=status,
+            goal=f"{kind} run",
+            project_id=uuid.UUID(project_id),
+            checkpoint=checkpoint,
+            usage=usage,
+        )
+        session.add(run)
+        await session.commit()
+        return run.id
+
+
+async def _seed_usage(voyage_id: uuid.UUID, rows: list[tuple[str, str, int, int]]) -> None:
+    """rows: (stage, model, prompt_tokens, completion_tokens)。"""
+    async with get_sessionmaker()() as session:
+        for stage, model, prompt, completion in rows:
+            session.add(
+                LLMUsage(
+                    voyage_id=voyage_id,
+                    stage=stage,
+                    model=model,
+                    prompt_tokens=prompt,
+                    completion_tokens=completion,
+                )
+            )
+        await session.commit()
+
+
+async def _seed_versions(manuscript_id: uuid.UUID, origins: list[str]) -> None:
+    async with get_sessionmaker()() as session:
+        file = ManuscriptFile(
+            manuscript_id=manuscript_id, path="main.tex", content="\\section{Intro}"
+        )
+        session.add(file)
+        await session.flush()
+        for seq, origin in enumerate(origins, start=1):
+            session.add(
+                ManuscriptFileVersion(
+                    file_id=file.id, seq=seq, origin=origin, content=f"v{seq}"
+                )
+            )
+        await session.commit()
+
+
+# ---- facts 聚合 ----
+
+
+async def test_facts_manuscript_with_runs_and_versions(client):
+    """discovery + 写作 run + 版本记录齐备的稿件：全溯源面都能取到，两次聚合一致。"""
+    project_id, _ = await _setup_project(client)
+    ms_id = await _seed_manuscript(project_id)
+    writing_run = await _seed_run(project_id, kind="paper_writing", manuscript_id=ms_id)
+    # 同课题另有一个 discovery run（不指向该稿件）：不得混进稿件披露
+    stray = await _seed_run(project_id, kind="discovery")
+    await _seed_usage(
+        writing_run,
+        [("writing", "fake-writer", 100, 40), ("writing", "fake-writer", 50, 10)],
+    )
+    await _seed_usage(stray, [("hyp_generate", "fake-hyp", 10, 5)])
+    await _seed_versions(ms_id, ["pre_ai", "pre_ai", "compile"])
+
+    async with get_sessionmaker()() as session:
+        facts = await ai_disclosure.build_disclosure_facts(session, manuscript_id=ms_id)
+        again = await ai_disclosure.build_disclosure_facts(session, manuscript_id=ms_id)
+    assert facts == again  # 确定性：同一数据两次聚合逐项一致
+    assert facts["subject"]["type"] == "manuscript"
+    assert facts["ai_used"] is True
+    assert [r["run_id"] for r in facts["runs"]] == [str(writing_run)]
+    run = facts["runs"][0]
+    assert run["kind"] == "paper_writing"
+    assert run["outputs"] == ["manuscript_text"]
+    # 同 stage+model 聚成一行，token/调用数求和
+    assert run["stages"] == [
+        {
+            "stage": "writing",
+            "model": "fake-writer",
+            "calls": 2,
+            "prompt_tokens": 150,
+            "completion_tokens": 50,
+        }
+    ]
+    assert facts["models"] == ["fake-writer"]
+    assert facts["totals"] == {"prompt_tokens": 150, "completion_tokens": 50, "calls": 2}
+    assert facts["editing"] == {
+        "ai_write_snapshots": 2,
+        "files_with_ai_writes": 1,
+        "compile_snapshots": 1,
+        "restore_snapshots": 0,
+    }
+    assert "human_edits_not_itemized" in facts["notes"]
+
+
+async def test_facts_discovery_run(client):
+    project_id, _ = await _setup_project(client, email="disclose2@example.com")
+    run_id = await _seed_run(project_id, kind="discovery")
+    await _seed_usage(
+        run_id,
+        [
+            ("hyp_generate", "fake-mid", 200, 80),
+            ("hyp_compare", "fake-short", 30, 10),
+            ("discovery_plan", "fake-mid", 50, 20),
+        ],
+    )
+    async with get_sessionmaker()() as session:
+        facts = await ai_disclosure.build_disclosure_facts(session, run_id=run_id)
+    assert facts["subject"]["type"] == "voyage"
+    assert facts["runs"][0]["outputs"] == ["hypothesis_tree", "research_proposal"]
+    # stage 行按 (stage, model) 排序，输出稳定
+    assert [r["stage"] for r in facts["runs"][0]["stages"]] == [
+        "discovery_plan",
+        "hyp_compare",
+        "hyp_generate",
+    ]
+    assert facts["models"] == ["fake-mid", "fake-short"]
+    assert facts["stages"] == ["discovery_plan", "hyp_compare", "hyp_generate"]
+
+
+async def test_facts_manuscript_without_ai(client):
+    """无 run、无版本记录：如实说明未使用，而不是硬凑一个披露。"""
+    project_id, _ = await _setup_project(client, email="disclose3@example.com")
+    ms_id = await _seed_manuscript(project_id)
+    async with get_sessionmaker()() as session:
+        facts = await ai_disclosure.build_disclosure_facts(session, manuscript_id=ms_id)
+    assert facts["ai_used"] is False
+    assert facts["runs"] == []
+    assert facts["editing"] is None
+    assert "no_runs_recorded" in facts["notes"]
+    assert "no_edit_history" in facts["notes"]
+
+    zh = ai_disclosure.render_disclosure(facts, "generic", "zh")
+    assert "未使用 AI 工具" in zh["statement"]
+    en = ai_disclosure.render_disclosure(facts, "icmje", "en")
+    assert "no artificial intelligence (AI)-assisted technologies were used" in en["statement"]
+
+
+async def test_facts_model_unrecorded(client):
+    """记账明细缺失但 run 累计用量非零：模型名如实标 unknown，不编造。"""
+    project_id, _ = await _setup_project(client, email="disclose4@example.com")
+    run_id = await _seed_run(
+        project_id,
+        kind="discovery",
+        usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    )
+    async with get_sessionmaker()() as session:
+        facts = await ai_disclosure.build_disclosure_facts(session, run_id=run_id)
+    assert facts["ai_used"] is True
+    assert facts["models"] == []
+    assert facts["runs"][0]["stages"][0]["model"] == "unknown"
+    assert f"model_unrecorded:{run_id}" in facts["notes"]
+    rendered = ai_disclosure.render_disclosure(facts, "generic", "en")
+    assert "an AI model whose name was not recorded" in rendered["statement"]
+    rendered = ai_disclosure.render_disclosure(facts, "generic", "zh")
+    assert "未记录到具体模型名" in rendered["statement"]
+
+
+# ---- 三模板 × 两语言渲染 ----
+
+
+def _sample_facts() -> dict:
+    return {
+        "version": 1,
+        "subject": {"type": "manuscript", "id": "x", "title": "T"},
+        "ai_used": True,
+        "runs": [
+            {
+                "run_id": "r1",
+                "kind": "paper_writing",
+                "status": "done",
+                "goal": "写稿",
+                "outputs": ["manuscript_text"],
+                "stages": [
+                    {
+                        "stage": "writing",
+                        "model": "fake-writer",
+                        "calls": 3,
+                        "prompt_tokens": 100,
+                        "completion_tokens": 30,
+                    }
+                ],
+            }
+        ],
+        "models": ["fake-writer"],
+        "stages": ["writing"],
+        "totals": {"prompt_tokens": 100, "completion_tokens": 30, "calls": 3},
+        "editing": None,
+        "notes": [],
+    }
+
+
+async def test_render_all_styles_and_langs():
+    """快照式关键句断言：三家模板的标志性措辞 + 模型名 + 附录明细齐备。"""
+    facts = _sample_facts()
+    key_sentences = {
+        ("icmje", "en"): [
+            "ICMJE recommendations",
+            "The following tools were used: fake-writer",
+            "take full responsibility",
+            "No AI tool is listed as an author",
+        ],
+        ("icmje", "zh"): ["ICMJE 建议", "fake-writer", "负全部责任", "未将任何 AI 工具列为作者"],
+        ("elsevier", "en"): [
+            "Declaration of generative AI and AI-assisted technologies",
+            "During the preparation of this work the author(s) used fake-writer",
+            "reviewed and edited",
+            "before the references",
+        ],
+        ("elsevier", "zh"): ["生成式 AI 与 AI 辅助技术的声明", "fake-writer", "参考文献之前"],
+        ("generic", "en"): ["AI Use Disclosure", "fake-writer", "full responsibility"],
+        ("generic", "zh"): ["AI 使用披露", "fake-writer", "负全部责任"],
+    }
+    for (style, lang), expected in key_sentences.items():
+        out = ai_disclosure.render_disclosure(facts, style, lang)
+        for sentence in expected:
+            assert sentence in out["statement"], (style, lang, sentence)
+        # 附录：明细表含 run 与模型
+        assert "r1" in out["appendix"]
+        assert "fake-writer" in out["appendix"]
+        assert out["appendix"].startswith("## ")
+
+
+async def test_render_rejects_unknown_style_and_lang():
+    facts = _sample_facts()
+    with pytest.raises(ValueError):
+        ai_disclosure.render_disclosure(facts, "nature", "en")
+    with pytest.raises(ValueError):
+        ai_disclosure.render_disclosure(facts, "icmje", "fr")
+
+
+# ---- 端点与权限 ----
+
+
+async def test_manuscript_disclosure_endpoint(client):
+    project_id, headers = await _setup_project(client, email="disclose5@example.com")
+    ms_id = await _seed_manuscript(project_id)
+    run_id = await _seed_run(project_id, kind="paper_writing", manuscript_id=ms_id)
+    await _seed_usage(run_id, [("writing", "fake-writer", 10, 5)])
+
+    resp = await client.get(
+        f"/api/manuscripts/{ms_id}/ai-disclosure?style=elsevier&lang=en", headers=headers
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert set(data) == {"statement", "appendix", "facts"}
+    assert "fake-writer" in data["statement"]
+    assert data["facts"]["ai_used"] is True
+
+    # 非法 style 被 422 顶回（Literal 校验）
+    resp = await client.get(
+        f"/api/manuscripts/{ms_id}/ai-disclosure?style=nature", headers=headers
+    )
+    assert resp.status_code == 422
+
+    # 非课题主人 404（与稿件详情同口径，不泄露存在性）
+    other = await register_and_login(client, "disclose5b@example.com")
+    resp = await client.get(
+        f"/api/manuscripts/{ms_id}/ai-disclosure",
+        headers={"Authorization": f"Bearer {other}"},
+    )
+    assert resp.status_code == 404
+
+
+async def test_voyage_disclosure_endpoint(client):
+    project_id, headers = await _setup_project(client, email="disclose6@example.com")
+    run_id = await _seed_run(project_id, kind="discovery")
+    await _seed_usage(run_id, [("hyp_generate", "fake-mid", 20, 8)])
+
+    resp = await client.get(
+        f"/api/voyages/{run_id}/ai-disclosure?style=icmje&lang=zh", headers=headers
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "ICMJE 建议" in data["statement"]
+    assert data["facts"]["subject"]["type"] == "voyage"
+
+    other = await register_and_login(client, "disclose6b@example.com")
+    resp = await client.get(
+        f"/api/voyages/{run_id}/ai-disclosure",
+        headers={"Authorization": f"Bearer {other}"},
+    )
+    assert resp.status_code == 404

--- a/src/frontend/src/components/ui/AiDisclosureModal.tsx
+++ b/src/frontend/src/components/ui/AiDisclosureModal.tsx
@@ -1,0 +1,160 @@
+/* AI 使用披露声明弹窗（#691，设计报告 §18 信任设计③）。
+
+   期刊要求作者披露 AI 使用且禁止 AI 署名——把这份合规负担做成一键生成：
+   声明由后端从既有留痕确定性聚合渲染（零 LLM），前端只做风格/语言切换、
+   复制与附录展开。稿件详情与 discovery 任务详情共用本组件（subject 二选一）。 */
+
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { api, type AiDisclosureStyle } from '../../lib/api';
+import { getLang, tr, type Lang } from '../../lib/i18n';
+import { copyText } from '../../lib/clipboard';
+import { Markdown } from '../../lib/markdown';
+import { toast } from './Toast';
+import { Modal } from './Modal';
+import { Segmented } from './Segmented';
+
+export interface AiDisclosureModalProps {
+  open: boolean;
+  onClose: () => void;
+  /** 披露对象：稿件或任务（二选一，路由到对应端点）。 */
+  subject: { kind: 'manuscript'; id: string } | { kind: 'voyage'; id: string };
+}
+
+export function AiDisclosureModal({ open, onClose, subject }: AiDisclosureModalProps) {
+  const [style, setStyle] = useState<AiDisclosureStyle>('generic');
+  // 声明语言独立于界面语言（界面中文也可能要投英文期刊），初始跟随界面
+  const [lang, setLang] = useState<Lang>(getLang());
+  const [showAppendix, setShowAppendix] = useState(false);
+
+  const query = useQuery({
+    queryKey: ['ai-disclosure', subject.kind, subject.id, style, lang],
+    queryFn: () =>
+      subject.kind === 'manuscript'
+        ? api.getManuscriptAiDisclosure(subject.id, style, lang)
+        : api.getVoyageAiDisclosure(subject.id, style, lang),
+    enabled: open,
+    staleTime: 60_000,
+  });
+
+  const data = query.data;
+
+  // 顶层常量禁止 tr（语言切换不会重估），风格选项在渲染时构造
+  const styleOptions = [
+    { v: 'icmje' as AiDisclosureStyle, label: 'ICMJE' },
+    { v: 'elsevier' as AiDisclosureStyle, label: 'Elsevier' },
+    { v: 'generic' as AiDisclosureStyle, label: tr('通用', 'Generic') },
+  ];
+
+  const copy = async (text: string) => {
+    if (await copyText(text)) toast(tr('已复制', 'Copied'));
+    else toast(tr('复制失败', 'Copy failed'), 'error');
+  };
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      width={640}
+      title={tr('AI 披露声明', 'AI use disclosure')}
+      sub={tr(
+        '按平台记录如实生成，可直接粘贴到投稿声明中',
+        'Generated verbatim from platform records; paste into your submission statement',
+      )}
+      footer={
+        <>
+          <button className="btn btn-ghost sm" onClick={onClose}>
+            {tr('关闭', 'Close')}
+          </button>
+          <button
+            className="btn btn-primary sm"
+            disabled={!data}
+            onClick={() => data && copy(data.statement)}
+          >
+            {tr('复制声明', 'Copy statement')}
+          </button>
+        </>
+      }
+    >
+      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 12 }}>
+        <Segmented options={styleOptions} value={style} onChange={setStyle} />
+        <Segmented
+          options={[
+            { v: 'zh' as Lang, label: '中文' },
+            { v: 'en' as Lang, label: 'English' },
+          ]}
+          value={lang}
+          onChange={setLang}
+        />
+      </div>
+
+      {query.isLoading && (
+        <div style={{ color: 'var(--text-3)', padding: '16px 0' }}>
+          {tr('生成中…', 'Generating…')}
+        </div>
+      )}
+      {query.isError && (
+        <div style={{ color: 'var(--danger, #c00)', padding: '16px 0' }}>
+          {tr('披露声明生成失败', 'Failed to generate the disclosure')}
+        </div>
+      )}
+      {data && (
+        <>
+          <div
+            style={{
+              whiteSpace: 'pre-wrap',
+              background: 'var(--surface-2)',
+              border: '0.5px solid var(--border-2)',
+              borderRadius: 8,
+              padding: 12,
+              fontSize: 13,
+              lineHeight: 1.7,
+              userSelect: 'text',
+            }}
+          >
+            {data.statement}
+          </div>
+
+          {!data.facts.ai_used && (
+            <div style={{ color: 'var(--text-3)', fontSize: 12, marginTop: 8 }}>
+              {tr(
+                '平台未记录到 AI 参与痕迹，声明如实说明未使用。',
+                'No AI participation was recorded; the statement honestly reports none was used.',
+              )}
+            </div>
+          )}
+
+          <div style={{ marginTop: 12 }}>
+            <button
+              className="btn btn-ghost sm"
+              onClick={() => setShowAppendix((v) => !v)}
+            >
+              {showAppendix
+                ? tr('收起明细附录', 'Hide appendix')
+                : tr('展开明细附录', 'Show appendix')}
+            </button>
+            {showAppendix && (
+              <div
+                style={{
+                  marginTop: 8,
+                  overflowX: 'auto',
+                  border: '0.5px solid var(--border-2)',
+                  borderRadius: 8,
+                  padding: 12,
+                  fontSize: 12,
+                }}
+              >
+                <Markdown source={data.appendix} />
+                <div style={{ marginTop: 8 }}>
+                  <button className="btn btn-ghost sm" onClick={() => copy(data.appendix)}>
+                    {tr('复制附录 Markdown', 'Copy appendix Markdown')}
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        </>
+      )}
+    </Modal>
+  );
+}

--- a/src/frontend/src/features/voyages/discovery.tsx
+++ b/src/frontend/src/features/voyages/discovery.tsx
@@ -5,6 +5,7 @@ import { Icon } from '../../components/ui/Icon';
 import { Modal } from '../../components/ui/Modal';
 import { FormField } from '../../components/ui/FormField';
 import { Segmented } from '../../components/ui/Segmented';
+import { AiDisclosureModal } from '../../components/ui/AiDisclosureModal';
 import { toast } from '../../components/ui/Toast';
 import {
   api,
@@ -1026,6 +1027,8 @@ function DisclosureView({ disclosure, active }: { disclosure: DisclosureData | n
 export function DiscoveryPanel({ voyage }: { voyage: VoyageRead }) {
   const active = !VOYAGE_TERMINAL.has(voyage.status);
   const [view, setView] = useState<'tree' | 'report' | 'disclosure'>('tree');
+  // AI 披露声明弹窗（#691）：与「过程记录」互补——那边是探索过程，这边是投稿声明
+  const [disclosureModalOpen, setDisclosureModalOpen] = useState(false);
   const { data } = useQuery({
     queryKey: ['hypothesis-tree', voyage.id],
     queryFn: () => api.listHypothesisTree(voyage.id),
@@ -1065,7 +1068,10 @@ export function DiscoveryPanel({ voyage }: { voyage: VoyageRead }) {
             {nodes.length} {tr('个节点', 'nodes')}
           </span>
         )}
-        <span style={{ marginLeft: 'auto' }}>
+        <span style={{ marginLeft: 'auto', display: 'inline-flex', gap: 8, alignItems: 'center' }}>
+          <button className="btn btn-ghost sm" onClick={() => setDisclosureModalOpen(true)}>
+            {tr('AI 披露声明', 'AI disclosure')}
+          </button>
           <Segmented
             options={[
               { v: 'tree' as const, label: tr('树视图', 'Tree') },
@@ -1090,6 +1096,11 @@ export function DiscoveryPanel({ voyage }: { voyage: VoyageRead }) {
       ) : (
         <ReportView nodes={nodes} active={active} pruneRecords={pruneRecords} />
       )}
+      <AiDisclosureModal
+        open={disclosureModalOpen}
+        onClose={() => setDisclosureModalOpen(false)}
+        subject={{ kind: 'voyage', id: voyage.id }}
+      />
     </div>
   );
 }

--- a/src/frontend/src/features/writer/WriterEditorPage.tsx
+++ b/src/frontend/src/features/writer/WriterEditorPage.tsx
@@ -29,6 +29,7 @@ import { DraftModal } from './DraftModal';
 import { OutlinePanel } from './OutlinePanel';
 import { AssistPanel, type AssistMode } from './AssistPanel';
 import { HistoryModal } from './HistoryModal';
+import { AiDisclosureModal } from '../../components/ui/AiDisclosureModal';
 import { colorForUser, ruleText, sectionText, type AiWritingState } from './shared';
 
 /* ============================================================
@@ -592,6 +593,7 @@ export function WriterEditorPage() {
 
   // —— 抽屉 / Modal ——
   const [factOpen, setFactOpen] = useState(false);
+  const [disclosureOpen, setDisclosureOpen] = useState(false);
   const [draftOpen, setDraftOpen] = useState(false);
 
   // 「初始化结构」后打开新生成的 draft.tex：先等详情刷新（文件树里出现 draft.tex、
@@ -790,6 +792,11 @@ export function WriterEditorPage() {
         <button className="btn btn-ghost sm" onClick={() => setFactOpen(true)}>
           <Icon name="layers" size={13} />
           {tr('事实包', 'Fact pack')}
+        </button>
+        {/* AI 披露声明（#691）：投稿合规入口，从平台留痕一键生成 */}
+        <button className="btn btn-ghost sm" onClick={() => setDisclosureOpen(true)}>
+          <Icon name="shield" size={13} />
+          {tr('AI 披露', 'AI disclosure')}
         </button>
         {/* 主文件 + 编译器（Overleaf 式；编译时后端按此读取） */}
         <select
@@ -1282,6 +1289,11 @@ export function WriterEditorPage() {
         onInsertFigure={onInsertFigure}
       />
       <DraftModal open={draftOpen} onClose={() => setDraftOpen(false)} manuscript={ms} onInitialized={handleInitialized} />
+      <AiDisclosureModal
+        open={disclosureOpen}
+        onClose={() => setDisclosureOpen(false)}
+        subject={{ kind: 'manuscript', id: ms.id }}
+      />
     </div>
   );
 }

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -519,6 +519,50 @@ export interface VoyageArtifactRead {
   content: unknown;
 }
 
+/** AI 使用披露声明（#691）：statement 纯文本、appendix 为 Markdown 明细，
+    facts 为确定性聚合的溯源事实（零 LLM）。 */
+export type AiDisclosureStyle = 'icmje' | 'elsevier' | 'generic';
+
+export interface AiDisclosureStageRow {
+  stage: string;
+  model: string;
+  calls: number;
+  prompt_tokens: number;
+  completion_tokens: number;
+}
+
+export interface AiDisclosureRun {
+  run_id: string;
+  kind: string;
+  status: string;
+  goal: string | null;
+  outputs: string[];
+  stages: AiDisclosureStageRow[];
+}
+
+export interface AiDisclosureFacts {
+  version: number;
+  subject: { type: 'manuscript' | 'voyage'; id: string; title: string | null };
+  ai_used: boolean;
+  runs: AiDisclosureRun[];
+  models: string[];
+  stages: string[];
+  totals: { prompt_tokens: number; completion_tokens: number; calls: number };
+  editing: {
+    ai_write_snapshots: number;
+    files_with_ai_writes: number;
+    compile_snapshots: number;
+    restore_snapshots: number;
+  } | null;
+  notes: string[];
+}
+
+export interface AiDisclosureRead {
+  statement: string;
+  appendix: string;
+  facts: AiDisclosureFacts;
+}
+
 export interface VoyageRead {
   id: string;
   kind: string;
@@ -3663,6 +3707,15 @@ export const api = {
     return request<VoyageArtifactRead>(`/voyages/${voyageId}/artifacts/${encodeURIComponent(name)}`);
   },
 
+  /** AI 使用披露声明（#691）：run 维度。可见性与任务详情同口径。 */
+  getVoyageAiDisclosure(
+    voyageId: string,
+    style: AiDisclosureStyle,
+    lang: 'zh' | 'en',
+  ): Promise<AiDisclosureRead> {
+    return request<AiDisclosureRead>(`/voyages/${voyageId}/ai-disclosure?style=${style}&lang=${lang}`);
+  },
+
   // —— Gates ——
   listGates(status?: 'pending' | 'decided', projectId?: string): Promise<GateRead[]> {
     const params = new URLSearchParams();
@@ -4778,6 +4831,15 @@ export const api = {
   },
   getManuscript(id: string): Promise<ManuscriptDetail> {
     return request<ManuscriptDetail>(`/manuscripts/${id}`);
+  },
+
+  /** AI 使用披露声明（#691）：稿件维度。可见性与稿件详情同口径。 */
+  getManuscriptAiDisclosure(
+    id: string,
+    style: AiDisclosureStyle,
+    lang: 'zh' | 'en',
+  ): Promise<AiDisclosureRead> {
+    return request<AiDisclosureRead>(`/manuscripts/${id}/ai-disclosure?style=${style}&lang=${lang}`);
   },
   patchManuscript(
     id: string,


### PR DESCRIPTION
Closes #691. Design report §18 trust design ③ — journals now require AI-use disclosure and forbid AI authorship; this turns the compliance burden into a feature.

- `ai_disclosure.build_disclosure_facts`: deterministic zero-LLM aggregation of what the platform actually recorded — run list, per-run stage→model rows, output types, editing traces — with fixed orderings (byte-identical facts for the same data, test-pinned)
- honesty is the design rule: the only durable model-name source is the usage ledger, so runs with spend but no ledger rows report model `unknown` with an explicit note; there is no manuscript→discovery linkage in the schema, so none is claimed; CRDT edits leave no per-edit versions, so human-editing coverage is stated as a lower bound rather than fabricated; a no-AI case says "based on recorded activity", never asserting absolute non-use
- `render_disclosure`: ICMJE / Elsevier / generic templates × zh/en — ICMJE's whether/how/responsibility structure, Elsevier's fixed end-of-manuscript paragraph, a neutral generic — plus a Markdown appendix (run/model/purpose table, editing stats, coverage notes)
- endpoints on manuscripts and voyage runs reusing each surface's existing visibility semantics; frontend modal (style/lang switches, copy buttons, collapsible appendix) reachable from the writer toolbar and the discovery run detail

Verification: clean baseline collect 1680; branch full suite 1684 passed / 3 failed — two pre-existing #581 legacies plus the known order-dependent manuscript caplog flake (green 3× standalone) — zero new real failures; 10 new tests; goldens unchanged; no migrations; frontend tsc/build/vitest 158 green.