### PR TITLE
feat: one-click full export

### DIFF
--- a/src/backend/app/api/export.py
+++ b/src/backend/app/api/export.py
@@ -1,0 +1,91 @@
+"""一键全量导出 API（#690）：入队 + 下载。
+
+进度不在这里——事件走既有 /paper-tasks/{task_id}/events SSE（与 Zotero 导入
+同口径），前端拿 task_id 后自行订阅。
+"""
+
+import re
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import FileResponse
+from redis.asyncio import Redis
+
+from app.api.auth import current_active_user
+from app.core.queue import TaskQueue, get_task_queue
+from app.core.redis import get_redis_dep
+from app.models.user import User
+from app.services import full_export as full_export_service
+from app.services import paper_enrich as paper_enrich_service
+
+router = APIRouter(prefix="/export", tags=["export"])
+
+#: task_id 是 uuid4().hex；下载端点拿它拼文件路径，先掐死一切非法形态
+_TASK_ID_RE = re.compile(r"^[0-9a-f]{32}$")
+
+
+@router.post("/full", status_code=status.HTTP_202_ACCEPTED)
+async def start_full_export(
+    user: User = Depends(current_active_user),
+    redis: Redis = Depends(get_redis_dep),
+    queue: TaskQueue = Depends(get_task_queue),
+) -> dict[str, str]:
+    """把用户的全部数据打包成 zip（后台任务）；返回 task_id 供订阅进度。
+
+    同一用户限并发 1：导出是全库扫描 + 拷 PDF 的重活，叠着跑只会互相拖慢，
+    且产物一样——已有进行中的直接 409。
+    """
+    task_id = uuid.uuid4().hex
+    try:
+        # NX 锁即「进行中」判据：worker 结束（成败皆然）删 key，TTL 兜底防 worker 崩死
+        acquired = await redis.set(
+            full_export_service.export_active_key(str(user.id)),
+            task_id,
+            nx=True,
+            ex=full_export_service.EXPORT_ACTIVE_TTL_SECONDS,
+        )
+    except Exception as e:  # noqa: BLE001 — redis 不可达时进度/归属都没法登记
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE, detail="TASK_SERVICE_UNAVAILABLE"
+        ) from e
+    if not acquired:
+        raise HTTPException(status.HTTP_409_CONFLICT, detail="EXPORT_ALREADY_RUNNING")
+    try:
+        # 两把归属 key：paper-task 的供 SSE 鉴权（1h，与事件日志同寿），
+        # full_export 的供下载鉴权（24h，给足下载窗口）
+        await redis.setex(
+            paper_enrich_service.paper_task_owner_key(task_id), 3600, str(user.id)
+        )
+        await redis.setex(
+            full_export_service.export_owner_key(task_id),
+            full_export_service.EXPORT_OWNER_TTL_SECONDS,
+            str(user.id),
+        )
+        await queue.enqueue("full_export", task_id=task_id, user_id=str(user.id))
+    except Exception as e:  # noqa: BLE001 — 入队失败必须放锁，否则 2h 内导不了
+        await redis.delete(full_export_service.export_active_key(str(user.id)))
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE, detail="TASK_SERVICE_UNAVAILABLE"
+        ) from e
+    return {"task_id": task_id}
+
+
+@router.get("/full/{task_id}/download")
+async def download_full_export(
+    task_id: str,
+    user: User = Depends(current_active_user),
+    redis: Redis = Depends(get_redis_dep),
+) -> FileResponse:
+    """下载导出 zip（仅属主；未就绪/过期/他人任务一律 404，不泄露存在性）。"""
+    if not _TASK_ID_RE.fullmatch(task_id):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="EXPORT_NOT_FOUND")
+    owner = await redis.get(full_export_service.export_owner_key(task_id))
+    if owner != str(user.id):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="EXPORT_NOT_FOUND")
+    path = full_export_service.export_zip_path(task_id)
+    if not path.is_file():
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="EXPORT_NOT_READY")
+    # 文件名固定 ASCII：Content-Disposition 是 latin-1 头，中文名会当场炸（同库页导出）
+    return FileResponse(
+        path, media_type="application/zip", filename="polaris-full-export.zip"
+    )

--- a/src/backend/app/api/router.py
+++ b/src/backend/app/api/router.py
@@ -13,6 +13,7 @@ from app.api import (
     download_client,
     evidence,
     experiments,
+    export,
     gates,
     health,
     highlights,
@@ -90,3 +91,4 @@ api_router.include_router(tts.router)
 api_router.include_router(evidence.router)
 api_router.include_router(experiments.router)
 api_router.include_router(manuscripts.router)
+api_router.include_router(export.router)

--- a/src/backend/app/core/queue.py
+++ b/src/backend/app/core/queue.py
@@ -33,6 +33,7 @@ WORKER_FUNCTIONS = frozenset(
         "run_literature_discovery",
         "translate_literature_hit",
         "zotero_import",
+        "full_export",
     }
 )
 

