### PR TITLE
feat: snapshot local databases before migrations with rollback on failure

### DIFF
--- a/src/desktop/src/bootstrap-smoke.ts
+++ b/src/desktop/src/bootstrap-smoke.ts
@@ -13,19 +13,25 @@
      node dist/bootstrap-smoke.cjs --resources <解包产物的 resources 目录> \
        [--data <临时 userData>] [--keep]
 
-   步骤：bootstrap（uv 装 Python → venv → 装后端）→ spawn 引擎 argv →
-   轮询 /api/health 到 200 → 回收进程 → 删测试数据目录（--keep 保留）。
-   每步耗时打到 stdout，退出码非 0 即失败。
+   步骤：bootstrap（uv 装 Python → venv → 装后端）→ 引擎起两轮
+   （首轮空库不快照；次轮非空库应先落一份迁移前快照，见 #694）→
+   用 venv Python 单独驱动迁移守卫片段验证「失败还原 + 成功修剪」→
+   删测试数据目录（--keep 保留）。每步耗时打到 stdout，退出码非 0 即失败。
    ============================================================ */
 
 import { spawn, type ChildProcess } from 'node:child_process';
-import { mkdtempSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 
-import { bootstrapEngine, type BootstrapPhase } from './main/engine-bootstrap';
+import {
+  bootstrapEngine,
+  buildMigrationGuard,
+  type BootstrapPhase,
+  type EngineCommand,
+} from './main/engine-bootstrap';
 
 const HEALTH_TIMEOUT_MS = 120_000;
 
@@ -61,6 +67,122 @@ function waitExit(child: ChildProcess, ms: number): Promise<boolean> {
   });
 }
 
