### PR TITLE
feat: BYO runner tier 2 outbound WebSocket transport

### DIFF
--- a/docs/byo-runner.md
+++ b/docs/byo-runner.md
@@ -9,7 +9,7 @@ Polaris 把「在哪跑实验」交给用户：实验室 GPU 机、云主机、�
 | Tier | 接入方式 | 状态 |
 | --- | --- | --- |
 | 1 | SSH 可达（平台主动连出去） | **已实现**（本页上半部分） |
-| 2 | 出站 WebSocket agent（机器主动连回来，适合 NAT/内网机） | **未实现**，协议草案见下 |
+| 2 | 出站 WebSocket agent（机器主动连回来，适合 NAT/内网机） | **传输层已实现**（#695，本页下半部分）；实验执行接线归 runner v2 后续 |
 
 ## Tier 1：SSH 直连（已实现）
 
@@ -66,52 +66,66 @@ GitHub self-hosted runner 的教训：非 ephemeral 环境的残留物会变成�
 - 解密后的私钥只进 asyncssh 连接参数，不进日志、不进 Activity、不进异常文本
   （连接失败的 detail 会先过 `scrub_secrets` 抹除，测试钉住该行为）。
 
-## Tier 2：出站 WebSocket agent（未实现，协议草案）
-
-> Not implemented. 本节是设计笔记，落地前以此为讨论基线；实现时另立 RFC。
+## Tier 2：出站 WebSocket agent（传输层已实现，#695）
 
 场景：内网/NAT 后的机器，平台连不进去。方案学 GitHub self-hosted runner：
-机器上跑一个常驻 agent，**出站**长连接拉任务，永不要求开入站端口；
-复杂 NAT 场景文档化 Tailscale，不自研穿透。
+机器上跑一个常驻 agent（参考实现 `integrations/runner-agent/`），**出站**
+长连接拉任务，永不要求开入站端口；复杂 NAT 场景文档化 Tailscale，不自研穿透。
 
-### 注册（短时效 token）
+当前范围：**传输层可用**——注册、长连接、心跳在线判定、任务派发座
+（`dispatch_task`）、事件回传。实验执行链（runner v2 在此底座上的接线：
+run 级派发、组件清单、产物分块上传、agent 自动升级、seq/ack 断点续传）
+归后续 PR。服务端实现：`app/services/runner_ws.py`。
+
+### 注册（短时效一次性 token）
 
 ```
-POST /api/resources/runner-hosts/registration-token   （用户，Web 端）
-  → {"token": "prt_…", "expires_in": 3600}            （一次性、短命）
+POST /api/resources/runner-hosts/registration-tokens    （登录用户，Web 端）
+  → {"token": "prt_…", "expires_in": 3600}              （一次性、1 小时时效）
 
-$ polaris-runner register --url https://polaris.example --token prt_…
+$ python agent.py register --server https://polaris.example --token prt_…
+  （agent 内部调 POST /api/resources/runner-hosts/register，
+   携 token + name + machine 自述信息）
 ```
 
-agent 用 token 换取长期凭据（仅限该机器身份），token 立即作废。注册成功 =
-服务端自动创建 `host` 类 Resource（与 tier-1 同一张表，租约语义共用），
-`config.transport = "websocket"`。
+- token 是随机串 + Redis TTL，GETDEL 原子消费：**用后即焚**，重放/过期一律
+  401（不区分原因）；
+- 注册成功 = 自动创建 `host` 类 Resource（与 tier-1 同一张表，租约语义共用），
+  `config.transport = "websocket"`、`config.machine` 存 agent 自述信息；
+- 机器凭据落 `connection_credentials`（kind=`ws`）：**只存 agent secret 的
+  sha256 摘要**（Fernet 加密后入 payload），明文 secret 仅注册响应返回一次，
+  服务端无法找回；agent 存本地 `~/.polaris-runner/agent.json`（0600）。
 
 ### 任务拉取（出站 WS 长连接）
 
 ```
-agent → wss://polaris.example/api/runner-agent/ws     （Authorization: 机器凭据）
-  ← {"kind": "hello", "agent_version": "…"}            agent 自述版本/硬件（probe 结果）
-  → {"kind": "upgrade", "payload_url": …}              版本过期时先升级（同 tier-1 钉定语义）
-  → {"kind": "task", "run_id": …, "spec": {…}}         派发：流程包 + 物料 + container spec
-  ← {"kind": "ack", "run_id": …}
+agent → wss://polaris.example/ws/runner-agents/connect
+  → {"type": "auth", "resource_id": …, "secret": "pra_…"}   首帧鉴权
+  ← {"type": "ready", "resource_id": …}                     鉴权通过
+  ← {"type": "task", "task_id": …, "payload": {…}}          派发（payload 对传输层不透明）
+  → {"type": "heartbeat"}                                   保活（agent 每 30s 一跳）
+  → {"type": "event"|"result", "task_id": …, "data": {…}}   回传
 ```
 
-- 派发以 run 为单位（voyage run 整体交给 runner，携带组件清单）；
-- 无任务时心跳保活；断线重连后按 run_id 对账续传（桌面/服务端离线不炸 run）。
-
-### 事件回传
-
-```
-  ← {"kind": "event", "run_id": …, "seq": N, "event": {…}}   日志/指标/状态，seq 单调
-  ← {"kind": "artifact", "run_id": …, "name": …}             产物分块上传
-  → {"kind": "ack_event", "run_id": …, "seq": N}             服务端确认位点
-```
-
-seq + ack 位点保证断线重连后从确认点续传，不丢不重。
+- 鉴权走**首消息**而非 Authorization header/query：长期 secret 不进 URL 与
+  各级访问日志；失败以 4401 关闭。WS 路径不挂 `/api` 前缀（nginx 按 `/ws`
+  反代 Upgrade，与现有 WS 端点一致）；
+- 在线判定：连接即在线（`config.agent_online`，连接边沿写库），90 秒收不到
+  任何帧（含心跳）判离线并以 4408 关闭；
+- 派发座 `dispatch_task(resource_id, payload) → task_id`：任务先进 Redis
+  队列（**离线排队**，TTL 1 小时兜底），再 publish 唤醒在线连接——在线即推、
+  离线排队、断线重连补投同一条路径；worker 进程也可经 Redis 向 API 进程的
+  连接派发；
+- 事件回传落专用 Redis 记录（`runner:task:{id}:events` 回放 list + 实时频道，
+  同 paper-task 的「先回放后实时」模式但独立 key 空间），runner v2 接线时
+  消费。seq/ack 断点续传（不丢不重的强保证）归接线 PR，当前档位：任务未投递
+  即断线会留在队列里重连补投；投递后 agent 崩溃的重试语义由执行层定义。
 
 ### Ephemeral 承诺
 
-tier-2 的任务**一律**容器内执行（tier-1 的裸机路径不下放）：agent 收到任务后
-`docker run` 一次性容器，结束即销毁，工作区产物先回传再删除。机器凭据可随时
-吊销（同 tier-1 语义），吊销后 WS 连接被服务端主动断开、Resource 标记不可用。
+tier-2 的任务**一律**容器内执行（tier-1 的裸机路径不下放）：注册即
+`config.ephemeral = true`，**不提供关闭口**。agent 收到任务后 `docker run`
+一次性容器，结束即销毁，工作区产物先回传再删除（执行部分随 runner v2 接线；
+参考 agent 目前只执行 echo 型任务验证传输）。机器凭据可随时吊销（同 tier-1
+语义，`DELETE /api/connection-credentials/{id}`）：吊销后新连接 4401 拒绝，
+在跳的连接最迟一个心跳周期内被服务端以 4403 断开，Resource 标记不可用。