--- a/src/backend/app/services/full_export.py
+++ b/src/backend/app/services/full_export.py
@@ -1,0 +1,680 @@
+"""一键全量导出（#690，设计报告 §17/§18 信任设计②「随时可走」）。
+
+把一个用户在平台上的全部数据面组装成一棵可读的目录树再打成 zip：
+
+    libraries/<库名>/library.json + papers.bib + papers.csl.json + pdfs/
+    notes/<论文名>.md            （笔记 + 划线，YAML frontmatter 带论文标识）
+    wiki/<库名>/                 （复用 Obsidian vault 导出的目录结构）
+    discovery/<run 名>/tree.json + proposal.md + disclosure.json
+    experiments/<实验名>/run.json
+    manuscripts/<题名>/source/ + compiled.pdf
+    manifest.json + README.md
+
+口径上的两条硬原则：
+- 空面跳过不报错——没有数据的面不产生目录，导出永远能出包；
+- 单项失败记 manifest.warnings 不拖垮整包——导出是「带走数据」的兜底通道，
+  一篇论文的 PDF 丢了不该让全部数据都带不走。
+"""
+
+import io
+import json
+import logging
+import re
+import shutil
+import uuid
+import zipfile
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from redis.asyncio import Redis
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app import __version__
+from app.core.config import get_settings
+from app.models.experiment import Experiment
+from app.models.idea import Idea
+from app.models.library_direction import DirectionLibrary, LibraryPaper, TopicSourceLibrary
+from app.models.manuscript import Manuscript
+from app.models.paper import Paper, PaperHighlight, PaperNote
+from app.models.project import Project
+from app.models.voyage import VoyageRun
+from app.services.citations import (
+    assign_citation_keys,
+    build_bibtex_for,
+    build_csl_json,
+    papers_for_library_export,
+)
+from app.services.hypothesis_tree import tree_for_run
+from app.services.latex_compile import latest_ok_pdf
+from app.services.libraries import library_definition
+from app.services.manuscripts import asset_path
+from app.services.projects import in_my_projects
+from app.services.wiki_export import build_obsidian_zip_for_libraries
+
+logger = logging.getLogger(__name__)
+
+# 进度回调：facet 名 + 当前累计计数（worker 侧转成 paper-task 事件发给前端）
+ProgressFn = Callable[[str, dict[str, int]], Awaitable[None]]
+
+
+def exports_dir() -> Path:
+    """导出产物落盘位置（api 与 worker 同挂数据卷，下载端点直接读这里）。"""
+    return Path(get_settings().data_dir) / "exports"
+
+
+def export_zip_path(task_id: str) -> Path:
+    return exports_dir() / f"{task_id}.zip"
+
+
+# 并发锁与下载归属都放 Redis（与 paper-task 归属同思路，不建表）。
+# 归属 key 存活 24h：zip 是一次性打包产物，给足下载窗口后连同鉴权一起过期。
+EXPORT_OWNER_TTL_SECONDS = 24 * 3600
+# 活动锁 TTL 兜底：worker 崩了没清锁时最多锁 2 小时，不至于永远导不了
+EXPORT_ACTIVE_TTL_SECONDS = 2 * 3600
+
+
+def export_owner_key(task_id: str) -> str:
+    return f"full_export_owner:{task_id}"
+
+
+def export_active_key(user_id: str) -> str:
+    return f"full_export_active:{user_id}"
+
+
+# 文件/目录名里剔除路径分隔与控制字符；库名/题名多为中文，zip 原生支持 UTF-8，
+# 不做转拼音之类的破坏性处理（file-over-app：用户看到的名字就是他起的名字）
+_UNSAFE_NAME_RE = re.compile(r'[\\/:*?"<>|\x00-\x1f]+')
+
+
+def _safe_name(name: str | None, used: set[str], fallback: str = "untitled") -> str:
+    base = _UNSAFE_NAME_RE.sub(" ", (name or "").strip()).strip(" .")[:80] or fallback
+    candidate, n = base, 2
+    # 大小写不敏感去重：macOS/Windows 文件系统大小写不敏感，解 zip 时会互相覆盖
+    while candidate.lower() in used:
+        candidate = f"{base}-{n}"
+        n += 1
+    used.add(candidate.lower())
+    return candidate
+
+
+def _dump_json(path: Path, data: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(data, ensure_ascii=False, indent=2, default=str) + "\n", encoding="utf-8"
+    )
+
+
+def _yaml_str(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, int | float):
+        return str(value)
+    return json.dumps(str(value), ensure_ascii=False)  # JSON 字符串是合法 YAML 标量
+
+
+def _warn(manifest: dict[str, Any], facet: str, item: str, error: Exception) -> None:
+    manifest["warnings"].append({"facet": facet, "item": item, "error": str(error)})
+    logger.warning("full export: %s/%s failed: %s", facet, item, error)
+
+
+async def _user_libraries(session: AsyncSession, user_id: uuid.UUID) -> list[DirectionLibrary]:
+    """导出的库范围 = 我建的库 ∪ 我课题关联的库。
+
+    刻意不用 library_visible_to：可见范围含全部公共库，把别人策展的公共大库
+    整个塞进「我的数据」既臃肿也名不副实——带走的应当是自己的与自己在用的。
+    """
+    linked = (
+        select(TopicSourceLibrary.library_id)
+        .join(Project, Project.id == TopicSourceLibrary.topic_id)
+        .where(Project.owner_id == user_id)
+    )
+    stmt = (
+        select(DirectionLibrary)
+        .where(
+            or_(
+                DirectionLibrary.submitted_by == user_id,
+                DirectionLibrary.id.in_(linked),
+            )
+        )
+        .order_by(DirectionLibrary.created_at)
+    )
+    return list((await session.execute(stmt)).scalars().all())
+
+
+async def _export_libraries(
+    session: AsyncSession, user_id: uuid.UUID, root: Path, manifest: dict[str, Any]
+) -> None:
+    counts = manifest["counts"]
+    used: set[str] = set()
+    for library in await _user_libraries(session, user_id):
+        name = _safe_name(library.name, used, fallback=str(library.id)[:8])
+        lib_dir = root / "libraries" / name
+        try:
+            member_rows = (
+                await session.execute(
+                    select(Paper, LibraryPaper)
+                    .join(LibraryPaper, LibraryPaper.paper_id == Paper.id)
+                    .where(LibraryPaper.library_id == library.id)
+                    .order_by(LibraryPaper.created_at)
+                )
+            ).all()
+            _dump_json(
+                lib_dir / "library.json",
+                {
+                    "id": str(library.id),
+                    "name": library.name,
+                    "library_kind": library.library_kind,
+                    "statement": library.statement,
+                    "is_public": library.is_public,
+                    "cadence": library.cadence,
+                    "monthly_budget": library.monthly_budget,
+                    "definition": library_definition(library),
+                    "created_at": library.created_at,
+                    "members": [
+                        {
+                            "paper_id": str(paper.id),
+                            "title": paper.title,
+                            "arxiv_id": paper.arxiv_id,
+                            "doi": paper.doi,
+                            "year": paper.year,
+                            "status": member.status,
+                            "relevance_score": member.relevance_score,
+                            "tldr_note": member.tldr_note,
+                        }
+                        for paper, member in member_rows
+                    ],
+                },
+            )
+            counts["libraries"] += 1
+
+            # 引用文件走既有 builder（与库页「导出引用」完全同口径）
+            papers = await papers_for_library_export(
+                session, library_id=library.id, user_id=user_id
+            )
+            if papers:
+                keys = assign_citation_keys(papers)
+                (lib_dir / "papers.bib").write_text(
+                    build_bibtex_for(papers, keys), encoding="utf-8"
+                )
+                _dump_json(lib_dir / "papers.csl.json", build_csl_json(papers))
+                counts["papers"] += len(papers)
+                for paper in papers:
+                    # PDF 按 citekey 命名：和 papers.bib 逐条对得上，离线也能引用
+                    try:
+                        if paper.pdf_path and Path(paper.pdf_path).is_file():
+                            pdf_dir = lib_dir / "pdfs"
+                            pdf_dir.mkdir(parents=True, exist_ok=True)
+                            shutil.copyfile(paper.pdf_path, pdf_dir / f"{keys[paper.id]}.pdf")
+                            counts["pdfs"] += 1
+                    except OSError as e:
+                        _warn(manifest, "libraries", f"{library.name}/pdf/{paper.title}", e)
+        except Exception as e:  # noqa: BLE001 — 单库失败不拖垮整包
+            _warn(manifest, "libraries", library.name, e)
+
+
+async def _export_notes(
+    session: AsyncSession, user_id: uuid.UUID, root: Path, manifest: dict[str, Any]
+) -> None:
+    """笔记/划线按论文分组落 Markdown（file-over-app：frontmatter 带论文标识，
+    离开平台后仍能凭 arxiv_id/doi/标题定位到是哪篇论文的笔记）。"""
+    counts = manifest["counts"]
+    note_rows = (
+        await session.execute(
+            select(PaperNote, Paper)
+            .join(Paper, Paper.id == PaperNote.paper_id)
+            .where(PaperNote.author_id == user_id)
+            .order_by(PaperNote.created_at)
+        )
+    ).all()
+    hl_rows = (
+        await session.execute(
+            select(PaperHighlight, Paper)
+            .join(Paper, Paper.id == PaperHighlight.paper_id)
+            .where(PaperHighlight.author_id == user_id)
+            .order_by(PaperHighlight.page, PaperHighlight.created_at)
+        )
+    ).all()
+    by_paper: dict[uuid.UUID, dict[str, Any]] = {}
+    for note, paper in note_rows:
+        entry = by_paper.setdefault(paper.id, {"paper": paper, "notes": [], "highlights": []})
+        entry["notes"].append(note)
+        counts["notes"] += 1
+    for hl, paper in hl_rows:
+        entry = by_paper.setdefault(paper.id, {"paper": paper, "notes": [], "highlights": []})
+        entry["highlights"].append(hl)
+        counts["highlights"] += 1
+
+    used: set[str] = set()
+    for entry in by_paper.values():
+        paper: Paper = entry["paper"]
+        try:
+            lines = [
+                "---",
+                f"title: {_yaml_str(paper.title)}",
+                f"paper_id: {_yaml_str(paper.id)}",
+                f"arxiv_id: {_yaml_str(paper.arxiv_id)}",
+                f"doi: {_yaml_str(paper.doi)}",
+                f"year: {_yaml_str(paper.year)}",
+                "---",
+                "",
+                f"# {paper.title}",
+            ]
+            if entry["notes"]:
+                lines += ["", "## 笔记 Notes"]
+                for note in entry["notes"]:
+                    lines += ["", f"### {note.created_at:%Y-%m-%d %H:%M}", "", note.content]
+            if entry["highlights"]:
+                lines += ["", "## 划线 Highlights"]
+                for hl in entry["highlights"]:
+                    lines += ["", f"- p.{hl.page}: > {hl.selected_text}"]
+                    if hl.note:
+                        lines += [f"  - {hl.note}"]
+            name = _safe_name(paper.title, used, fallback=str(paper.id)[:8])
+            notes_dir = root / "notes"
+            notes_dir.mkdir(parents=True, exist_ok=True)
+            (notes_dir / f"{name}.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+        except Exception as e:  # noqa: BLE001
+            _warn(manifest, "notes", paper.title, e)
+
+
+async def _export_wiki(
+    session: AsyncSession, user_id: uuid.UUID, root: Path, manifest: dict[str, Any]
+) -> None:
+    """每库一个 Obsidian vault，复用既有 builder（zip bytes 原地解开成目录）。
+
+    重造一份「wiki 页写 markdown」的逻辑必然与库页导出漂移（图链重写、双链、
+    笔记小节都在 builder 里），所以宁可 zip→解包一次，也不复制那段逻辑。
+    """
+    counts = manifest["counts"]
+    used: set[str] = set()
+    for library in await _user_libraries(session, user_id):
+        try:
+            has_members = (
+                await session.execute(
+                    select(LibraryPaper.paper_id)
+                    .where(
+                        LibraryPaper.library_id == library.id,
+                        LibraryPaper.status.in_(("compiled", "included")),
+                    )
+                    .limit(1)
+                )
+            ).first() is not None
+            if not has_members:
+                continue  # 空库的 vault 只剩占位 index，不值得占一个目录
+            vault = await build_obsidian_zip_for_libraries(
+                session, library_ids=[library.id], title=library.name, user_id=user_id
+            )
+            name = _safe_name(library.name, used, fallback=str(library.id)[:8])
+            target = root / "wiki" / name
+            target.mkdir(parents=True, exist_ok=True)
+            with zipfile.ZipFile(io.BytesIO(vault)) as zf:
+                zf.extractall(target)  # 条目名都是 builder 生成的 slug，无穿越风险
+                counts["wiki_pages"] += sum(
+                    1 for n in zf.namelist() if n.startswith("papers/") and n.endswith(".md")
+                )
+        except Exception as e:  # noqa: BLE001
+            _warn(manifest, "wiki", library.name, e)
+
+
+def _parse_artifact(artifacts: dict[str, Any], key: str) -> dict[str, Any] | None:
+    raw = artifacts.get(key)
+    if raw is None:
+        return None
+    return json.loads(raw) if isinstance(raw, str) else raw
+
+
+def _render_proposal_md(run: VoyageRun, artifact: dict[str, Any]) -> str:
+    """研究方案的可读渲染：discovery-summary.json 是给前端的结构化产物，
+    导出时铺成 Markdown——带走的文件要能直接读，不能要求先装个查看器。"""
+    lines = [f"# 研究方案 · {run.goal}", ""]
+    if artifact.get("direction"):
+        lines += [f"> 方向：{artifact['direction']}", ""]
+    if artifact.get("summary"):
+        lines += [str(artifact["summary"]), ""]
+    for i, hyp in enumerate(artifact.get("hypotheses") or [], start=1):
+        lines += [f"## 假设 {i}：{hyp.get('statement', '')}", ""]
+        if hyp.get("score") is not None:
+            lines += [f"- 评分：{hyp['score']}"]
+        if hyp.get("status"):
+            lines += [f"- 状态：{hyp['status']}"]
+        lines += [""]
+    pruned = artifact.get("pruned_appendix") or []
+    if pruned:
+        lines += ["## 附录：被剪枝的分支", ""]
+        for item in pruned:
+            lines += [f"- {item.get('statement', '')} — {item.get('reason', '')}"]
+        lines += [""]
+    return "\n".join(lines)
+
+
+async def _export_discovery(
+    session: AsyncSession, user_id: uuid.UUID, root: Path, manifest: dict[str, Any]
+) -> None:
+    counts = manifest["counts"]
+    runs = (
+        (
+            await session.execute(
+                select(VoyageRun)
+                .where(VoyageRun.kind == "discovery", VoyageRun.created_by == user_id)
+                .order_by(VoyageRun.created_at)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    used: set[str] = set()
+    for run in runs:
+        try:
+            name = _safe_name(run.goal, used, fallback=str(run.id)[:8])
+            run_dir = root / "discovery" / name
+            nodes = await tree_for_run(session, run.id)
+            _dump_json(
+                run_dir / "tree.json",
+                {
+                    "run_id": str(run.id),
+                    "goal": run.goal,
+                    "status": run.status,
+                    "nodes": [
+                        {
+                            "id": str(n.id),
+                            "parent_id": str(n.parent_id) if n.parent_id else None,
+                            "kind": n.kind,
+                            "statement": n.statement,
+                            "status": n.status,
+                            "score": n.score,
+                            "grounding": n.grounding,
+                            "novelty_report": n.novelty_report,
+                            "feasibility": n.feasibility,
+                        }
+                        for n in nodes
+                    ],
+                },
+            )
+            # 产物存 checkpoint["artifacts"]（值是 JSON 字符串，同 api/hypotheses.py 口径）
+            artifacts = (run.checkpoint or {}).get("artifacts") or {}
+            summary = _parse_artifact(artifacts, "discovery-summary.json")
+            if summary is not None:
+                (run_dir / "proposal.md").write_text(
+                    _render_proposal_md(run, summary), encoding="utf-8"
+                )
+            disclosure = _parse_artifact(artifacts, "discovery-disclosure.json")
+            if disclosure is not None:
+                _dump_json(run_dir / "disclosure.json", disclosure)
+            counts["discovery_runs"] += 1
+        except Exception as e:  # noqa: BLE001
+            _warn(manifest, "discovery", run.goal, e)
+
+
+async def _export_experiments(
+    session: AsyncSession, user_id: uuid.UUID, root: Path, manifest: dict[str, Any]
+) -> None:
+    counts = manifest["counts"]
+    rows = (
+        await session.execute(
+            select(Experiment, Idea.title)
+            .join(Idea, Idea.id == Experiment.idea_id)
+            .where(
+                in_my_projects(Experiment.project_id, user_id),
+                Experiment.trashed_at.is_(None),
+            )
+            .options(selectinload(Experiment.runs))
+            .order_by(Experiment.created_at)
+        )
+    ).all()
+    used: set[str] = set()
+    for experiment, idea_title in rows:
+        try:
+            name = _safe_name(idea_title, used, fallback=str(experiment.id)[:8])
+            _dump_json(
+                root / "experiments" / name / "run.json",
+                {
+                    "id": str(experiment.id),
+                    "idea_title": idea_title,
+                    "status": experiment.status,
+                    "plan": experiment.plan,
+                    "budget": experiment.budget,
+                    "server_host": experiment.server_host,
+                    "workdir": experiment.workdir,
+                    "metrics": experiment.metrics,
+                    "report": experiment.report,
+                    "created_at": experiment.created_at,
+                    "runs": [
+                        {
+                            "seq": r.seq,
+                            "command": r.command,
+                            "status": r.status,
+                            "exit_code": r.exit_code,
+                            "metrics": r.metrics,
+                            "primary_value": r.primary_value,
+                            "reflection": r.reflection,
+                            "started_at": r.started_at,
+                            "finished_at": r.finished_at,
+                        }
+                        for r in experiment.runs
+                    ],
+                    # 产物清单：图表按名字列出（文件在服务器数据卷，路径不外露）
+                    "artifacts": {
+                        "figures": [
+                            {
+                                "index": f.get("index"),
+                                "name": f.get("name"),
+                                "caption": f.get("caption"),
+                            }
+                            for f in experiment.figures or []
+                        ],
+                    },
+                },
+            )
+            counts["experiments"] += 1
+        except Exception as e:  # noqa: BLE001
+            _warn(manifest, "experiments", idea_title, e)
+
+
+async def _export_manuscripts(
+    session: AsyncSession, user_id: uuid.UUID, root: Path, manifest: dict[str, Any]
+) -> None:
+    counts = manifest["counts"]
+    manuscripts = (
+        (
+            await session.execute(
+                select(Manuscript)
+                .where(
+                    in_my_projects(Manuscript.project_id, user_id),
+                    Manuscript.trashed_at.is_(None),
+                )
+                .options(selectinload(Manuscript.files))
+                .order_by(Manuscript.created_at)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    used: set[str] = set()
+    for manuscript in manuscripts:
+        try:
+            name = _safe_name(manuscript.title, used, fallback=str(manuscript.id)[:8])
+            ms_dir = root / "manuscripts" / name
+            source_dir = ms_dir / "source"
+            for file in manuscript.files:
+                if file.is_folder:
+                    continue
+                rel = Path(file.path)
+                # 文件路径来自 DB，仍防一手越界（".." / 绝对路径都拒收，记 warning）
+                if rel.is_absolute() or ".." in rel.parts:
+                    _warn(
+                        manifest,
+                        "manuscripts",
+                        f"{manuscript.title}/{file.path}",
+                        ValueError("unsafe path"),
+                    )
+                    continue
+                target = source_dir / rel
+                target.parent.mkdir(parents=True, exist_ok=True)
+                if file.is_binary:
+                    src = asset_path(manuscript.id, file.path)
+                    if src.is_file():
+                        shutil.copyfile(src, target)
+                else:
+                    target.write_text(file.content or "", encoding="utf-8")
+            pdf = latest_ok_pdf(manuscript)
+            if pdf is not None:
+                ms_dir.mkdir(parents=True, exist_ok=True)
+                shutil.copyfile(pdf, ms_dir / "compiled.pdf")
+            counts["manuscripts"] += 1
+        except Exception as e:  # noqa: BLE001
+            _warn(manifest, "manuscripts", manuscript.title, e)
+
+
+_README = """# Polaris 全量导出 / Full export
+
+这是你在 Polaris 里全部数据的打包副本，随时可以离开平台继续使用：
+
+- `libraries/<库名>/`：文献库设置与成员清单（library.json）、引用文件
+  （papers.bib / papers.csl.json，可导入 Zotero 等工具）、已下载的 PDF（pdfs/，
+  文件名与 papers.bib 的 citekey 一一对应）。
+- `notes/`：你的论文笔记与 PDF 划线，按论文一篇一个 Markdown 文件，
+  开头的 frontmatter 带论文标识（arxiv_id / doi / 标题）。
+- `wiki/<库名>/`：各库的论文解读页，Obsidian vault 结构，可直接用 Obsidian 打开。
+- `discovery/<任务名>/`：假设探索任务的完整留痕——假设树（tree.json）、
+  研究方案（proposal.md）、过程披露（disclosure.json）。
+- `experiments/<实验名>/run.json`：实验计划、逐次运行记录、指标与产物清单。
+- `manuscripts/<题名>/`：论文稿件源文件（source/）与最近一次编译的 PDF（compiled.pdf）。
+- `manifest.json`：导出时间、版本、各面计数；导出中跳过的单项记录在 warnings。
+
+---
+
+This archive is a portable copy of all your data in Polaris:
+
+- `libraries/<name>/`: library settings and member list (library.json), citation
+  files (papers.bib / papers.csl.json, importable into Zotero etc.), and downloaded
+  PDFs (pdfs/, named after the citekeys in papers.bib).
+- `notes/`: your paper notes and PDF highlights, one Markdown file per paper with a
+  frontmatter identifying the paper (arxiv_id / doi / title).
+- `wiki/<name>/`: compiled paper interpretations per library, as an Obsidian vault.
+- `discovery/<run>/`: hypothesis-discovery runs — the hypothesis tree (tree.json),
+  the research proposal (proposal.md), and the process disclosure (disclosure.json).
+- `experiments/<name>/run.json`: experiment plan, per-run records, metrics and an
+  artifact inventory.
+- `manuscripts/<title>/`: manuscript sources (source/) plus the latest compiled PDF.
+- `manifest.json`: export time, version and per-facet counts; items skipped during
+  export are listed under warnings.
+"""
+
+# 导出的面（顺序即进度顺序）
+_FACETS: list[tuple[str, Any]] = [
+    ("libraries", _export_libraries),
+    ("notes", _export_notes),
+    ("wiki", _export_wiki),
+    ("discovery", _export_discovery),
+    ("experiments", _export_experiments),
+    ("manuscripts", _export_manuscripts),
+]
+
+_COUNT_KEYS = (
+    "libraries",
+    "papers",
+    "pdfs",
+    "notes",
+    "highlights",
+    "wiki_pages",
+    "discovery_runs",
+    "experiments",
+    "manuscripts",
+)
+
+
+def _zip_tree(tree_dir: Path, zip_path: Path) -> None:
+    with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for path in sorted(tree_dir.rglob("*")):
+            if path.is_file():
+                zf.write(path, path.relative_to(tree_dir).as_posix())
+
+
+async def run_full_export(
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    dest_dir: Path,
+    *,
+    progress: ProgressFn | None = None,
+) -> tuple[Path, dict[str, Any]]:
+    """组装目录树并打 zip；返回 (zip 路径, manifest)。
+
+    树落 ``dest_dir/tree``，zip 落 ``dest_dir/export.zip``；打包完成后树目录
+    即被清掉（zip 才是产物，树只是中间态）。facet 级异常也只记 warnings：
+    「随时可走」的承诺不能被任何一面的数据伤破坏。
+    """
+    dest_dir = Path(dest_dir)
+    tree = dest_dir / "tree"
+    tree.mkdir(parents=True, exist_ok=True)
+    manifest: dict[str, Any] = {
+        "exported_at": datetime.now(UTC).isoformat(),
+        "version": __version__,
+        "user_id": str(user_id),
+        "counts": dict.fromkeys(_COUNT_KEYS, 0),
+        "warnings": [],
+    }
+    for facet, export_fn in _FACETS:
+        try:
+            await export_fn(session, user_id, tree, manifest)
+        except Exception as e:  # noqa: BLE001
+            _warn(manifest, facet, "*", e)
+        if progress is not None:
+            await progress(facet, dict(manifest["counts"]))
+    (tree / "README.md").write_text(_README, encoding="utf-8")
+    _dump_json(tree / "manifest.json", manifest)
+    zip_path = dest_dir / "export.zip"
+    _zip_tree(tree, zip_path)
+    shutil.rmtree(tree, ignore_errors=True)
+    return zip_path, manifest
+
+
+async def run_full_export_task(redis: Redis, *, task_id: str, user_id: str) -> dict[str, Any]:
+    """worker 入口：跑导出、把 zip 挪到下载位、发进度/完成事件。
+
+    事件走 paper-task 通道（与 Zotero 导入同口径）：API 入队前已注册任务归属，
+    前端订阅 /paper-tasks/{task_id}/events。「done」在 zip 就位**之后**才发——
+    前端收到 done 即可下载，不能有窗口期。
+    """
+    from app.core.db import get_sessionmaker
+    from app.core.events import EventBus, publish_paper_task_event
+
+    bus = EventBus(redis)
+    workdir = exports_dir() / task_id
+    try:
+        async with get_sessionmaker()() as session:
+
+            async def _progress(facet: str, counts: dict[str, int]) -> None:
+                await publish_paper_task_event(
+                    bus, task_id, "export_progress", {"facet": facet, "counts": counts}
+                )
+
+            zip_path, manifest = await run_full_export(
+                session, uuid.UUID(user_id), workdir, progress=_progress
+            )
+        final = export_zip_path(task_id)
+        final.parent.mkdir(parents=True, exist_ok=True)
+        zip_path.replace(final)
+        shutil.rmtree(workdir, ignore_errors=True)
+        await publish_paper_task_event(
+            bus,
+            task_id,
+            "done",
+            {
+                "counts": manifest["counts"],
+                "warnings": manifest["warnings"],
+                "download_path": f"/export/full/{task_id}/download",
+            },
+        )
+        return {"counts": manifest["counts"]}
+    except Exception as e:  # noqa: BLE001 — 失败以 error 事件告知前端，不再重抛（重试无意义）
+        logger.exception("full export failed: task=%s user=%s", task_id, user_id)
+        shutil.rmtree(workdir, ignore_errors=True)
+        await publish_paper_task_event(bus, task_id, "error", {"message": str(e)})
+        return {"error": str(e)}
+    finally:
+        # 无论成败都放并发锁：锁的语义是「同一用户同时最多一个导出任务」
+        await redis.delete(export_active_key(user_id))

--- a/src/backend/tests/test_full_export.py
+++ b/src/backend/tests/test_full_export.py
@@ -1,0 +1,319 @@
+"""一键全量导出（#690）：服务级目录树/zip 断言 + worker 事件 + API 入队/409/下载鉴权。"""
+
+import json
+import uuid
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from app.core.config import get_settings
+from app.core.db import get_sessionmaker
+from app.core.events import paper_task_log_key
+from app.models.experiment import Experiment, ExperimentRun
+from app.models.hypothesis import HypothesisNode
+from app.models.idea import Idea
+from app.models.manuscript import Manuscript, ManuscriptFile
+from app.models.paper import PaperHighlight, PaperNote
+from app.models.voyage import VoyageRun
+from app.services.full_export import export_zip_path, run_full_export
+from tests.conftest import add_paper, make_project_with_library, register_and_login
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _user_id_of(client, headers) -> uuid.UUID:
+    resp = await client.get("/api/users/me", headers=headers)
+    assert resp.status_code == 200, resp.text
+    return uuid.UUID(resp.json()["id"])
+
+
+async def _seed_full_plane(client, headers) -> tuple[uuid.UUID, str]:
+    """造一个小而全的数据面：库 + 2 论文（1 带 PDF/解读）+ 笔记/划线 +
+    1 个 discovery run（树 + 产物）+ 1 实验 + 1 稿件。返回 (user_id, 库名)。"""
+    user_id = await _user_id_of(client, headers)
+    lib_name = "全量导出测试库"
+    project_id, _library_id = await make_project_with_library(
+        client, headers, name=lib_name
+    )
+    pid = uuid.UUID(project_id)
+    async with get_sessionmaker()() as session:
+        p1 = await add_paper(
+            session,
+            project_id=project_id,
+            title="Paper Alpha",
+            year=2024,
+            authors=[{"name": "Alice Smith"}],
+            arxiv_id="2401.00001",
+            status="included",
+            wiki_content="# Alpha 解读\n\n正文。",
+        )
+        await add_paper(
+            session,
+            project_id=project_id,
+            title="Paper Beta",
+            year=2023,
+            authors=[{"name": "Bob Jones"}],
+            status="compiled",
+        )
+        # 附件 PDF：落在 data_dir，pdf_path 是权威指针（与线上口径一致）
+        pdf_dir = Path(get_settings().data_dir) / "papers"
+        pdf_dir.mkdir(parents=True, exist_ok=True)
+        pdf_file = pdf_dir / f"{p1.id}.pdf"
+        pdf_file.write_bytes(b"%PDF-1.4 fake")
+        p1.pdf_path = str(pdf_file)
+        session.add(PaperNote(paper_id=p1.id, author_id=user_id, content="很重要的一篇"))
+        session.add(
+            PaperHighlight(
+                paper_id=p1.id,
+                author_id=user_id,
+                page=2,
+                rects=[{"x0": 0, "y0": 0, "x1": 1, "y1": 0.1}],
+                selected_text="a key sentence",
+                note="划线批注",
+            )
+        )
+        run = VoyageRun(
+            kind="discovery",
+            mode="loop",
+            goal="探索注意力机制的新假设",
+            status="done",
+            created_by=user_id,
+            checkpoint={
+                "artifacts": {
+                    "discovery-summary.json": json.dumps(
+                        {
+                            "direction": "attention",
+                            "summary": "两条存活假设。",
+                            "hypotheses": [
+                                {"statement": "假设一", "score": 0.8, "status": "expanded"}
+                            ],
+                            "pruned_appendix": [],
+                        },
+                        ensure_ascii=False,
+                    ),
+                    "discovery-disclosure.json": json.dumps({"version": 1, "queries": []}),
+                }
+            },
+        )
+        session.add(run)
+        await session.flush()
+        root_node = HypothesisNode(
+            run_id=run.id, kind="hypothesis", statement="根假设", status="expanded"
+        )
+        session.add(root_node)
+        await session.flush()
+        session.add(
+            HypothesisNode(
+                run_id=run.id,
+                parent_id=root_node.id,
+                kind="experiment",
+                statement="验证实验",
+                status="open",
+                score=0.5,
+            )
+        )
+        idea = Idea(project_id=pid, title="An Idea About Attention")
+        session.add(idea)
+        await session.flush()
+        experiment = Experiment(
+            project_id=pid,
+            idea_id=idea.id,
+            status="done",
+            metrics={"loss": [{"step": 1, "value": 0.5}]},
+            figures=[{"index": 0, "name": "fig0.png", "caption": "loss curve", "path": "x"}],
+        )
+        session.add(experiment)
+        await session.flush()
+        session.add(
+            ExperimentRun(
+                experiment_id=experiment.id,
+                seq=1,
+                command="python train.py",
+                status="succeeded",
+                exit_code=0,
+            )
+        )
+        manuscript = Manuscript(project_id=pid, title="伟大的论文草稿")
+        session.add(manuscript)
+        await session.flush()
+        session.add(
+            ManuscriptFile(
+                manuscript_id=manuscript.id,
+                path="main.tex",
+                content="\\documentclass{article}",
+            )
+        )
+        await session.commit()
+    return user_id, lib_name
+
+
+async def test_full_export_builds_expected_tree(client, tmp_path):
+    token = await register_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    user_id, lib_name = await _seed_full_plane(client, headers)
+
+    async with get_sessionmaker()() as session:
+        zip_path, manifest = await run_full_export(session, user_id, tmp_path)
+
+    assert zip_path.is_file()
+    with zipfile.ZipFile(zip_path) as zf:
+        names = set(zf.namelist())
+        # 库面：设置+成员清单 / 引用文件 / PDF（citekey 命名，与 papers.bib 对应）
+        lib = json.loads(zf.read(f"libraries/{lib_name}/library.json"))
+        assert lib["name"] == lib_name
+        assert {m["title"] for m in lib["members"]} == {"Paper Alpha", "Paper Beta"}
+        bib = zf.read(f"libraries/{lib_name}/papers.bib").decode()
+        assert "smith2024paper" in bib  # citekey 由既有规则派生
+        csl = json.loads(zf.read(f"libraries/{lib_name}/papers.csl.json"))
+        assert len(csl) == 2
+        assert f"libraries/{lib_name}/pdfs/smith2024paper.pdf" in names
+        # 笔记面：按论文分组，frontmatter 带论文标识
+        note_md = zf.read("notes/Paper Alpha.md").decode()
+        assert 'title: "Paper Alpha"' in note_md
+        assert 'arxiv_id: "2401.00001"' in note_md
+        assert "很重要的一篇" in note_md
+        assert "a key sentence" in note_md
+        # wiki 面：Obsidian vault 结构
+        assert f"wiki/{lib_name}/index.md" in names
+        assert any(n.startswith(f"wiki/{lib_name}/papers/") for n in names)
+        # discovery 面：树 + 方案 + 披露
+        tree = json.loads(zf.read("discovery/探索注意力机制的新假设/tree.json"))
+        assert len(tree["nodes"]) == 2
+        assert tree["nodes"][0]["parent_id"] is None
+        assert tree["nodes"][1]["kind"] == "experiment"
+        proposal = zf.read("discovery/探索注意力机制的新假设/proposal.md").decode()
+        assert "假设一" in proposal
+        disclosure = json.loads(zf.read("discovery/探索注意力机制的新假设/disclosure.json"))
+        assert disclosure["version"] == 1
+        # 实验面：run.json 带逐次运行与产物清单
+        run_json = json.loads(zf.read("experiments/An Idea About Attention/run.json"))
+        assert run_json["runs"][0]["command"] == "python train.py"
+        assert run_json["artifacts"]["figures"][0]["name"] == "fig0.png"
+        assert "path" not in run_json["artifacts"]["figures"][0]
+        # 稿件面：源文件
+        assert (
+            zf.read("manuscripts/伟大的论文草稿/source/main.tex").decode()
+            == "\\documentclass{article}"
+        )
+        # 顶层：manifest 计数与 README
+        assert "README.md" in names
+        m = json.loads(zf.read("manifest.json"))
+        assert m["counts"] == {
+            "libraries": 1,
+            "papers": 2,
+            "pdfs": 1,
+            "notes": 1,
+            "highlights": 1,
+            "wiki_pages": 2,
+            "discovery_runs": 1,
+            "experiments": 1,
+            "manuscripts": 1,
+        }
+        assert m["warnings"] == []
+    assert manifest["counts"]["papers"] == 2
+
+
+async def test_full_export_empty_user_yields_skeleton(client, tmp_path):
+    token = await register_and_login(client, email="empty@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    user_id = await _user_id_of(client, headers)
+
+    async with get_sessionmaker()() as session:
+        zip_path, manifest = await run_full_export(session, user_id, tmp_path)
+
+    with zipfile.ZipFile(zip_path) as zf:
+        assert set(zf.namelist()) == {"README.md", "manifest.json"}
+        m = json.loads(zf.read("manifest.json"))
+        assert all(v == 0 for v in m["counts"].values())
+        assert m["warnings"] == []
+    assert manifest["warnings"] == []
+
+
+async def test_full_export_worker_emits_events_and_places_zip(client, fake_redis):
+    """worker 入口：进度/完成事件按 paper-task 口径落回放日志，zip 落下载位。"""
+    from worker import tasks as worker_tasks
+
+    token = await register_and_login(client, email="worker@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    user_id = await _user_id_of(client, headers)
+    task_id = uuid.uuid4().hex
+
+    result = await worker_tasks.full_export(
+        {"redis": fake_redis}, task_id=task_id, user_id=str(user_id)
+    )
+    assert "counts" in result
+
+    events = [
+        json.loads(raw) for raw in await fake_redis.lrange(paper_task_log_key(task_id), 0, -1)
+    ]
+    kinds = [e["event"] for e in events]
+    assert kinds[-1] == "done"
+    assert "export_progress" in kinds
+    done = events[-1]["data"]
+    assert done["download_path"] == f"/export/full/{task_id}/download"
+    assert export_zip_path(task_id).is_file()
+
+
+async def test_full_export_api_enqueue_conflict_and_download(client, fake_redis, queue_stub):
+    token = await register_and_login(client, email="api@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    user_id = await _user_id_of(client, headers)
+
+    # 未登录一律 401
+    resp = await client.post("/api/export/full")
+    assert resp.status_code == 401
+
+    resp = await client.post("/api/export/full", headers=headers)
+    assert resp.status_code == 202, resp.text
+    task_id = resp.json()["task_id"]
+    assert queue_stub.jobs[0][0] == "full_export"
+    assert queue_stub.jobs[0][2] == {"task_id": task_id, "user_id": str(user_id)}
+
+    # 限并发 1：进行中（锁未释放）再点一次 → 409
+    resp = await client.post("/api/export/full", headers=headers)
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "EXPORT_ALREADY_RUNNING"
+
+    # zip 未就绪 → 404（属主也一样）
+    resp = await client.get(f"/api/export/full/{task_id}/download", headers=headers)
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "EXPORT_NOT_READY"
+
+    # 模拟 worker 完成：zip 就位后属主可下载
+    path = export_zip_path(task_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"PK\x05\x06" + b"\x00" * 18)  # 空 zip
+    resp = await client.get(f"/api/export/full/{task_id}/download", headers=headers)
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "application/zip"
+
+    # 非属主/非法 task_id 一律 404（不泄露存在性）
+    other = await register_and_login(client, email="other@example.com")
+    resp = await client.get(
+        f"/api/export/full/{task_id}/download",
+        headers={"Authorization": f"Bearer {other}"},
+    )
+    assert resp.status_code == 404
+    resp = await client.get("/api/export/full/../../etc/passwd/download", headers=headers)
+    assert resp.status_code == 404
+    path.unlink()
+
+
+async def test_full_export_lock_released_after_worker_failure(app, fake_redis):
+    """worker 失败也要放锁（error 事件 + 可重试），不能把用户锁死 2 小时。"""
+    from app.services.full_export import export_active_key
+    from worker import tasks as worker_tasks
+
+    task_id = uuid.uuid4().hex
+    # user_id 不是合法 uuid → run_full_export 前置就炸，走 error 分支
+    await fake_redis.set(export_active_key("not-a-uuid"), task_id)
+    result = await worker_tasks.full_export(
+        {"redis": fake_redis}, task_id=task_id, user_id="not-a-uuid"
+    )
+    assert "error" in result
+    events = [
+        json.loads(raw) for raw in await fake_redis.lrange(paper_task_log_key(task_id), 0, -1)
+    ]
+    assert events[-1]["event"] == "error"
+    assert await fake_redis.get(export_active_key("not-a-uuid")) is None

--- a/src/backend/worker/settings.py
+++ b/src/backend/worker/settings.py
@@ -10,6 +10,7 @@ from worker.tasks import (
     daily_publication_match,
     daily_wiki_ingest,
     dispatch_literature_discovery_schedules,
+    full_export,
     index_papers_fulltext_task,
     match_user_publications,
     parse_paper_content_task,
@@ -46,6 +47,8 @@ class WorkerSettings:
         func(translate_literature_hit, timeout=600),
         # Zotero 导入：整库几百条 + 逐篇补全（LLM 打分限并发 3），1h 上限不够用
         func(zotero_import, timeout=4 * 3600),
+        # 全量导出：全库扫描 + 拷 PDF，默认 1h 上限够用（超大库另议）
+        full_export,
     ]
     # 抓取时刻可由管理员配置（SystemSetting daily_feed_sync_time，默认 UTC 02:30 =
     # 北京 10:30；arXiv 约北京 10:00 放新公告）。arq 的 cron 时刻在 worker 启动时就固定

--- a/src/backend/worker/tasks.py
+++ b/src/backend/worker/tasks.py
@@ -491,3 +491,15 @@ async def zotero_import(
         user_id=uuid.UUID(user_id),
         project_id=uuid.UUID(project_id) if project_id else None,
     )
+
+
+async def full_export(ctx: dict[str, Any], *, task_id: str, user_id: str) -> dict[str, Any]:
+    """一键全量导出（#690）：把用户全部数据面打包成 zip 供下载。
+
+    zip 落共享数据卷 data_dir/exports/<task_id>.zip（api 侧下载端点直接读），
+    进度与完成事件走 paper-task 通道（归属在 API 入队前已注册），并发锁
+    （每用户同时一个）由任务结束时释放。
+    """
+    from app.services.full_export import run_full_export_task
+
+    return await run_full_export_task(ctx["redis"], task_id=task_id, user_id=user_id)

--- a/src/frontend/src/features/settings/FullExportSettings.tsx
+++ b/src/frontend/src/features/settings/FullExportSettings.tsx
@@ -1,0 +1,215 @@
+/* 一键全量导出（#690，「随时可走」做进界面）：
+   点按钮 → 入队后台任务 → SSE 收各面进度 → 完成后就地下载 zip。
+   进度复用 paper-task 事件通道（与 Zotero 导入同口径），不新起轮询。 */
+import { useEffect, useState } from 'react';
+import { Icon } from '../../components/ui/Icon';
+import { toast } from '../../components/ui/Toast';
+import { api, ApiError } from '../../lib/api';
+import { tr } from '../../lib/i18n';
+import { subscribeSse } from '../../lib/sse';
+import { saveBlob } from '../wiki/shared';
+
+type Phase = 'idle' | 'running' | 'done' | 'error';
+
+interface ExportCounts {
+  [key: string]: number;
+}
+
+/* 面/计数的展示名放函数里取——模块级常量不能顶层调 tr（语言切换后会失效） */
+function facetLabel(facet: string): string {
+  switch (facet) {
+    case 'libraries':
+      return tr('文献库', 'Libraries');
+    case 'notes':
+      return tr('笔记与划线', 'Notes & highlights');
+    case 'wiki':
+      return tr('论文解读', 'Paper interpretations');
+    case 'discovery':
+      return tr('假设探索', 'Hypothesis discovery');
+    case 'experiments':
+      return tr('实验记录', 'Experiments');
+    case 'manuscripts':
+      return tr('论文稿件', 'Manuscripts');
+    default:
+      return facet;
+  }
+}
+
+function countSummary(counts: ExportCounts): string {
+  const parts: string[] = [];
+  const push = (n: number | undefined, zh: string, en: string) => {
+    if (n) parts.push(tr(`${n} ${zh}`, `${n} ${en}`));
+  };
+  push(counts.libraries, '个文献库', 'libraries');
+  push(counts.papers, '篇论文', 'papers');
+  push(counts.pdfs, '份 PDF', 'PDFs');
+  push(counts.notes, '条笔记', 'notes');
+  push(counts.highlights, '条划线', 'highlights');
+  push(counts.wiki_pages, '页解读', 'wiki pages');
+  push(counts.discovery_runs, '个探索任务', 'discovery runs');
+  push(counts.experiments, '个实验', 'experiments');
+  push(counts.manuscripts, '篇稿件', 'manuscripts');
+  return parts.length > 0 ? parts.join(tr('、', ', ')) : tr('还没有数据，导出的是空骨架', 'No data yet — the archive is an empty skeleton');
+}
+
+export function FullExportSettings() {
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [taskId, setTaskId] = useState<string | null>(null);
+  const [doneFacets, setDoneFacets] = useState<string[]>([]);
+  const [counts, setCounts] = useState<ExportCounts>({});
+  const [warnings, setWarnings] = useState<number>(0);
+  const [errorMsg, setErrorMsg] = useState<string>('');
+  const [starting, setStarting] = useState(false);
+  const [downloading, setDownloading] = useState(false);
+
+  useEffect(() => {
+    if (phase !== 'running' || !taskId) return;
+    const cancel = subscribeSse(`/paper-tasks/${taskId}/events`, {
+      onEvent(event, data) {
+        let payload: any = {};
+        try {
+          payload = JSON.parse(data);
+        } catch {
+          return;
+        }
+        if (event === 'export_progress') {
+          setDoneFacets((prev) => (prev.includes(payload.facet) ? prev : [...prev, payload.facet]));
+          setCounts(payload.counts ?? {});
+        } else if (event === 'done') {
+          setCounts(payload.counts ?? {});
+          setWarnings((payload.warnings ?? []).length);
+          setPhase('done');
+        } else if (event === 'error') {
+          setErrorMsg(String(payload.message ?? ''));
+          setPhase('error');
+        }
+      },
+    });
+    return cancel;
+  }, [phase, taskId]);
+
+  async function start() {
+    setStarting(true);
+    try {
+      const { task_id } = await api.startFullExport();
+      setTaskId(task_id);
+      setDoneFacets([]);
+      setCounts({});
+      setWarnings(0);
+      setErrorMsg('');
+      setPhase('running');
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 409) {
+        toast(tr('已经有一个导出在进行中，请稍候', 'An export is already running. Please wait.'), 'error');
+      } else {
+        const message = error instanceof Error ? error.message : String(error);
+        toast(`${tr('导出启动失败', 'Could not start export')}: ${message}`, 'error');
+      }
+    } finally {
+      setStarting(false);
+    }
+  }
+
+  async function download() {
+    if (!taskId) return;
+    setDownloading(true);
+    try {
+      const blob = await api.downloadFullExport(taskId);
+      saveBlob(blob, 'polaris-full-export.zip');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      toast(`${tr('下载失败', 'Download failed')}: ${message}`, 'error');
+    } finally {
+      setDownloading(false);
+    }
+  }
+
+  return (
+    <section className="card card-pad" style={{ maxWidth: 880 }}>
+      <div
+        className="row"
+        style={{ justifyContent: 'space-between', alignItems: 'flex-start', gap: 16, flexWrap: 'wrap' }}
+      >
+        <div style={{ flex: '1 1 420px', minWidth: 0 }}>
+          <div className="section-h">
+            <Icon name="download" size={15} style={{ color: 'var(--accent)' }} />
+            {tr('全量导出', 'Full export')}
+          </div>
+          <div style={{ fontSize: 12, color: 'var(--text-3)', marginTop: 5, lineHeight: 1.65 }}>
+            {tr(
+              '把你在 Polaris 里的全部数据打包带走：文献库和 PDF、笔记划线、论文解读、假设探索、实验记录、论文稿件，全部装进一个 zip。里面都是普通的 Markdown、BibTeX 和 JSON 文件，离开平台也能直接用。',
+              'Take all your Polaris data with you: libraries and PDFs, notes and highlights, paper interpretations, hypothesis discovery runs, experiment records and manuscripts, packed into one zip of plain Markdown, BibTeX and JSON files that work anywhere.',
+            )}
+          </div>
+        </div>
+        <button
+          className="btn btn-primary"
+          disabled={starting || phase === 'running'}
+          onClick={() => void start()}
+        >
+          <Icon name={phase === 'running' ? 'refresh' : 'download'} size={14} />
+          {phase === 'running'
+            ? tr('打包中...', 'Packing...')
+            : starting
+              ? tr('启动中...', 'Starting...')
+              : tr('打包我的全部数据', 'Pack all my data')}
+        </button>
+      </div>
+
+      {phase !== 'idle' && (
+        <div
+          style={{
+            marginTop: 18,
+            padding: 14,
+            background: 'var(--surface-2)',
+            border: '1px solid var(--border)',
+            borderRadius: 6,
+            fontSize: 12.5,
+            lineHeight: 1.8,
+          }}
+        >
+          {doneFacets.map((facet) => (
+            <div key={facet} className="row" style={{ gap: 8, alignItems: 'center' }}>
+              <Icon name="check" size={13} style={{ color: 'var(--ok-tx, var(--accent))' }} />
+              <span>{facetLabel(facet)}</span>
+            </div>
+          ))}
+          {phase === 'running' && (
+            <div style={{ color: 'var(--text-3)', marginTop: doneFacets.length > 0 ? 6 : 0 }}>
+              {tr('正在收拾你的数据，请稍等……', 'Gathering your data, one moment...')}
+            </div>
+          )}
+          {phase === 'done' && (
+            <div style={{ marginTop: 8 }}>
+              <div style={{ color: 'var(--text-2)' }}>
+                {tr('打包完成：', 'All packed: ')}
+                {countSummary(counts)}
+                {warnings > 0 &&
+                  tr(
+                    `（有 ${warnings} 项没能装进去，详见包内 manifest.json）`,
+                    ` (${warnings} item(s) could not be included — see manifest.json inside the archive)`,
+                  )}
+              </div>
+              <button
+                className="btn btn-soft sm"
+                disabled={downloading}
+                onClick={() => void download()}
+                style={{ marginTop: 10 }}
+              >
+                <Icon name="download" size={13} />
+                {downloading ? tr('下载中...', 'Downloading...') : tr('下载 zip', 'Download zip')}
+              </button>
+            </div>
+          )}
+          {phase === 'error' && (
+            <div style={{ color: 'var(--danger-tx)', marginTop: 6 }}>
+              {tr('导出没成功', 'Export failed')}
+              {errorMsg ? `: ${errorMsg}` : ''}
+              {tr('。可以稍后再试一次。', ' You can try again later.')}
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/frontend/src/features/settings/SettingsPage.tsx
+++ b/src/frontend/src/features/settings/SettingsPage.tsx
@@ -38,6 +38,7 @@ import {
 } from '../../lib/api';
 import { BuddySettings } from './BuddySettings';
 import { ExtensionApiKeySettings } from './ExtensionApiKeySettings';
+import { FullExportSettings } from './FullExportSettings';
 import { AdminSpeechSettings, PersonalSpeechSettings } from './SpeechSettings';
 
 /* ============================================================
@@ -2285,7 +2286,7 @@ function MyUsageTab() {
 // ---------------- 页面 ----------------
 
 /** 普通用户设置的标签页（管理员那组在 /admin，见 AdminSettingsPage）。 */
-type Tab = 'personal' | 'prefs' | 'buddy' | 'speech' | 'bots' | 'ssh' | 'myusage' | 'extension' | 'mcp';
+type Tab = 'personal' | 'prefs' | 'buddy' | 'speech' | 'bots' | 'ssh' | 'myusage' | 'extension' | 'mcp' | 'export';
 
 /** 旧的 /settings?tab=xxx 深链里属于管理员组的值 → 统一改跳 /admin。 */
 export const ADMIN_TABS = ['llm', 'daily', 'usage'] as const;
@@ -2716,7 +2717,7 @@ export function DailyCategoriesTab() {
   );
 }
 
-const PERSONAL_TABS: Tab[] = ['personal', 'prefs', 'buddy', 'speech', 'bots', 'ssh', 'myusage', 'extension', 'mcp'];
+const PERSONAL_TABS: Tab[] = ['personal', 'prefs', 'buddy', 'speech', 'bots', 'ssh', 'myusage', 'extension', 'mcp', 'export'];
 
 export function SettingsPage() {
   // 支持 /settings?tab=mcp 这类深链（如旧 /mcp-tools 路由的重定向）
@@ -2745,6 +2746,7 @@ export function SettingsPage() {
     { v: 'myusage', label: tr('用量', 'Usage') },
     { v: 'extension', label: tr('Polaris 扩展', 'Polaris extension') },
     { v: 'mcp', label: tr('MCP 接入', 'MCP access') },
+    { v: 'export', label: tr('数据导出', 'Data export') },
   ];
 
   return (
@@ -2762,6 +2764,7 @@ export function SettingsPage() {
       {tab === 'myusage' && <MyUsageTab />}
       {tab === 'extension' && <ExtensionApiKeySettings />}
       {tab === 'mcp' && <McpToolsContent />}
+      {tab === 'export' && <FullExportSettings />}
     </div>
   );
 }

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -4550,6 +4550,14 @@ export const api = {
     return requestBlob(`/libraries/${libraryId}/export/obsidian`);
   },
 
+  // —— 一键全量导出（#690）：入队后走 /paper-tasks/{task_id}/events 订阅进度 ——
+  startFullExport(): Promise<{ task_id: string }> {
+    return request<{ task_id: string }>('/export/full', { method: 'POST' });
+  },
+  downloadFullExport(taskId: string): Promise<Blob> {
+    return requestBlob(`/export/full/${taskId}/download`);
+  },
+
   // —— M2 · Dashboard 统计 ——
   getStats(projectId: string): Promise<StatsRead> {
     return request<StatsRead>(`/projects/${projectId}/stats`);


### PR DESCRIPTION
Closes #690. Design report §17/§18 trust design ② — "free to leave" as a product feature, not a clause.

One action packs everything the user owns into a zip: per-library `library.json` (settings + full member roster) with `papers.bib`/`papers.csl.json` via the existing citation builders and citekey-matched PDFs; notes/highlights as per-paper Markdown with identifying frontmatter; the wiki as its existing Obsidian-vault structure (unpacked in place from the existing exporter — image links and backlinks logic not duplicated); discovery runs as tree + readable proposal + disclosure; experiments as plan/runs/metrics/artifact listings with internal paths scrubbed; manuscripts with sources and compiled PDFs; a top-level manifest (counts × 9, warnings) and a bilingual README.

- library scope is deliberately mine-plus-project-linked, not every public library
- empty facets skip; a single failing item lands in `manifest.warnings` instead of sinking the archive
- runs as a queued task on the existing paper-task event channel (existing SSE progress UI just works); single-flight via a Redis NX+TTL lock; download endpoint is owner-checked with ASCII-safe filenames; no migrations
- settings gains a "data export" tab with plain-language copy

Verification: clean baseline 1676 passed / 3 pre-existing #581 failures; branch 1681 = baseline + exactly the 5 new tests, same failures — zero new; goldens unchanged; rebased onto #692 cleanly with a 30-test cross-surface re-run green; frontend tsc/build/vitest 158 green.