+/** 拉起引擎 argv，轮询 /api/health 到 200，然后回收进程。 */
+async function runEngineOnce(config: EngineCommand): Promise<void> {
+  // 与 legacy-engine 插件 command 模式相同的 spawn 环境（它注入的两个变量
+  // 这里照抄；引导器返回的 argv 自带 chdir 与数据库地址，见 engine-bootstrap）
+  const child = spawn(config.command[0]!, config.command.slice(1), {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env, POLARIS_PROFILE: 'desktop', POLARIS_LLM_FAKE_FALLBACK: '1' },
+  });
+  const tail: string[] = [];
+  const capture = (chunk: Buffer): void => {
+    for (const line of chunk.toString().split('\n')) {
+      if (!line.trim()) continue;
+      tail.push(line);
+      if (tail.length > 100) tail.shift();
+    }
+  };
+  child.stdout!.on('data', capture);
+  child.stderr!.on('data', capture);
+
+  try {
+    const baseUrl = `http://127.0.0.1:${config.port}`;
+    const tHealth = Date.now();
+    const deadline = tHealth + HEALTH_TIMEOUT_MS;
+    for (;;) {
+      if (child.exitCode !== null || child.signalCode !== null) {
+        throw new Error(`引擎提前退出 (code=${child.exitCode})\n${tail.join('\n')}`);
+      }
+      try {
+        const res = await fetch(`${baseUrl}/api/health`);
+        if (res.ok) {
+          console.log(`GET ${baseUrl}/api/health → ${res.status} ${await res.text()}`);
+          console.log(`engine healthy in ${((Date.now() - tHealth) / 1000).toFixed(1)}s (含 alembic 迁移)`);
+          break;
+        }
+      } catch {
+        /* 还没起来 */
+      }
+      if (Date.now() > deadline) {
+        throw new Error(`引擎 ${HEALTH_TIMEOUT_MS}ms 内未就绪\n${tail.join('\n')}`);
+      }
+      await delay(500);
+    }
+  } finally {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill('SIGTERM');
+      if (!(await waitExit(child, 5_000))) {
+        child.kill('SIGKILL');
+        await waitExit(child, 5_000);
+      }
+    }
+  }
+}
+
+/** 跑一段 python -c，返回退出码；失败时把 stderr 打出来供排查。 */
+function runPython(python: string, code: string): Promise<number> {
+  return new Promise((resolveExit, rejectExit) => {
+    const child = spawn(python, ['-X', 'utf8', '-c', code], { stdio: ['ignore', 'ignore', 'pipe'] });
+    let stderr = '';
+    child.stderr!.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    child.on('error', rejectExit);
+    child.on('exit', (exitCode) => {
+      if (exitCode !== 0) console.log(`   python 退出码 ${exitCode}：\n${stderr.trim()}`);
+      resolveExit(exitCode ?? 1);
+    });
+  });
+}
+
+/**
+ * 引擎跑两轮太贵，失败注入更没法对真 alembic 做——所以「失败还原 +
+ * 成功修剪」直接用 venv Python 驱动 buildMigrationGuard 生成的同一段
+ * 片段验证：伪迁移命令先把库改坏再失败，守卫必须把文件组还原并透传
+ * 非零退出；随后的空操作成功迁移把快照修剪到 3 份。
+ */
+async function assertGuardSemantics(python: string): Promise<void> {
+  const dir = mkdtempSync(join(tmpdir(), 'polaris-guard-'));
+  try {
+    const db = join(dir, 'polaris.db').split('\\').join('/');
+    const snapRoot = join(dir, 'snapshots').split('\\').join('/');
+    writeFileSync(db, 'original-db');
+    writeFileSync(`${db}-wal`, 'original-wal');
+
+    // 伪迁移先覆写主库再失败：逼出「真还原」，而不是「碰巧没动过」
+    const sabotage = `open(${JSON.stringify(db)}, 'wb').write(b'corrupted'); raise SystemExit(3)`;
+    const failCode = buildMigrationGuard(db, snapRoot, `[sys.executable, '-c', ${JSON.stringify(sabotage)}]`).join('\n');
+    if ((await runPython(python, failCode)) === 0) {
+      throw new Error('migration guard: 迁移失败必须透传为非零退出');
+    }
+    if (readFileSync(db, 'utf8') !== 'original-db') {
+      throw new Error('migration guard: 迁移失败后主库文件没有还原');
+    }
+    if (readFileSync(`${db}-wal`, 'utf8') !== 'original-wal') {
+      throw new Error('migration guard: 迁移失败后 -wal 没有还原');
+    }
+    if (readdirSync(snapRoot).length !== 1) {
+      throw new Error('migration guard: 失败现场应保留恰好 1 份快照');
+    }
+
+    // 成功路径：每轮留一份快照，修剪只保最近 3 份
+    const okCode = buildMigrationGuard(db, snapRoot, "[sys.executable, '-c', 'pass']").join('\n');
+    for (let i = 0; i < 4; i++) {
+      if ((await runPython(python, okCode)) !== 0) {
+        throw new Error('migration guard: 空操作迁移不该失败');
+      }
+    }
+    const kept = readdirSync(snapRoot);
+    if (kept.length !== 3) {
+      throw new Error(`migration guard: 快照应修剪到 3 份，实际 ${kept.length} 份`);
+    }
+    console.log('migration guard: 失败还原 + 成功修剪 OK');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
 async function main(): Promise<void> {
   const args = parseArgs();
   const dataDir = args.data ? resolve(args.data) : mkdtempSync(join(tmpdir(), 'polaris-engine-smoke-'));
@@ -73,7 +195,6 @@ async function main(): Promise<void> {
   let phaseStart = Date.now();
   let lineCount = 0;
 
-  let engineChild: ChildProcess | null = null;
   let failed = false;
   try {
     const t0 = Date.now();
@@ -98,59 +219,38 @@ async function main(): Promise<void> {
     console.log(`\nbootstrap done in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
     for (const [phase, ms] of timings) console.log(`  ${phase.padEnd(8)} ${(ms / 1000).toFixed(1)}s`);
 
-    // 与 legacy-engine 插件 command 模式相同的 spawn 环境（它注入的两个变量
-    // 这里照抄；引导器返回的 argv 自带 chdir 与数据库地址，见 engine-bootstrap）
-    console.log('\n== engine start');
-    const child = spawn(config.command[0]!, config.command.slice(1), {
-      stdio: ['ignore', 'pipe', 'pipe'],
-      env: { ...process.env, POLARIS_PROFILE: 'desktop', POLARIS_LLM_FAKE_FALLBACK: '1' },
-    });
-    engineChild = child;
-    const tail: string[] = [];
-    const capture = (chunk: Buffer): void => {
-      for (const line of chunk.toString().split('\n')) {
-        if (!line.trim()) continue;
-        tail.push(line);
-        if (tail.length > 100) tail.shift();
-      }
-    };
-    child.stdout!.on('data', capture);
-    child.stderr!.on('data', capture);
+    const snapRoot = join(dataDir, 'engine', 'snapshots');
 
-    const baseUrl = `http://127.0.0.1:${config.port}`;
-    const tHealth = Date.now();
-    const deadline = tHealth + HEALTH_TIMEOUT_MS;
-    for (;;) {
-      if (child.exitCode !== null || child.signalCode !== null) {
-        throw new Error(`引擎提前退出 (code=${child.exitCode})\n${tail.join('\n')}`);
-      }
-      try {
-        const res = await fetch(`${baseUrl}/api/health`);
-        if (res.ok) {
-          console.log(`GET ${baseUrl}/api/health → ${res.status} ${await res.text()}`);
-          console.log(`engine healthy in ${((Date.now() - tHealth) / 1000).toFixed(1)}s (含 alembic 迁移)`);
-          break;
-        }
-      } catch {
-        /* 还没起来 */
-      }
-      if (Date.now() > deadline) {
-        throw new Error(`引擎 ${HEALTH_TIMEOUT_MS}ms 内未就绪\n${tail.join('\n')}`);
-      }
-      await delay(500);
+    // 首轮：空库首启，守卫应跳过快照（没有可保护的数据）
+    console.log('\n== engine run 1 (fresh database)');
+    await runEngineOnce(config);
+    if (existsSync(snapRoot) && readdirSync(snapRoot).length > 0) {
+      throw new Error('首启空库不该产生迁移前快照');
     }
+
+    // 次轮：库已非空，alembic（即便空操作）之前必须先落一份快照
+    console.log('\n== engine run 2 (snapshot before alembic)');
+    await runEngineOnce(config);
+    const snaps = existsSync(snapRoot) ? readdirSync(snapRoot) : [];
+    if (snaps.length === 0) {
+      throw new Error('第二次启动应在迁移前留下快照目录');
+    }
+    for (const name of snaps) {
+      if (!existsSync(join(snapRoot, name, 'polaris.db'))) {
+        throw new Error(`快照 ${name} 里缺少 polaris.db`);
+      }
+    }
+    console.log(`snapshots after run 2: ${snaps.sort().join(', ')}`);
+
+    // 守卫语义：失败还原 + 成功修剪（用引导出来的 venv Python 驱动）
+    console.log('\n== migration guard semantics');
+    await assertGuardSemantics(config.command[0]!);
+
     console.log('\nbootstrap-smoke: PASS');
   } catch (err) {
     failed = true;
     console.error(`\nbootstrap-smoke: FAIL — ${err instanceof Error ? err.message : String(err)}`);
   } finally {
-    if (engineChild && engineChild.exitCode === null && engineChild.signalCode === null) {
-      engineChild.kill('SIGTERM');
-      if (!(await waitExit(engineChild, 5_000))) {
-        engineChild.kill('SIGKILL');
-        await waitExit(engineChild, 5_000);
-      }
-    }
     if (args.keep) {
       console.log(`bootstrap-smoke: --keep，保留 ${dataDir}`);
     } else {

--- a/src/desktop/src/main/engine-bootstrap.ts
+++ b/src/desktop/src/main/engine-bootstrap.ts
@@ -190,6 +190,7 @@ export async function bootstrapEngine(opts: BootstrapOptions): Promise<EngineCom
  */
 function buildEngineCommand(venvPython: string, backendDir: string, engineDir: string): string[] {
   const dbPath = join(engineDir, 'polaris.db').split('\\').join('/');
+  const snapshotRoot = join(engineDir, 'snapshots').split('\\').join('/');
   // JSON.stringify 产出的字符串字面量对 Python 同样合法（转义子集兼容），
   // 借它安全嵌入含空格/反斜杠/非 ASCII 的路径
   const launcher = [
@@ -199,10 +200,63 @@ function buildEngineCommand(venvPython: string, backendDir: string, engineDir: s
     "os.environ.setdefault('POLARIS_PROFILE', 'desktop')",
     `os.environ['POLARIS_DATABASE_URL'] = ${JSON.stringify(`sqlite+aiosqlite:///${dbPath}`)}`,
     `os.chdir(${JSON.stringify(backendDir)})`,
-    "subprocess.run([sys.executable, '-m', 'alembic', 'upgrade', 'head'], check=True)",
+    ...buildMigrationGuard(dbPath, snapshotRoot, "[sys.executable, '-m', 'alembic', 'upgrade', 'head']"),
     'import uvicorn',
     `uvicorn.run('app.main:app', host='127.0.0.1', port=${ENGINE_PORT})`,
   ].join('\n');
   // -X utf8：启动器自身的解释器也走 UTF-8 模式（env 对已启动的进程无效）
   return [venvPython, '-X', 'utf8', '-c', launcher];
+}
+
+/**
+ * 迁移守卫的 Python 片段（#694）：跑迁移命令前把非空库快照到
+ * snapshots/<时间戳>/，命令失败（check=True 抛 CalledProcessError）先把
+ * 快照复制回原位再重新抛出——引擎照现有流程失败退出/回落，但库保证
+ * 停在迁移前；成功则只保留最近 3 份快照。
+ *
+ * 为什么放在启动器 Python 串里而不是 TS 侧：bootstrapEngine 有哨兵，
+ * 后端没变化的启动整段跳过，而 alembic 是引擎每次 spawn 都会跑的——
+ * 快照必须与 alembic 同进程同时机，TS 侧根本不知道它何时执行。
+ * 纯 stdlib（os/shutil/datetime/subprocess），不给后端加任何依赖。
+ *
+ * `migrateArgv` 是一个 Python 表达式字符串（如
+ * "[sys.executable, '-m', 'alembic', 'upgrade', 'head']"），原样嵌进
+ * subprocess.run(...)；表达式形态让 bootstrap-smoke 能塞入伪造的失败
+ * 命令单独验证「还原快照」路径。片段自带 import，可独立喂给 python -c。
+ */
+export function buildMigrationGuard(dbPath: string, snapshotRoot: string, migrateArgv: string): string[] {
+  return [
+    'import datetime, os, shutil, subprocess, sys',
+    `_db = ${JSON.stringify(dbPath)}`,
+    `_snap_root = ${JSON.stringify(snapshotRoot)}`,
+    // -wal 里可能有未合并的写入，只拷主文件会丢数据；三个文件成组进退
+    "_sfx = ('', '-wal', '-shm')",
+    '_snap = None',
+    // 空库/不存在（首启）不快照：没有可保护的数据就不留空目录
+    'if os.path.exists(_db) and os.path.getsize(_db) > 0:',
+    // 冒号在 Windows 文件名里非法；%f（微秒）让同秒重启也不撞名
+    "    _stamp = datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H-%M-%S.%fZ')",
+    '    _snap = os.path.join(_snap_root, _stamp)',
+    '    os.makedirs(_snap, exist_ok=True)',
+    '    for _s in _sfx:',
+    '        if os.path.exists(_db + _s):',
+    '            shutil.copy2(_db + _s, os.path.join(_snap, os.path.basename(_db) + _s))',
+    'try:',
+    `    subprocess.run(${migrateArgv}, check=True)`,
+    'except BaseException:',
+    '    if _snap is not None:',
+    '        for _s in _sfx:',
+    '            _saved = os.path.join(_snap, os.path.basename(_db) + _s)',
+    '            if os.path.exists(_saved):',
+    '                shutil.copy2(_saved, _db + _s)',
+    // 快照里没有的伴生文件要删掉现场的：失败迁移留下的新 -wal
+    // 会在还原后的主文件上重放，等于又把库弄脏
+    '            elif os.path.exists(_db + _s):',
+    '                os.remove(_db + _s)',
+    '    raise',
+    'if _snap is not None:',
+    '    _dirs = sorted(_d for _d in os.listdir(_snap_root) if os.path.isdir(os.path.join(_snap_root, _d)))',
+    '    for _old in _dirs[:-3]:',
+    '        shutil.rmtree(os.path.join(_snap_root, _old), ignore_errors=True)',
+  ];
 }

--- a/src/kernel/src/index.ts
+++ b/src/kernel/src/index.ts
@@ -17,7 +17,17 @@ export {
   legacyEngine,
   type LegacyEngineService,
 } from './plugins/legacy-engine.ts'
-export { MIGRATIONS, migrate, openStorage, type Migration } from './storage/db.ts'
+export {
+  MIGRATIONS,
+  SNAPSHOT_KEEP,
+  migrate,
+  openStorage,
+  openStorageWithMigrations,
+  pruneSnapshots,
+  restoreSnapshot,
+  snapshotDatabase,
+  type Migration,
+} from './storage/db.ts'
 export { PluginMetaStore, SqliteConfigTreeStore } from './storage/store.ts'
 export { StorageConfig, storage, type StorageService } from './plugins/storage.ts'
 export {

--- a/src/kernel/src/plugins/storage.ts
+++ b/src/kernel/src/plugins/storage.ts
@@ -13,7 +13,7 @@
 import type { DatabaseSync } from 'node:sqlite'
 import Schema from '@deepseek-ai/schemastery'
 import type { Context } from '@deepseek-ai/cordis'
-import { migrate, openStorage } from '../storage/db.ts'
+import { openStorageWithMigrations } from '../storage/db.ts'
 import { PluginMetaStore, SqliteConfigTreeStore } from '../storage/store.ts'
 
 export interface StorageConfig {
@@ -44,8 +44,10 @@ export const storage = {
   apply(ctx: Context, config: StorageConfig): void {
     let db!: DatabaseSync
     ctx.effect(() => {
-      db = openStorage(config.path)
-      migrate(db)
+      // 打开即迁移，且被快照守护（#694）：非空库先复制到旁边的
+      // snapshots/<时间戳>/，迁移失败就还原文件再把错误抛给装载方——
+      // 插件装载失败，但库保证完好停在迁移前；成功则只保留最近几份。
+      db = openStorageWithMigrations(config.path)
       return () => {
         try {
           db.close()

--- a/src/kernel/src/storage/db.ts
+++ b/src/kernel/src/storage/db.ts
@@ -11,8 +11,8 @@
    down-migration）、按版本号有序执行、事务内落表并记账，重跑天然无操作。
    ============================================================ */
 
-import { mkdirSync } from 'node:fs'
-import { dirname } from 'node:path'
+import { copyFileSync, existsSync, mkdirSync, readdirSync, rmSync, statSync } from 'node:fs'
+import { basename, dirname, join } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
 
 export interface Migration {
@@ -99,4 +99,94 @@ export function migrate(db: DatabaseSync, migrations: Migration[] = MIGRATIONS):
       throw error
     }
   }
+}
+
+/* ---------- 迁移前快照 + 失败回滚（#694） ----------
+   迁移器只前向不回滚，但「迁移把库改坏」这种事故必须可撤销：每次
+   migrate 前把库文件按原样复制到 snapshots/<时间戳>/ 下，失败就整组
+   文件复制回来——文件级还原比 SQL 级 down-migration 简单且绝对可靠。
+   与桌面引擎侧（engine-bootstrap 启动器里的 alembic 守卫）语义对齐。 */
+
+/** 快照要带上的 SQLite 伴生文件后缀。WAL 模式下 -wal 里可能有未合并
+    的写入，只拷主文件会丢数据；-shm 是共享内存索引，跟着拷保持成组。 */
+const DB_FILE_SUFFIXES = ['', '-wal', '-shm'] as const
+
+/** 成功迁移后保留的快照份数，更旧的删除。 */
+export const SNAPSHOT_KEEP = 3
+
+/** 库文件旁边的快照根目录：<库所在目录>/snapshots。 */
+function snapshotRoot(path: string): string {
+  return join(dirname(path), 'snapshots')
+}
+
+/**
+ * 把库文件（含 -wal/-shm 若存在）复制成一份快照，返回快照目录。
+ * 空库或不存在（首启）返回 null——没有可保护的数据就不留空快照。
+ * 必须在库被打开之前调用：无打开句柄时磁盘上的文件组才保证自洽。
+ */
+export function snapshotDatabase(path: string): string | null {
+  if (!existsSync(path) || statSync(path).size === 0) return null
+  // 冒号在 Windows 文件名里非法，换成横线；同毫秒重入时用 -2/-3 后缀
+  // 避让（后缀名字典序仍排在原名之后，prune 的排序不乱）。
+  const stamp = new Date().toISOString().replace(/:/g, '-')
+  const root = snapshotRoot(path)
+  let dir = join(root, stamp)
+  for (let n = 2; existsSync(dir); n++) dir = join(root, `${stamp}-${n}`)
+  mkdirSync(dir, { recursive: true })
+  for (const suffix of DB_FILE_SUFFIXES) {
+    if (existsSync(path + suffix)) copyFileSync(path + suffix, join(dir, basename(path) + suffix))
+  }
+  return dir
+}
+
+/**
+ * 用快照覆盖回库文件。快照里没有的伴生文件要把现场的删掉：失败的
+ * 迁移可能留下一个新 -wal，主文件还原后再被它重放就又脏了。
+ * 必须在库句柄关闭之后调用。
+ */
+export function restoreSnapshot(path: string, snapshotDir: string): void {
+  for (const suffix of DB_FILE_SUFFIXES) {
+    const saved = join(snapshotDir, basename(path) + suffix)
+    if (existsSync(saved)) copyFileSync(saved, path + suffix)
+    else rmSync(path + suffix, { force: true })
+  }
+}
+
+/** 按名字（即时间戳）排序，删掉最旧的、只留 keep 份。 */
+export function pruneSnapshots(path: string, keep: number = SNAPSHOT_KEEP): void {
+  const root = snapshotRoot(path)
+  if (!existsSync(root)) return
+  const dirs = readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort()
+  for (const name of dirs.slice(0, Math.max(0, dirs.length - keep))) {
+    rmSync(join(root, name), { recursive: true, force: true })
+  }
+}
+
+/**
+ * 打开并迁移，整个过程被快照守护：迁移抛错 → 关句柄 → 文件还原 →
+ * 原错误照抛（调用方按「迁移失败」处理，库保证停在迁移前的状态）；
+ * 成功才修剪旧快照——失败现场的快照永远留着供人排查。
+ */
+export function openStorageWithMigrations(
+  path: string,
+  migrations: Migration[] = MIGRATIONS,
+): DatabaseSync {
+  const snapshot = snapshotDatabase(path)
+  const db = openStorage(path)
+  try {
+    migrate(db, migrations)
+  } catch (error) {
+    try {
+      db.close()
+    } catch {
+      // 还原优先：句柄关不上也要把文件抢救回去
+    }
+    if (snapshot) restoreSnapshot(path, snapshot)
+    throw error
+  }
+  if (snapshot) pruneSnapshots(path)
+  return db
 }

--- a/src/kernel/tests/snapshot.test.ts
+++ b/src/kernel/tests/snapshot.test.ts
@@ -1,0 +1,79 @@
+/* 迁移前快照 + 失败回滚（#694）的单元测试。用「追加一条坏 SQL 的
+   迁移」模拟升级事故：断言库文件被逐字节还原、原错误照抛、之后仍能
+   用正常迁移打开且数据无损；成功路径断言快照存在并修剪到只留 3 份。 */
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, describe, expect, it } from 'vitest'
+import {
+  MIGRATIONS,
+  PluginMetaStore,
+  SNAPSHOT_KEEP,
+  openStorageWithMigrations,
+  type Migration,
+} from '../src/index.ts'
+
+const dir = mkdtempSync(join(tmpdir(), 'kernel-snapshot-'))
+afterAll(() => rmSync(dir, { recursive: true, force: true }))
+
+let seq = 0
+/** 每个用例独立子目录：snapshots/ 落在库旁边，互相不串。 */
+const freshPath = (): string => join(dir, `case-${++seq}`, 'storage.db')
+
+/** 在 MIGRATIONS 之后追加一条必然失败的迁移，模拟「升级把库搞坏」。 */
+const badMigrations = (): Migration[] => [
+  ...MIGRATIONS,
+  { version: 9999, statements: ['THIS IS NOT SQL'] },
+]
+
+const snapshotsRoot = (path: string): string => join(path, '..', 'snapshots')
+
+describe('database snapshot before migrations', () => {
+  it('does not snapshot a fresh (empty) database', () => {
+    const path = freshPath()
+    const db = openStorageWithMigrations(path)
+    db.close()
+    expect(existsSync(snapshotsRoot(path))).toBe(false)
+  })
+
+  it('restores the files and rethrows when a migration fails', () => {
+    const path = freshPath()
+    // 先造一个有数据的正常库
+    const db = openStorageWithMigrations(path)
+    new PluginMetaStore(db).set('探针', { 值: '迁移前' })
+    db.close()
+    const before = readFileSync(path)
+
+    // 坏迁移：错误原样抛出，不能被吞成静默降级
+    expect(() => openStorageWithMigrations(path, badMigrations())).toThrow(/syntax|SQL/i)
+
+    // 库文件逐字节回到迁移前；失败留下的 -wal/-shm 也被清场
+    expect(readFileSync(path)).toEqual(before)
+    expect(existsSync(`${path}-wal`)).toBe(false)
+    expect(existsSync(`${path}-shm`)).toBe(false)
+
+    // 失败现场的快照保留（不修剪），且就是迁移前的那份
+    const kept = readdirSync(snapshotsRoot(path))
+    expect(kept.length).toBe(1)
+    expect(readFileSync(join(snapshotsRoot(path), kept[0]!, 'storage.db'))).toEqual(before)
+
+    // 还原后的库仍可正常打开，数据无损
+    const reopened = openStorageWithMigrations(path)
+    expect(new PluginMetaStore(reopened).get('探针')).toEqual({ 值: '迁移前' })
+    reopened.close()
+  })
+
+  it('keeps a snapshot on success and prunes to the retention limit', () => {
+    const path = freshPath()
+    // 首启（空库）不产生快照；之后每次打开都会先快照再迁移
+    for (let round = 0; round < SNAPSHOT_KEEP + 3; round++) {
+      openStorageWithMigrations(path).close()
+    }
+    const names = readdirSync(snapshotsRoot(path)).sort()
+    expect(names.length).toBe(SNAPSHOT_KEEP)
+    // 每份快照都完整带着主库文件
+    for (const name of names) {
+      expect(existsSync(join(snapshotsRoot(path), name, 'storage.db'))).toBe(true)
+    }
+  })
+})

--- a/src/kernel/tests/storage.test.ts
+++ b/src/kernel/tests/storage.test.ts
@@ -184,6 +184,8 @@ describe('storage plugin', () => {
     const reloaded = kernel.ctx.get('storage') as StorageService
     expect(reloaded.pluginMeta.get('probe')).toEqual({ 值: 1 })
     expect(await reloaded.configTree.load()).toEqual(sampleTree())
+    // 重装走的是快照守护路径（#694）：非空库在迁移前留下了一份快照
+    expect(existsSync(join(dir, 'nested', 'deeper', 'snapshots'))).toBe(true)
 
     await kernel.stop()
     expect(() => reloaded.db.prepare('SELECT 1')).toThrow()


### PR DESCRIPTION
Closes #694. Design report §16 (first-release must-have): a failed migration must never leave the user's local database half-migrated.

- **engine side lives in the launcher, deliberately**: the TS bootstrap is sentinel-gated and skips entirely when the backend hasn't changed, while alembic runs on every engine spawn — a TS-side guard would miss exactly the post-upgrade first start it exists to protect. `buildMigrationGuard` emits stdlib-only Python wrapping the alembic step; zero backend changes
- semantics (identical on both layers): snapshot only a non-empty database (first start skips), copying db + `-wal`/`-shm` siblings to a timestamped folder beside it; on failure restore the whole group **and delete stray siblings the snapshot didn't have** (a failed migration's fresh WAL would replay over the restored main file), then rethrow — the engine falls back per the existing flow; prune to the last 3 snapshots only on success, failure-scene snapshots are always kept for diagnosis
- kernel storage (#688) gets the same guard via `openStorageWithMigrations` (node:fs only, electron-free scan green)
- tests: kernel injects a failing migration and asserts byte-identical restoration, sibling cleanup, error propagation, and prune-to-3; the bootstrap smoke runs the engine twice (no snapshot on empty first start, snapshot present on the second) and drives the generated guard fragment directly through a fake failing migration

Verification: kernel 43 tests, desktop lint/build/smoke (persistence group green, "全部通过"), frontend build — all green; no backend/suite impact.