--- a/integrations/runner-agent/README.md
+++ b/integrations/runner-agent/README.md
@@ -1,0 +1,55 @@
+# Polaris BYO runner agent（tier-2 参考实现）
+
+跑在你自己机器上的常驻 agent：**出站** WebSocket 连回 Polaris 平台拉任务，
+适合 NAT/内网后、平台连不进来的机器（实验室工作站、家里的 GPU 机）。
+不需要公网 IP，不需要开任何入站端口。协议与服务端实现见
+[docs/byo-runner.md](../../docs/byo-runner.md)。
+
+## 安装
+
+需要 Python 3.10+：
+
+```bash
+pip install -r requirements.txt   # 仅一个依赖：websockets
+```
+
+## 注册（一次性）
+
+1. 在 Polaris Web 端（设置 → 实验资源）生成注册 token：
+   `POST /api/resources/runner-hosts/registration-tokens`，得到 `prt_...`
+   （1 小时内有效、只能用一次）。
+2. 在机器上执行：
+
+```bash
+python agent.py register --server https://polaris.example --token prt_xxx
+```
+
+注册成功后长期机器凭据（agent secret）写入 `~/.polaris-runner/agent.json`
+（权限 0600）。secret 服务端只存摘要、**仅此一次下发**；文件丢了就在平台上
+吊销对应凭据、重新注册。
+
+## 运行
+
+```bash
+python agent.py run
+```
+
+agent 保持出站长连接、每 30 秒心跳；断线自动重连（5 秒退避）。当前为参考
+实现：只执行 echo 型任务（payload 原样回传），容器化实验执行由后续版本接入。
+建议用 systemd/tmux 常驻。
+
+## 吊销
+
+在平台上删除该机器对应的连接凭据（kind=ws）即吊销：在跳的连接最迟一个
+心跳周期内被服务端断开，之后无法再连。
+
+## NAT 很深 / 出站也受限？用 Tailscale
+
+绝大多数 NAT 下直接出站 `wss://` 就能用，无需任何穿透。若机器所在网络
+连平台地址都不可达（如只通内网），推荐 [Tailscale](https://tailscale.com/)
+组网而不是自研穿透：
+
+1. 平台服务器与 runner 机器都加入同一个 tailnet（`tailscale up`）;
+2. `--server` 填平台的 Tailscale 地址（如 `https://polaris-srv.tailnet-xxx.ts.net`
+   或 `http://100.x.y.z:8000`）；
+3. 其余流程完全相同——agent 仍然只是出站连接，Tailscale 负责打洞与加密。

--- a/integrations/runner-agent/agent.py
+++ b/integrations/runner-agent/agent.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Polaris BYO runner agent —— tier-2 出站 WebSocket 参考实现（#695）。
+
+跑在用户自己的机器上（NAT/内网也行）：只发**出站**连接回 Polaris 平台，
+永不要求开入站端口。两个子命令：
+
+    python agent.py register --server https://polaris.example --token prt_xxx
+    python agent.py run
+
+register 用一次性 token 换长期机器凭据（agent secret），存到
+~/.polaris-runner/agent.json（0600，仅本用户可读）；run 建立出站 WS 长连接、
+定期心跳、接收任务。参考实现级别：只会执行 echo 型任务（把 payload 原样回传），
+真正的容器化实验执行由后续版本接入（docs/byo-runner.md）。
+
+依赖：标准库 + websockets（pip install -r requirements.txt）。
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import platform
+import socket
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+CONFIG_PATH = Path.home() / ".polaris-runner" / "agent.json"
+HEARTBEAT_INTERVAL = 30.0  # 服务端 90s 没帧判离线，30s 一跳留足余量
+RECONNECT_DELAY = 5.0
+
+
+def machine_info() -> dict:
+    """注册时自述的机器信息（非敏感；进服务端 Resource.config.machine）。"""
+    return {
+        "hostname": socket.gethostname(),
+        "os": platform.platform(),
+        "python": platform.python_version(),
+        "cpu_count": os.cpu_count(),
+    }
+
+
+def save_config(config: dict) -> None:
+    CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    # 先建 0600 空文件再写入：避免默认 umask 下出现短暂的可读窗口
+    fd = os.open(CONFIG_PATH, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as f:
+        json.dump(config, f, indent=2)
+    print(f"credentials saved to {CONFIG_PATH} (0600)")
+
+
+def load_config() -> dict:
+    if not CONFIG_PATH.exists():
+        sys.exit(f"no config at {CONFIG_PATH}; run `python agent.py register` first")
+    with open(CONFIG_PATH) as f:
+        return json.load(f)
+
+
+def cmd_register(args: argparse.Namespace) -> None:
+    server = args.server.rstrip("/")
+    body = json.dumps(
+        {
+            "token": args.token,
+            "name": args.name or socket.gethostname(),
+            "machine": machine_info(),
+        }
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        f"{server}/api/resources/runner-hosts/register",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            data = json.load(resp)
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", "replace")
+        sys.exit(f"registration failed: HTTP {e.code} {detail}")
+    save_config(
+        {
+            "server": server,
+            "resource_id": data["resource"]["id"],
+            "secret": data["agent_secret"],
+            "ws_path": data.get("ws_path", "/ws/runner-agents/connect"),
+        }
+    )
+    print(f"registered as resource {data['resource']['id']} ({data['resource']['name']})")
+
+
+def ws_url(config: dict) -> str:
+    server = config["server"]
+    scheme = "wss" if server.startswith("https") else "ws"
+    host = server.split("://", 1)[1]
+    return f"{scheme}://{host}{config['ws_path']}"
+
+
+async def send_json(ws, frame: dict) -> None:
+    await ws.send(json.dumps(frame, ensure_ascii=False))
+
+
+async def heartbeat_loop(ws) -> None:
+    while True:
+        await asyncio.sleep(HEARTBEAT_INTERVAL)
+        await send_json(ws, {"type": "heartbeat"})
+
+
+async def handle_task(ws, frame: dict) -> None:
+    """参考实现：echo 型任务原样回传，其余打印后回报 unsupported。
+
+    真正的执行（docker 一次性容器 + 产物回传，ephemeral 承诺）由后续版本接入。
+    """
+    task_id = frame.get("task_id")
+    payload = frame.get("payload") or {}
+    print(f"[task] {task_id}: {json.dumps(payload, ensure_ascii=False)}")
+    await send_json(
+        ws, {"type": "event", "task_id": task_id, "data": {"status": "received"}}
+    )
+    if payload.get("kind") == "echo":
+        await send_json(ws, {"type": "result", "task_id": task_id, "data": {"echo": payload}})
+    else:
+        await send_json(
+            ws,
+            {
+                "type": "result",
+                "task_id": task_id,
+                "data": {"status": "unsupported", "detail": "reference agent only runs echo"},
+            },
+        )
+
+
+async def run_once(config: dict) -> None:
+    import websockets
+
+    url = ws_url(config)
+    async with websockets.connect(url) as ws:
+        await send_json(
+            ws,
+            {"type": "auth", "resource_id": config["resource_id"], "secret": config["secret"]},
+        )
+        ready = json.loads(await ws.recv())
+        if ready.get("type") != "ready":
+            raise RuntimeError(f"unexpected first frame: {ready}")
+        print(f"connected to {url} as resource {config['resource_id']}")
+        hb = asyncio.create_task(heartbeat_loop(ws))
+        try:
+            async for raw in ws:
+                try:
+                    frame = json.loads(raw)
+                except ValueError:
+                    continue
+                if frame.get("type") == "task":
+                    await handle_task(ws, frame)
+        finally:
+            hb.cancel()
+
+
+async def run_forever(config: dict) -> None:
+    while True:
+        try:
+            await run_once(config)
+            print("connection closed by server")
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:  # noqa: BLE001 —— 常驻进程：断线/网络抖动一律重连
+            print(f"connection error: {e!r}")
+        print(f"reconnecting in {RECONNECT_DELAY:.0f}s ...")
+        await asyncio.sleep(RECONNECT_DELAY)
+
+
+def cmd_run(_args: argparse.Namespace) -> None:
+    config = load_config()
+    try:
+        asyncio.run(run_forever(config))
+    except KeyboardInterrupt:
+        print("bye")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Polaris BYO runner agent (tier-2)")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_register = sub.add_parser("register", help="register this machine with a one-time token")
+    p_register.add_argument("--server", required=True, help="Polaris server URL, e.g. https://polaris.example")
+    p_register.add_argument("--token", required=True, help="one-time registration token (prt_...)")
+    p_register.add_argument("--name", default=None, help="display name (default: hostname)")
+    p_register.set_defaults(func=cmd_register)
+
+    p_run = sub.add_parser("run", help="connect outbound and serve tasks")
+    p_run.set_defaults(func=cmd_run)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/runner-agent/requirements.txt
+++ b/integrations/runner-agent/requirements.txt
@@ -1,0 +1,1 @@
+websockets>=12

--- a/src/backend/app/api/resources.py
+++ b/src/backend/app/api/resources.py
@@ -9,10 +9,12 @@
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from redis.asyncio import Redis
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.auth import current_active_user
 from app.core.db import get_session
+from app.core.redis import get_redis_dep
 from app.models.resource import Resource
 from app.models.user import User
 from app.schemas.resource import (
@@ -21,10 +23,14 @@ from app.schemas.resource import (
     ResourceCreate,
     ResourceRead,
     ResourceUpdate,
+    RunnerAgentRegister,
+    RunnerAgentRegistered,
     RunnerHostRegister,
+    RunnerRegistrationTokenRead,
 )
 from app.services import byo_runner as byo_runner_service
 from app.services import resources as resources_service
+from app.services import runner_ws as runner_ws_service
 
 router = APIRouter(prefix="/resources", tags=["resources"])
 credentials_router = APIRouter(prefix="/connection-credentials", tags=["connection-credentials"])
@@ -98,6 +104,53 @@ async def register_runner_host(
     except byo_runner_service.RunnerHostKindError as e:
         raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e)) from e
     return ResourceRead.model_validate(resource)
+
+
+# ---- BYO runner tier-2：出站 WebSocket agent（#695） ----
+
+
+@router.post(
+    "/runner-hosts/registration-tokens",
+    response_model=RunnerRegistrationTokenRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_runner_registration_token(
+    user: User = Depends(current_active_user),
+    redis: Redis = Depends(get_redis_dep),
+) -> RunnerRegistrationTokenRead:
+    """签发一次性注册 token（短时效）：拿到 token 的机器可注册为当前用户的 runner。"""
+    token = await runner_ws_service.issue_registration_token(redis, user_id=user.id)
+    return RunnerRegistrationTokenRead(
+        token=token, expires_in=runner_ws_service.REGISTRATION_TOKEN_TTL
+    )
+
+
+@router.post(
+    "/runner-hosts/register",
+    response_model=RunnerAgentRegistered,
+    status_code=status.HTTP_201_CREATED,
+)
+async def register_runner_agent(
+    data: RunnerAgentRegister,
+    session: AsyncSession = Depends(get_session),
+    redis: Redis = Depends(get_redis_dep),
+) -> RunnerAgentRegistered:
+    """agent 侧注册：token 换长期机器凭据。token 用后即焚（GETDEL 原子消费），
+    无效/过期/重放一律 401，不区分原因。agent_secret 仅此一次返回。"""
+    user_id = await runner_ws_service.consume_registration_token(redis, data.token)
+    if user_id is None:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="INVALID_REGISTRATION_TOKEN")
+    if await session.get(User, user_id) is None:
+        # token 有效期内签发者被删号：同样按无效 token 处理
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="INVALID_REGISTRATION_TOKEN")
+    resource, agent_secret = await runner_ws_service.register_agent_host(
+        session, owner_id=user_id, name=data.name, machine=data.machine
+    )
+    return RunnerAgentRegistered(
+        resource=ResourceRead.model_validate(resource),
+        agent_secret=agent_secret,
+        ws_path="/ws/runner-agents/connect",
+    )
 
 
 @router.get("/{resource_id}", response_model=ResourceRead)

--- a/src/backend/app/api/ws.py
+++ b/src/backend/app/api/ws.py
@@ -7,6 +7,10 @@
 - ``WS /ws/manuscripts/{file_id}?token=<jwt>``（docs/api-m5-b.md §6）：pycrdt CRDT
   协同房间（y-websocket 二进制协议，房间名 = file id）。on_connect 校验
   JWT + 课题归属 + 文件存在且非 readonly，失败分别以 4401 / 4404 / 4403 关闭。
+- ``WS /ws/runner-agents/connect``（docs/byo-runner.md tier-2，#695）：BYO runner
+  出站 agent 长连接。鉴权走**首消息**而非 query 参数（agent secret 是长期凭据，
+  放 URL 会进各级访问日志），失败 4401 关闭；协议与生命周期见
+  app/services/runner_ws.py。
 """
 
 import asyncio
@@ -24,6 +28,7 @@ from app.core.redis import get_redis
 from app.models.project import Project
 from app.models.user import User
 from app.services import manuscripts as manuscripts_service
+from app.services import runner_ws as runner_ws_service
 from app.services.crdt_rooms import get_crdt_rooms
 
 router = APIRouter()
@@ -163,3 +168,10 @@ async def manuscript_crdt_ws(
     finally:
         # 断开即冲刷快照（防抖窗口内的最后编辑不丢）
         await rooms.flush(file.id)
+
+
+@router.websocket("/ws/runner-agents/connect")
+async def runner_agent_ws(websocket: WebSocket) -> None:
+    """BYO runner tier-2 agent 出站连接（#695）。薄转发：协议全在 service 层，
+    便于测试直接驱动 serve_agent（注入 fakeredis 与假 WebSocket）。"""
+    await runner_ws_service.serve_agent(websocket, redis=get_redis())

--- a/src/backend/app/models/ssh_credential.py
+++ b/src/backend/app/models/ssh_credential.py
@@ -19,6 +19,9 @@ app/core/security.py；所有敏感字段绝不明文出库/出 API）：
 - ``visa``：host = 仪器主机（展示用）；payload = {"resource": str
   (pyvisa 资源串，如 "TCPIP0::10.0.0.5::INSTR"), "secret"?: str}。
   资源串含内网定位信息，整体按敏感处理。
+- ``ws``：BYO runner tier-2 机器凭据（#695）。连接方向反过来——agent 出站
+  连回平台，host/port 仅作展示；payload = {"secret_sha256": str}，只存 agent
+  secret 的 sha256 摘要（服务端只需验证、永不回读明文，泄库也拼不回 secret）。
 """
 
 import uuid
@@ -31,7 +34,7 @@ from app.core.db import Base
 from app.models.base import TimestampMixin, UUIDPrimaryKeyMixin
 
 # 合法凭据类型（Runner v2 manifest.credential_kinds 的运行时对应物）
-CREDENTIAL_KINDS = ("ssh", "grpc", "visa", "http")
+CREDENTIAL_KINDS = ("ssh", "grpc", "visa", "http", "ws")
 
 
 class ConnectionCredential(UUIDPrimaryKeyMixin, TimestampMixin, Base):
@@ -40,7 +43,7 @@ class ConnectionCredential(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     user_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=False
     )
-    # ssh | grpc | visa | http（载荷约定见模块 docstring）
+    # ssh | grpc | visa | http | ws（载荷约定见模块 docstring）
     kind: Mapped[str] = mapped_column(String(16), default="ssh", nullable=False)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     host: Mapped[str] = mapped_column(String(255), nullable=False)

--- a/src/backend/app/schemas/resource.py
+++ b/src/backend/app/schemas/resource.py
@@ -7,7 +7,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, ConfigDict, Field
 
 ResourceKind = Literal["host", "queue", "license_pool", "instrument"]
-CredentialKind = Literal["ssh", "grpc", "visa", "http"]
+CredentialKind = Literal["ssh", "grpc", "visa", "http", "ws"]
 
 
 class ResourceCreate(BaseModel):
@@ -87,3 +87,31 @@ class ConnectionCredentialRead(BaseModel):
     created_at: datetime
     last_verified_at: datetime | None
     proxy_url: str | None
+
+
+# ---- BYO runner tier-2：出站 WebSocket agent 注册（#695） ----
+
+
+class RunnerRegistrationTokenRead(BaseModel):
+    """注册 token（一次性、短时效）：Web 端签发，agent 用它换长期机器凭据。"""
+
+    token: str
+    expires_in: int
+
+
+class RunnerAgentRegister(BaseModel):
+    """agent 侧注册请求：token 即鉴权（无需登录态——agent 机器上没有用户会话）。"""
+
+    token: str = Field(min_length=1, max_length=255)
+    name: str = Field(min_length=1, max_length=255)
+    # agent 自述的机器信息（hostname/os/cpu 等，probe 结果），原样进 config.machine
+    machine: dict[str, Any] | None = None
+
+
+class RunnerAgentRegistered(BaseModel):
+    """注册成功响应。agent_secret 仅此一次返回，服务端只存摘要、无法找回。"""
+
+    resource: ResourceRead
+    agent_secret: str
+    # agent 出站连接的 WS 路径（相对服务器根，不挂 /api 前缀）
+    ws_path: str

--- a/src/backend/app/services/runner_ws.py
+++ b/src/backend/app/services/runner_ws.py
@@ -1,0 +1,487 @@
+"""BYO runner tier-2（#695，设计草案 docs/byo-runner.md）：出站 WebSocket 传输层。
+
+场景：NAT/内网后的机器平台连不进去（tier-1 的 SSH 直连走不通）。学 GitHub
+self-hosted runner：机器上跑常驻 agent（integrations/runner-agent/），**出站**
+长连接回平台拉任务，永不要求开入站端口。
+
+本模块只做「传输层」四件事，**不接实验执行链**（runner v2 在 ws 底座上的
+接线归后续 PR，见 dispatch_task 的注释留位）：
+
+1. **注册 token**：短时效一次性 token（随机串 + Redis TTL + GETDEL 原子消费）。
+   选 Redis 而非 Fernet 自包含 token：一次性语义必须有服务端状态才能保证
+   （Fernet 只能保证过期，防重放还得回 Redis），不如直接一个 key 又短又可靠。
+2. **agent 注册**：token 换长期机器凭据（agent secret）。secret 只存 sha256
+   摘要（Fernet 加密后落 connection_credentials.payload_encrypted，kind='ws'）
+   ——服务端永远不需要回读明文，摘要即可验证，泄库也拼不回 secret。
+   同时建 host 类 Resource（config.transport="websocket"），与 tier-1 同一张表，
+   租约互斥/容量语义天然共用（#680）。
+3. **WS 服务循环**：首消息鉴权（accept 之后才能 receive，故先 accept 再验，
+   失败 4401 关闭）；在线状态双写——进程内 hub 计数（同资源允许多连接，
+   派发经 Redis lpop 天然只投一份）+ Resource.config.agent_online（跨进程/
+   前端可见，只在连接建立与断开时写库，心跳不写）。心跳超时 4408 判离线。
+4. **派发座**：dispatch_task 把任务压进 Redis list（离线排队，TTL 兜底）并
+   publish 唤醒；连接侧「先订阅唤醒频道、再排空队列、每次唤醒/轮询再排空」
+   ——在线即推、离线排队、重连补投三种情形同一条路径覆盖，且 worker 进程
+   （无 WS 连接）也能经 Redis 向 API 进程的连接派发。
+
+事件回传选「专用 Redis 记录」而非 paper-task 事件通道：paper_task:* 是文献
+处理进度的约定（task_id 语义不同、消费方是文献 SSE），混用会把两个领域的
+key 空间搅在一起。这里按同样的「回放 list + 实时频道」模式另起 runner:task:*
+前缀，runner v2 接线时既可回放也可实时订阅。
+
+帧协议（JSON 文本帧，docs/byo-runner.md tier-2 节）：
+- agent → server（首帧）：{"type": "auth", "resource_id": …, "secret": …}
+- server → agent：{"type": "ready"} / {"type": "task", "task_id": …, "payload": …}
+- agent → server：{"type": "heartbeat"} / {"type": "event"|"result",
+  "task_id": …, "data": …}
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import hashlib
+import hmac
+import json
+import logging
+import secrets
+import uuid
+from typing import Any
+
+from redis.asyncio import Redis
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.websockets import WebSocket, WebSocketDisconnect
+
+from app.core.db import get_sessionmaker
+from app.core.security import decrypt_secret, encrypt_secret
+from app.models.base import utcnow
+from app.models.resource import Resource
+from app.models.ssh_credential import ConnectionCredential
+
+logger = logging.getLogger("polaris.runner_ws")
+
+# ---------------------------------------------------------------------------
+# 常量与 Redis key 约定
+# ---------------------------------------------------------------------------
+
+REGISTRATION_TOKEN_TTL = 3600  # 注册 token 有效期（秒）；一次性，用后即焚
+TASK_QUEUE_TTL = 3600  # 离线任务排队的兜底 TTL：机器长期不上线时任务自然过期
+TASK_EVENTS_TTL = 3600  # 事件回放 list 的存活期（同 paper_task 日志口径）
+HEARTBEAT_TIMEOUT = 90.0  # 秒内收不到任何帧（含心跳）即判离线
+AUTH_TIMEOUT = 10.0  # 连上后首帧鉴权的等待上限
+WAKE_POLL_TIMEOUT = 5.0  # 唤醒频道的轮询间隔（错过 publish 时的兜底补扫）
+
+# 自定义关闭码（4000+ 区间；4401 与现有 WS 端点的「未认证」口径一致）
+CLOSE_UNAUTHORIZED = 4401
+CLOSE_REVOKED = 4403
+CLOSE_HEARTBEAT_TIMEOUT = 4408
+
+
+def registration_token_key(token: str) -> str:
+    return f"runner:regtoken:{token}"
+
+
+def task_queue_key(resource_id: uuid.UUID | str) -> str:
+    return f"runner:{resource_id}:tasks"
+
+
+def wake_channel(resource_id: uuid.UUID | str) -> str:
+    return f"runner:{resource_id}:wake"
+
+
+def task_events_key(task_id: str) -> str:
+    return f"runner:task:{task_id}:events"
+
+
+def task_events_channel(task_id: str) -> str:
+    return f"runner:task:{task_id}:events:live"
+
+
+# ---------------------------------------------------------------------------
+# 注册 token（一次性、短时效）
+# ---------------------------------------------------------------------------
+
+
+async def issue_registration_token(
+    redis: Redis, *, user_id: uuid.UUID, ttl: int = REGISTRATION_TOKEN_TTL
+) -> str:
+    """签发注册 token：随机串落 Redis（值 = 签发者 user_id），到期自动蒸发。"""
+    token = "prt_" + secrets.token_urlsafe(24)
+    await redis.set(registration_token_key(token), str(user_id), ex=ttl)
+    return token
+
+
+async def consume_registration_token(redis: Redis, token: str) -> uuid.UUID | None:
+    """消费注册 token：GETDEL 原子取走（并发重放只有一个赢家），无效/过期返回 None。"""
+    if not token or not token.startswith("prt_"):
+        return None
+    value = await redis.getdel(registration_token_key(token))
+    if not value:
+        return None
+    try:
+        return uuid.UUID(value if isinstance(value, str) else value.decode())
+    except ValueError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# agent 注册：token → host Resource + 机器凭据（agent secret）
+# ---------------------------------------------------------------------------
+
+
+async def register_agent_host(
+    session: AsyncSession,
+    *,
+    owner_id: uuid.UUID,
+    name: str,
+    machine: dict[str, Any] | None = None,
+) -> tuple[Resource, str]:
+    """建 host 类 Resource + kind='ws' 机器凭据，返回 (资源, agent secret)。
+
+    - secret 只在这里生成并返回一次，库里仅存 sha256 摘要（再 Fernet 加密）；
+    - config.ephemeral 恒为 True 且不提供关闭口：tier-2 的任务一律容器内执行，
+      tier-1 的裸机 non-ephemeral 路径不下放（GitHub runner 残留物事故的教训）；
+    - 与 tier-1 注册同构（都是 host Resource），租约互斥天然生效。
+    """
+    agent_secret = "pra_" + secrets.token_urlsafe(32)
+    digest = hashlib.sha256(agent_secret.encode("utf-8")).hexdigest()
+    hostname = str((machine or {}).get("hostname") or "outbound")[:255]
+    credential = ConnectionCredential(
+        user_id=owner_id,
+        kind="ws",
+        name=f"runner-agent:{name}"[:255],
+        # host/port 仅作展示：连接方向是 agent 出站，平台从不主动连它
+        host=hostname,
+        port=443,
+        payload_encrypted=encrypt_secret(json.dumps({"secret_sha256": digest})),
+    )
+    session.add(credential)
+    await session.flush()
+    config: dict[str, Any] = {
+        "transport": "websocket",
+        "ephemeral": True,
+        "agent_online": False,
+    }
+    if machine:
+        config["machine"] = machine
+    resource = Resource(
+        owner_id=owner_id,
+        name=name,
+        kind="host",
+        capacity=1,
+        exclusive=True,
+        credential_id=credential.id,
+        config=config,
+    )
+    session.add(resource)
+    await session.commit()
+    await session.refresh(resource)
+    return resource, agent_secret
+
+
+async def _verify_agent_secret(resource_id: uuid.UUID, secret: str) -> Resource | None:
+    """按 resource_id 定位凭据并校验 secret 摘要（常数时间比较）。
+
+    资源必须是 websocket 传输的 host、未被吊销（config.unavailable）；凭据必须
+    kind='ws'。任何一环不满足都返回 None——鉴权失败不区分原因，不泄露存在性。
+    """
+    async with get_sessionmaker()() as session:
+        resource = await session.get(Resource, resource_id)
+        if resource is None or resource.kind != "host":
+            return None
+        config = resource.config or {}
+        if config.get("transport") != "websocket" or config.get("unavailable"):
+            return None
+        if resource.credential_id is None:
+            return None
+        credential = await session.get(ConnectionCredential, resource.credential_id)
+        if credential is None or credential.kind != "ws" or not credential.payload_encrypted:
+            return None
+        try:
+            payload = json.loads(decrypt_secret(credential.payload_encrypted))
+        except Exception:  # 解密失败按无效凭据处理（换过加密密钥等）
+            return None
+        stored = str(payload.get("secret_sha256") or "")
+        given = hashlib.sha256(secret.encode("utf-8")).hexdigest()
+        if not stored or not hmac.compare_digest(stored, given):
+            return None
+        return resource
+
+
+# ---------------------------------------------------------------------------
+# 在线登记（进程内 hub + Resource.config 双写）
+# ---------------------------------------------------------------------------
+
+
+class RunnerHub:
+    """进程内连接登记：resource_id → 活跃连接数。
+
+    允许同一资源多连接（agent 重启后旧连接可能要等心跳超时才消失，若拒绝新连
+    会把重连挡在门外一整个超时窗口）；任务经 Redis lpop 派发，多连接也只投一份。
+    只有计数归零才写库标离线。
+    """
+
+    def __init__(self) -> None:
+        self._connections: dict[uuid.UUID, int] = {}
+
+    def connect(self, resource_id: uuid.UUID) -> None:
+        self._connections[resource_id] = self._connections.get(resource_id, 0) + 1
+
+    def disconnect(self, resource_id: uuid.UUID) -> bool:
+        """减计数；返回是否已无任何连接（需要写库标离线）。"""
+        count = self._connections.get(resource_id, 0) - 1
+        if count <= 0:
+            self._connections.pop(resource_id, None)
+            return True
+        self._connections[resource_id] = count
+        return False
+
+    def is_online(self, resource_id: uuid.UUID) -> bool:
+        return self._connections.get(resource_id, 0) > 0
+
+
+_hub = RunnerHub()
+
+
+def get_runner_hub() -> RunnerHub:
+    return _hub
+
+
+async def _mark_agent_presence(resource_id: uuid.UUID, *, online: bool) -> None:
+    """把在线状态落到 Resource.config（跨进程/前端可见）。只在连接边沿写。"""
+    async with get_sessionmaker()() as session:
+        resource = await session.get(Resource, resource_id)
+        if resource is None:  # 连接期间资源被删：无处可写，直接返回
+            return
+        merged = dict(resource.config or {})
+        merged["agent_online"] = online
+        merged["agent_last_seen"] = utcnow().isoformat()
+        resource.config = merged
+        await session.commit()
+
+
+async def _resource_still_valid(resource_id: uuid.UUID) -> bool:
+    """心跳时复核资源仍可用：凭据吊销（credential_id 清空 + unavailable）后，
+    活跃连接在下一次心跳被踢掉——不用额外的跨进程踢人通道，最迟一个心跳周期生效。"""
+    async with get_sessionmaker()() as session:
+        resource = await session.get(Resource, resource_id)
+        if resource is None or resource.credential_id is None:
+            return False
+        return not (resource.config or {}).get("unavailable")
+
+
+# ---------------------------------------------------------------------------
+# 派发座（transport-level dispatch seat）
+# ---------------------------------------------------------------------------
+
+
+async def dispatch_task(
+    redis: Redis, resource_id: uuid.UUID | str, payload: dict[str, Any]
+) -> str:
+    """向某台 runner 机器派发一个任务，返回 task_id。
+
+    统一路径：先压 Redis 队列（离线排队 + TTL 兜底），再 publish 唤醒在线连接。
+    agent 在线 → 连接侧被唤醒立即 lpop 推送；离线 → 任务躺在队列里等重连补投。
+
+    NOTE(runner-v2): 实验执行链接线时，payload 放流程包 + 物料 + container spec
+    （docs/byo-runner.md tier-2 节），并由租约（resource_leases）决定派发对象；
+    本 PR 只提供传输语义，payload 对传输层不透明。
+    """
+    task_id = uuid.uuid4().hex
+    entry = json.dumps({"task_id": task_id, "payload": payload}, ensure_ascii=False)
+    key = task_queue_key(resource_id)
+    pipe = redis.pipeline()
+    pipe.rpush(key, entry)
+    pipe.expire(key, TASK_QUEUE_TTL)
+    await pipe.execute()
+    await redis.publish(wake_channel(resource_id), task_id)
+    return task_id
+
+
+async def record_agent_event(redis: Redis, task_id: str, frame: dict[str, Any]) -> None:
+    """落一条 agent 回传（event/result）：回放 list + 实时频道，同 paper_task 模式。
+
+    先 append 再 publish：迟到的消费方从 list 回放，已订阅的从频道实时拿。
+    """
+    payload = json.dumps(frame, ensure_ascii=False, default=str)
+    key = task_events_key(task_id)
+    pipe = redis.pipeline()
+    pipe.rpush(key, payload)
+    pipe.expire(key, TASK_EVENTS_TTL)
+    await pipe.execute()
+    await redis.publish(task_events_channel(task_id), payload)
+
+
+async def fetch_task_events(redis: Redis, task_id: str) -> list[dict[str, Any]]:
+    """回放某任务的全部回传帧（runner v2 接线前主要供测试与排查用）。"""
+    raw_items = await redis.lrange(task_events_key(task_id), 0, -1)
+    events: list[dict[str, Any]] = []
+    for raw in raw_items:
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        try:
+            events.append(json.loads(raw))
+        except ValueError:
+            continue
+    return events
+
+
+# ---------------------------------------------------------------------------
+# WS 服务循环
+# ---------------------------------------------------------------------------
+
+
+async def _authenticate_first_frame(
+    websocket: WebSocket, auth_timeout: float
+) -> Resource | None:
+    """读首帧并鉴权。任何失败（超时/坏 JSON/断开/校验不过）都返回 None。"""
+    try:
+        raw = await asyncio.wait_for(websocket.receive_text(), timeout=auth_timeout)
+        frame = json.loads(raw)
+        if not isinstance(frame, dict) or frame.get("type") != "auth":
+            return None
+        resource_id = uuid.UUID(str(frame.get("resource_id")))
+        secret = str(frame.get("secret") or "")
+    except (TimeoutError, ValueError, WebSocketDisconnect):
+        return None
+    if not secret:
+        return None
+    return await _verify_agent_secret(resource_id, secret)
+
+
+async def _drain_tasks(redis: Redis, websocket: WebSocket, resource_id: uuid.UUID) -> None:
+    """排空该资源的待派发队列，逐条以 task 帧推给 agent。"""
+    key = task_queue_key(resource_id)
+    while True:
+        raw = await redis.lpop(key)
+        if raw is None:
+            return
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        try:
+            entry = json.loads(raw)
+        except ValueError:
+            continue  # 队列里出现坏行只可能是外部手写，跳过别炸连接
+        await websocket.send_text(
+            json.dumps(
+                {"type": "task", "task_id": entry.get("task_id"), "payload": entry.get("payload")},
+                ensure_ascii=False,
+            )
+        )
+
+
+async def _deliver_loop(
+    redis: Redis, websocket: WebSocket, resource_id: uuid.UUID, wake_poll: float
+) -> None:
+    """派发侧：订阅唤醒频道 → 排空队列 → 每次唤醒（或轮询兜底）再排空。
+
+    先订阅再排空：反过来会在「排空完、订阅前」漏掉一次 publish。轮询兜底
+    （get_message 超时后也排空一次）让极端情况下的漏唤醒最迟 wake_poll 秒补上。
+    """
+    pubsub = redis.pubsub()
+    await pubsub.subscribe(wake_channel(resource_id))
+    try:
+        while True:
+            await _drain_tasks(redis, websocket, resource_id)
+            await pubsub.get_message(ignore_subscribe_messages=True, timeout=wake_poll)
+    finally:
+        await pubsub.unsubscribe(wake_channel(resource_id))
+        await pubsub.aclose()
+
+
+async def _receive_loop(
+    redis: Redis, websocket: WebSocket, resource_id: uuid.UUID, heartbeat_timeout: float
+) -> str:
+    """接收侧：心跳/事件/结果。返回结束原因（disconnect|timeout|revoked）。"""
+    while True:
+        try:
+            raw = await asyncio.wait_for(websocket.receive_text(), timeout=heartbeat_timeout)
+        except TimeoutError:
+            return "timeout"
+        except WebSocketDisconnect:
+            return "disconnect"
+        try:
+            frame = json.loads(raw)
+        except ValueError:
+            logger.warning("runner_ws.bad_frame resource=%s", resource_id)
+            continue
+        if not isinstance(frame, dict):
+            continue
+        kind = frame.get("type")
+        if kind == "heartbeat":
+            # 心跳顺带复核吊销：凭据被吊销的连接最迟一个心跳周期内被断开
+            if not await _resource_still_valid(resource_id):
+                return "revoked"
+            continue
+        if kind in ("event", "result"):
+            task_id = frame.get("task_id")
+            if task_id:
+                await record_agent_event(redis, str(task_id), frame)
+            continue
+        logger.debug("runner_ws.unknown_frame resource=%s type=%r", resource_id, kind)
+
+
+async def serve_agent(
+    websocket: WebSocket,
+    *,
+    redis: Redis,
+    hub: RunnerHub | None = None,
+    heartbeat_timeout: float = HEARTBEAT_TIMEOUT,
+    auth_timeout: float = AUTH_TIMEOUT,
+    wake_poll: float = WAKE_POLL_TIMEOUT,
+) -> None:
+    """一条 agent 连接的完整生命周期（WS 端点薄转发到这里，参数可注入便于测试）。"""
+    hub = hub or _hub
+    await websocket.accept()
+    resource = await _authenticate_first_frame(websocket, auth_timeout)
+    if resource is None:
+        await websocket.close(code=CLOSE_UNAUTHORIZED)
+        return
+    resource_id = resource.id
+
+    hub.connect(resource_id)
+    await _mark_agent_presence(resource_id, online=True)
+    logger.info("runner_ws.connected resource=%s", resource_id)
+    reason = "disconnect"
+    try:
+        await websocket.send_text(
+            json.dumps({"type": "ready", "resource_id": str(resource_id)})
+        )
+        receiver = asyncio.create_task(
+            _receive_loop(redis, websocket, resource_id, heartbeat_timeout)
+        )
+        deliverer = asyncio.create_task(_deliver_loop(redis, websocket, resource_id, wake_poll))
+        try:
+            done, pending = await asyncio.wait(
+                {receiver, deliverer}, return_when=asyncio.FIRST_COMPLETED
+            )
+            for task in pending:
+                task.cancel()
+            for task in done:
+                exc = task.exception()
+                if exc is not None:
+                    if isinstance(exc, WebSocketDisconnect):
+                        continue
+                    raise exc
+                if task is receiver:
+                    reason = task.result()
+        finally:
+            for task in (receiver, deliverer):
+                task.cancel()
+            # 等取消真正落地：不等的话事件循环收尾时会冒 pending task 警告，
+            # deliverer 的 pubsub 清理也没机会跑完
+            await asyncio.gather(receiver, deliverer, return_exceptions=True)
+    except WebSocketDisconnect:
+        pass
+    finally:
+        if hub.disconnect(resource_id):
+            await _mark_agent_presence(resource_id, online=False)
+        logger.info("runner_ws.disconnected resource=%s reason=%s", resource_id, reason)
+        close_code = {
+            "timeout": CLOSE_HEARTBEAT_TIMEOUT,
+            "revoked": CLOSE_REVOKED,
+        }.get(reason)
+        if close_code is not None:
+            # 对端可能已断：重复 close 抛 RuntimeError，不追究
+            with contextlib.suppress(RuntimeError):
+                await websocket.close(code=close_code)

--- a/src/backend/tests/test_runner_ws.py
+++ b/src/backend/tests/test_runner_ws.py
@@ -1,0 +1,313 @@
+"""BYO runner tier-2（#695）：注册 token / agent 注册 / WS 鉴权与派发 / 心跳与吊销。
+
+WS 侧不走 httpx（AsyncClient 不支持 websocket），直接驱动 service 层的
+serve_agent：注入假 WebSocket + fakeredis，超时参数调小让离线判定秒级可测。
+"""
+
+import asyncio
+import hashlib
+import json
+import uuid
+
+from starlette.websockets import WebSocketDisconnect
+
+from app.core.db import get_sessionmaker
+from app.core.security import decrypt_secret
+from app.models.resource import Resource
+from app.models.ssh_credential import ConnectionCredential
+from app.services import runner_ws
+from tests.conftest import register_and_login
+
+
+async def _auth(client, email="alice@example.com"):
+    token = await register_and_login(client, email)
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _issue_token(client, headers) -> str:
+    resp = await client.post("/api/resources/runner-hosts/registration-tokens", headers=headers)
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["expires_in"] == runner_ws.REGISTRATION_TOKEN_TTL
+    return body["token"]
+
+
+async def _register(client, token, name="nat-box", machine=None):
+    return await client.post(
+        "/api/resources/runner-hosts/register",
+        json={"token": token, "name": name, "machine": machine},
+    )
+
+
+async def _register_agent(client, fake_redis, name="nat-box"):
+    """完整注册一台 tier-2 机器，返回 (resource_id, agent_secret, 用户 headers)。"""
+    headers = await _auth(client)
+    token = await _issue_token(client, headers)
+    resp = await _register(client, token, name=name)
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    return uuid.UUID(body["resource"]["id"]), body["agent_secret"], headers
+
+
+class FakeAgentSocket:
+    """进程内假 agent 连接：喂帧给 serve_agent、收集它发出的帧。"""
+
+    def __init__(self):
+        self.accepted = False
+        self.close_code: int | None = None
+        self.sent: list[dict] = []
+        self._incoming: asyncio.Queue = asyncio.Queue()
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def receive_text(self) -> str:
+        item = await self._incoming.get()
+        if item is None:
+            raise WebSocketDisconnect(code=1000)
+        return item
+
+    async def send_text(self, text: str) -> None:
+        self.sent.append(json.loads(text))
+
+    async def close(self, code: int = 1000, reason: str | None = None) -> None:
+        if self.close_code is None:
+            self.close_code = code
+
+    # ---- 测试侧助手 ----
+
+    async def push(self, frame: dict) -> None:
+        await self._incoming.put(json.dumps(frame))
+
+    def drop(self) -> None:
+        """模拟 agent 断线（receive 抛 WebSocketDisconnect）。"""
+        self._incoming.put_nowait(None)
+
+    async def wait_frame(self, ftype: str, timeout: float = 3.0) -> dict:
+        deadline = asyncio.get_event_loop().time() + timeout
+        while True:
+            for frame in self.sent:
+                if frame.get("type") == ftype:
+                    return frame
+            assert asyncio.get_event_loop().time() < deadline, (
+                f"no {ftype!r} frame within {timeout}s; got {self.sent}"
+            )
+            await asyncio.sleep(0.01)
+
+
+def _serve(ws, fake_redis, hub, **overrides):
+    kwargs = {"heartbeat_timeout": 5.0, "auth_timeout": 2.0, "wake_poll": 0.05}
+    kwargs.update(overrides)
+    return asyncio.create_task(
+        runner_ws.serve_agent(ws, redis=fake_redis, hub=hub, **kwargs)
+    )
+
+
+async def _agent_online(resource_id: uuid.UUID) -> bool:
+    async with get_sessionmaker()() as session:
+        resource = await session.get(Resource, resource_id)
+        return bool((resource.config or {}).get("agent_online"))
+
+
+# ---- 注册 token：一次性、短时效 ----
+
+
+async def test_registration_token_requires_login(client, fake_redis):
+    resp = await client.post("/api/resources/runner-hosts/registration-tokens")
+    assert resp.status_code == 401
+
+
+async def test_register_flow_and_token_single_use(client, fake_redis):
+    headers = await _auth(client)
+    token = await _issue_token(client, headers)
+    assert token.startswith("prt_")
+    # 短时效：key 带 TTL（到期自动蒸发）
+    ttl = await fake_redis.ttl(runner_ws.registration_token_key(token))
+    assert 0 < ttl <= runner_ws.REGISTRATION_TOKEN_TTL
+
+    machine = {"hostname": "gpu-home", "os": "Linux", "cpu_count": 16}
+    resp = await _register(client, token, name="home-box", machine=machine)
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["agent_secret"].startswith("pra_")
+    assert body["ws_path"] == "/ws/runner-agents/connect"
+    resource = body["resource"]
+    assert resource["kind"] == "host" and resource["exclusive"] is True
+    assert resource["config"]["transport"] == "websocket"
+    assert resource["config"]["ephemeral"] is True  # tier-2 恒 ephemeral，无关闭口
+    assert resource["config"]["agent_online"] is False
+    assert resource["config"]["machine"] == machine
+
+    # 机器凭据：kind=ws，只存 secret 摘要（加密），明文任何列都不落
+    async with get_sessionmaker()() as session:
+        credential = await session.get(
+            ConnectionCredential, uuid.UUID(resource["credential_id"])
+        )
+        assert credential.kind == "ws"
+        assert credential.host == "gpu-home"
+        assert credential.private_key_encrypted is None
+        payload = json.loads(decrypt_secret(credential.payload_encrypted))
+        expected = hashlib.sha256(body["agent_secret"].encode()).hexdigest()
+        assert payload == {"secret_sha256": expected}
+
+    # 一次性：token 用后即焚，重放 401
+    resp = await _register(client, token)
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "INVALID_REGISTRATION_TOKEN"
+    # 凭空编的 token 同样 401
+    resp = await _register(client, "prt_forged")
+    assert resp.status_code == 401
+
+
+async def test_registration_token_expiry(client, fake_redis):
+    headers = await _auth(client)
+    token = await _issue_token(client, headers)
+    # 模拟到期：key 蒸发后 token 不再可用
+    await fake_redis.delete(runner_ws.registration_token_key(token))
+    resp = await _register(client, token)
+    assert resp.status_code == 401
+
+
+# ---- WS 鉴权 ----
+
+
+async def test_ws_rejects_bad_secret(client, fake_redis):
+    resource_id, _secret, _headers = await _register_agent(client, fake_redis)
+    hub = runner_ws.RunnerHub()
+
+    ws = FakeAgentSocket()
+    task = _serve(ws, fake_redis, hub)
+    await ws.push({"type": "auth", "resource_id": str(resource_id), "secret": "pra_wrong"})
+    await asyncio.wait_for(task, timeout=3.0)
+    assert ws.accepted and ws.close_code == runner_ws.CLOSE_UNAUTHORIZED
+    assert not hub.is_online(resource_id)
+    assert await _agent_online(resource_id) is False
+
+    # 首帧不是 auth：同样 4401 关闭
+    ws = FakeAgentSocket()
+    task = _serve(ws, fake_redis, hub)
+    await ws.push({"type": "heartbeat"})
+    await asyncio.wait_for(task, timeout=3.0)
+    assert ws.close_code == runner_ws.CLOSE_UNAUTHORIZED
+
+
+# ---- 在线派发与事件回传 ----
+
+
+async def test_online_dispatch_and_event_roundtrip(client, fake_redis):
+    resource_id, secret, _headers = await _register_agent(client, fake_redis)
+    hub = runner_ws.RunnerHub()
+    ws = FakeAgentSocket()
+    task = _serve(ws, fake_redis, hub)
+    await ws.push({"type": "auth", "resource_id": str(resource_id), "secret": secret})
+    ready = await ws.wait_frame("ready")
+    assert ready["resource_id"] == str(resource_id)
+    assert hub.is_online(resource_id)
+    assert await _agent_online(resource_id) is True
+
+    # 在线派发：任务被立即推给 agent
+    payload = {"kind": "echo", "msg": "hi"}
+    task_id = await runner_ws.dispatch_task(fake_redis, resource_id, payload)
+    frame = await ws.wait_frame("task")
+    assert frame["task_id"] == task_id and frame["payload"] == payload
+
+    # 事件回传：event + result 落专用记录，可回放
+    await ws.push({"type": "event", "task_id": task_id, "data": {"status": "received"}})
+    await ws.push({"type": "result", "task_id": task_id, "data": {"echo": payload}})
+    deadline = asyncio.get_event_loop().time() + 3.0
+    while True:
+        events = await runner_ws.fetch_task_events(fake_redis, task_id)
+        if len(events) >= 2:
+            break
+        assert asyncio.get_event_loop().time() < deadline, events
+        await asyncio.sleep(0.01)
+    assert events[0]["type"] == "event" and events[0]["data"] == {"status": "received"}
+    assert events[1]["type"] == "result" and events[1]["data"] == {"echo": payload}
+
+    # 断线：hub 与库里都标离线
+    ws.drop()
+    await asyncio.wait_for(task, timeout=3.0)
+    assert not hub.is_online(resource_id)
+    assert await _agent_online(resource_id) is False
+
+
+async def test_offline_queue_and_reconnect_delivery(client, fake_redis):
+    resource_id, secret, _headers = await _register_agent(client, fake_redis)
+
+    # 离线派发：任务进队列（带 TTL 兜底），没人在线也不丢
+    task_id = await runner_ws.dispatch_task(fake_redis, resource_id, {"kind": "echo"})
+    queue_key = runner_ws.task_queue_key(resource_id)
+    assert await fake_redis.llen(queue_key) == 1
+    assert 0 < await fake_redis.ttl(queue_key) <= runner_ws.TASK_QUEUE_TTL
+
+    # 重连补投：agent 一上线就收到排队中的任务，队列排空
+    hub = runner_ws.RunnerHub()
+    ws = FakeAgentSocket()
+    task = _serve(ws, fake_redis, hub)
+    await ws.push({"type": "auth", "resource_id": str(resource_id), "secret": secret})
+    frame = await ws.wait_frame("task")
+    assert frame["task_id"] == task_id
+    assert await fake_redis.llen(queue_key) == 0
+
+    ws.drop()
+    await asyncio.wait_for(task, timeout=3.0)
+
+
+# ---- 心跳超时与凭据吊销 ----
+
+
+async def test_heartbeat_timeout_marks_offline(client, fake_redis):
+    resource_id, secret, _headers = await _register_agent(client, fake_redis)
+    hub = runner_ws.RunnerHub()
+    ws = FakeAgentSocket()
+    task = _serve(ws, fake_redis, hub, heartbeat_timeout=0.15)
+    await ws.push({"type": "auth", "resource_id": str(resource_id), "secret": secret})
+    await ws.wait_frame("ready")
+
+    # 不发任何帧：心跳窗口过后服务端主动关闭并标离线
+    await asyncio.wait_for(task, timeout=3.0)
+    assert ws.close_code == runner_ws.CLOSE_HEARTBEAT_TIMEOUT
+    assert not hub.is_online(resource_id)
+    assert await _agent_online(resource_id) is False
+
+    # 心跳按时到则保持在线（帧到达即重置接收窗口）
+    ws2 = FakeAgentSocket()
+    task2 = _serve(ws2, fake_redis, hub, heartbeat_timeout=0.5)
+    await ws2.push({"type": "auth", "resource_id": str(resource_id), "secret": secret})
+    await ws2.wait_frame("ready")
+    for _ in range(3):
+        await asyncio.sleep(0.2)
+        await ws2.push({"type": "heartbeat"})
+    assert not task2.done()
+    assert hub.is_online(resource_id)
+    ws2.drop()
+    await asyncio.wait_for(task2, timeout=3.0)
+
+
+async def test_revoked_credential_kicks_connection(client, fake_redis):
+    """吊销机器凭据后：新连接 4401 拒绝；在跳的连接下一次心跳被 4403 踢掉。"""
+    resource_id, secret, headers = await _register_agent(client, fake_redis)
+    hub = runner_ws.RunnerHub()
+    ws = FakeAgentSocket()
+    task = _serve(ws, fake_redis, hub)
+    await ws.push({"type": "auth", "resource_id": str(resource_id), "secret": secret})
+    await ws.wait_frame("ready")
+
+    # 吊销：走通用凭据删除端点（#685 的吊销语义对 kind=ws 同样生效）
+    async with get_sessionmaker()() as session:
+        resource = await session.get(Resource, resource_id)
+        credential_id = resource.credential_id
+    resp = await client.delete(f"/api/connection-credentials/{credential_id}", headers=headers)
+    assert resp.status_code == 204, resp.text
+
+    await ws.push({"type": "heartbeat"})
+    await asyncio.wait_for(task, timeout=3.0)
+    assert ws.close_code == runner_ws.CLOSE_REVOKED
+    assert not hub.is_online(resource_id)
+
+    # 吊销后的重连被拒（资源 unavailable + 凭据已删）
+    ws3 = FakeAgentSocket()
+    task3 = _serve(ws3, fake_redis, hub)
+    await ws3.push({"type": "auth", "resource_id": str(resource_id), "secret": secret})
+    await asyncio.wait_for(task3, timeout=3.0)
+    assert ws3.close_code == runner_ws.CLOSE_UNAUTHORIZED


### PR DESCRIPTION
Closes #695. The deferred tier-2 transport from #685, per design report §15: NAT'd machines connect **outbound** and never open an inbound port.

- registration: a logged-in user mints a short-lived one-time token (random string + Redis TTL + GETDEL — one-time semantics require server state, so the simplest reliable primitive wins); the agent registers with it and receives its long-lived secret exactly once — the credential row stores only a sha256 digest (Fernet-wrapped), so the server can verify but never read back
- `WS /ws/runner-agents/connect`: first-message auth (the secret never rides URLs or access logs), close codes for bad auth / heartbeat timeout / revocation; online state kept in-process with an edge-written `agent_online` mirror on the host Resource; revocation (#685 semantics) evicts a live connection within one heartbeat
- dispatch seat: tasks land in a Redis list (offline queueing, TTL backstop) then publish wakes the connection — subscribe-then-drain gives online-push, offline-queue, and reconnect-redelivery through one path, and works cross-process from workers; events return on a dedicated replay-list + live-channel pair (paper-task pattern, separate key space)
- deliberately transport-only: the sketched hello/seq-ack resume and artifact chunking stay documented as the runner-v2 wiring PR's scope, with a NOTE at the dispatch seat; tier-2 execution is unconditionally ephemeral (stricter than tier 1)
- reference agent under `integrations/runner-agent/` (stdlib + websockets; register/run subcommands, secret at 0600, README with the Tailscale NAT section); `docs/byo-runner.md` updated from "not implemented" to match the implementation

Verification: full suite 1692 passed = baseline 1684 + exactly the 8 new tests, the 3 pre-existing #581 failures unchanged — zero new; goldens untouched; no migrations; no frontend changes; ruff green including the agent.