### PR TITLE
feat: persistent loader tree over the config store with a builtins registry

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ importers:
       '@deepseek-ai/cordis':
         specifier: workspace:*
         version: link:../../vendor/deepseek-cordis/cordis
+      '@deepseek-ai/cordis-plugin-loader':
+        specifier: workspace:*
+        version: link:../../vendor/deepseek-cordis/loader
       '@deepseek-ai/cosmokit':
         specifier: workspace:*
         version: link:../../vendor/deepseek-cordis/cosmokit

--- a/src/kernel/package.json
+++ b/src/kernel/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@deepseek-ai/cordis": "workspace:*",
+    "@deepseek-ai/cordis-plugin-loader": "workspace:*",
     "@deepseek-ai/cosmokit": "workspace:*",
     "@deepseek-ai/schemastery": "workspace:*"
   },

--- a/src/kernel/src/config/sqlite-tree.ts
+++ b/src/kernel/src/config/sqlite-tree.ts
@@ -1,0 +1,247 @@
+/* ============================================================
+   SqliteTree：把 loader 的 EntryTree 挂到 ConfigTreeStore 上（#699，D2）。
+
+   形态对标 vendor 的 Include（文件版持久树）：SqliteTree 自己就是一棵
+   EntryTree 插件，使用方先 ctx.plugin(Loader) 再 ctx.plugin(SqliteTree,
+   { store })。没有选「继承 Loader 覆写 root/write」那条路，原因：
+   Loader 是全局单例服务（构造期注册一堆 global 钩子、provide('loader')），
+   把持久化揉进去会让「树」跟「装载服务」耦死；而 Include 型子树是
+   vendor 已验证的扩展点（UPSTREAM.md 第 8/12/14 条的事务化/串行化/
+   防抖写全是围着这个形态修的），entry 生命周期照样全部由 loader
+   机制驱动（import/热更/回滚/启停都走 Entry.update 的分档策略）。
+
+   两个边界只做两件事：
+   - load：ConfigEntry[] → EntryOptions[]（children ↔ group:true+config
+     子列表），交给 root.update() 复用 EntryGroup 的事务化 reconcile；
+   - write：root.data → ConfigEntry[]，防抖合并后 store.save() 全量覆盖。
+
+   v1 拒载面（D2/D5）：inject/isolate/intercept 等 loader 扩展字段、
+   以及任意深度的 __jsExpr 表达式节点，装载与落库两个方向都拒绝——
+   SqliteTree 永远不触达 evaluate，配置树里不存在可执行内容。
+   本文件必须保持 electron-free（tests/electron-free.test.ts 强制）。
+   ============================================================ */
+
+import { Context, Service } from '@deepseek-ai/cordis'
+import { EntryGroup, EntryTree, type EntryOptions } from '@deepseek-ai/cordis-plugin-loader'
+import type { ConfigEntry, ConfigTreeStore } from './tree.ts'
+
+/** ConfigEntry 允许的键。多出来的一律拒载，见 assertEntryKeys。 */
+const CONFIG_ENTRY_KEYS = new Set(['id', 'name', 'config', 'disabled', 'children'])
+
+/** 序列化方向 EntryOptions 允许的键：group 是内部表示（children 的等价物）。 */
+const ENTRY_OPTIONS_KEYS = new Set(['id', 'name', 'config', 'disabled', 'group'])
+
+/**
+ * 深扫 config 载荷里的 __jsExpr 节点（D5：!!js 封死）。
+ * include 的 YAML 方言允许配置里带可执行表达式，SqliteTree 的树来自
+ * SQLite/导入数据，任何位置出现表达式节点都视为投毒，带路径拒绝。
+ */
+function assertNoJsExpr(value: unknown, path: string): void {
+  if (!value || typeof value !== 'object') return
+  if ('__jsExpr' in value) {
+    throw new Error(`配置树 ${path} 含 __jsExpr 表达式节点，SqliteTree 拒绝装载可执行配置`)
+  }
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => assertNoJsExpr(item, `${path}[${index}]`))
+  } else {
+    for (const [key, item] of Object.entries(value)) {
+      assertNoJsExpr(item, `${path}.${key}`)
+    }
+  }
+}
+
+function assertEntryKeys(entry: object, allowed: Set<string>, path: string): void {
+  for (const key of Object.keys(entry)) {
+    if (!allowed.has(key)) {
+      throw new Error(
+        `配置树条目 ${path} 含不支持的字段 "${key}"（v1 不支持 inject/isolate/intercept 等 loader 扩展，遇到即拒载）`,
+      )
+    }
+  }
+}
+
+/**
+ * 装载边界：ConfigEntry → EntryOptions。
+ * children 的存在与否是「组」的唯一判据：有 children 就转成
+ * group:true + config=子条目列表（loader 里组的 config 就是子条目
+ * 列表，见 vendor loader Group）；组条目的 name 原样透传（组行需要
+ * 一个可导入的 specifier，如 cordis:group）。
+ */
+function toEntryOptions(entry: ConfigEntry, path: string, seen: Set<string>): EntryOptions {
+  assertEntryKeys(entry, CONFIG_ENTRY_KEYS, path)
+  if (typeof entry.id !== 'string' || !entry.id) {
+    throw new Error(`配置树条目 ${path} 缺少字符串 id`)
+  }
+  if (entry.id.includes(':')) {
+    // ':' 是 loader 的嵌套树 id 分隔符（EntryTree.sep），resolve 会把它
+    // 当子树路径拆开；组内条目其实平铺在同一个 store 里，id 带冒号必错
+    throw new Error(`配置树条目 ${path} 的 id "${entry.id}" 含保留分隔符 ":"`)
+  }
+  if (seen.has(entry.id)) {
+    // loader 的 store 是全树平铺的字典，跨组重复 id 会让后者静默
+    // 抢占（reparent）前者的条目，必须在装载前挡下
+    throw new Error(`配置树条目 ${path} 的 id "${entry.id}" 在树内重复`)
+  }
+  seen.add(entry.id)
+  if (typeof entry.name !== 'string' || !entry.name) {
+    throw new Error(`配置树条目 ${path} 缺少字符串 name`)
+  }
+  if (entry.disabled !== undefined && typeof entry.disabled !== 'boolean') {
+    throw new Error(`配置树条目 ${path} 的 disabled 必须是布尔值`)
+  }
+  if (entry.children !== undefined && entry.config !== undefined) {
+    throw new Error(`配置树条目 ${path} 同时带 children 与 config（组的配置就是子条目列表，两者互斥）`)
+  }
+
+  const options: EntryOptions = { id: entry.id, name: entry.name }
+  if (entry.children !== undefined) {
+    if (!Array.isArray(entry.children)) {
+      throw new Error(`配置树条目 ${path} 的 children 必须是数组`)
+    }
+    options.group = true
+    options.config = entry.children.map((child, index) =>
+      toEntryOptions(child, childPath(path, child, index), seen),
+    )
+  } else if (entry.config !== undefined) {
+    assertNoJsExpr(entry.config, `${path}.config`)
+    options.config = entry.config
+  }
+  if (entry.disabled !== undefined) options.disabled = entry.disabled
+  return options
+}
+
+/**
+ * 落库边界：EntryOptions → ConfigEntry（toEntryOptions 的逆变换）。
+ * 组条目的 config 数组与 EntryGroup.data 是同一份引用（loader 的
+ * 事务化 update 保证 identity），所以直接递归它就是当前真相。
+ * 运行期若有钩子往 options 里塞了 v1 不支持的字段，这里同样拒绝——
+ * 静默丢字段落库会让下次装载读到与真相不符的树。
+ */
+function toConfigEntry(options: EntryOptions, path: string): ConfigEntry {
+  assertEntryKeys(options, ENTRY_OPTIONS_KEYS, path)
+  const entry: ConfigEntry = { id: options.id, name: options.name }
+  if (options.group) {
+    const children = (options.config ?? []) as EntryOptions[]
+    entry.children = children.map((child, index) =>
+      toConfigEntry(child, childPath(path, child, index)),
+    )
+  } else if (options.config !== undefined) {
+    assertNoJsExpr(options.config, `${path}.config`)
+    entry.config = options.config
+  }
+  if (typeof options.disabled === 'boolean') entry.disabled = options.disabled
+  return entry
+}
+
+function childPath(parent: string, child: { id?: unknown }, index: number): string {
+  const label = typeof child?.id === 'string' && child.id ? child.id : `#${index}`
+  return parent ? `${parent}.${label}` : label
+}
+
+export namespace SqliteTree {
+  export interface Config {
+    /** 树的持久化后座：SqliteConfigTreeStore（生产）或 Memory（测试）。 */
+    store: ConfigTreeStore
+  }
+}
+
+/** ConfigTreeStore 持久化的 loader 条目树。用法：先装 Loader，再装它。 */
+export class SqliteTree extends EntryTree {
+  static inject = ['loader']
+
+  // 树载体标记（Group/Include 同款）：本插件的 config 是 { store } 与
+  // 子条目列表的容器，loader 的 internal/config 插值必须对它保持字面
+  // 透传——valueMap 递归克隆会把 store 实例克隆成失去原型的空壳
+  static readonly [EntryGroup.key] = true
+
+  #dirty = false
+  #writeTask: NodeJS.Timeout | undefined
+  #writeQueue: Promise<void> = Promise.resolve()
+
+  constructor(ctx: Context, public config: SqliteTree.Config) {
+    super(ctx)
+  }
+
+  async *[Service.init](): AsyncGenerator<() => Promise<void>, void, void> {
+    const entries = await this.config.store.load()
+    const data = entries.map((entry, index) =>
+      toEntryOptions(entry, childPath('', entry, index), new Set()),
+    )
+    // 挂成服务：桌面侧（PR-2）要拿树的句柄做 engine spec 注入与
+    // plugins.* IPC（PR-3），reflect 的严格模式顺便保证「树没就绪
+    // 就拿不到句柄」
+    this.ctx.provide('configTree', this)
+    yield () => this.stop()
+    // 复用 EntryGroup 的事务化 reconcile：并发拉起、失败整体回滚
+    await this.root.update(data)
+  }
+
+  async stop(): Promise<void> {
+    await this.root.stop()
+    // root.stop 只 dispose 不改 data，最后一次 flush 落的仍是完整的树
+    await this.flush()
+  }
+
+  override import(name: string, getOuterStack?: () => string[]) {
+    // 基类对未知的 cordis: builtin 返回 undefined，这个 undefined 会一路
+    // 走到 Entry.update「先 dispose 旧 fiber 再 start」之后才炸，回滚只能
+    // 重建一个新 fiber。在 import 阶段就抛错，Entry.update 会在动手前
+    // 失败——原 fiber 原样活着，这正是坏包回滚想要的语义。
+    if (name.startsWith('cordis:') && !(name.slice(7) in this.ctx.loader.builtins)) {
+      throw new Error(`未知的内置插件 "${name}"（未在 loader.builtins 注册）`)
+    }
+    return super.import(name, getOuterStack)
+  }
+
+  /**
+   * 防抖合并写（why：写放大）。loader 的每个树操作都会调一次 write——
+   * create/update/remove 各一次，internal/update 钩子回写 config 又一次，
+   * 一轮 root.update 重放整树更是 O(条目数) 次。store.save 本身是全量
+   * 覆盖语义，最后一份快照就是完整真相，中间态可以无损丢弃，所以这里
+   * 只置脏标记，用一个 0ms 定时器把同一轮事件循环里的写合并成一次。
+   */
+  write(): void {
+    this.#dirty = true
+    this.#writeTask ??= setTimeout(() => {
+      this.#writeTask = undefined
+      void this.#drain()
+    }, 0)
+  }
+
+  /** 立刻落库：测试断言前与 stop() 前调用。返回值会把落库失败抛给调用方。 */
+  flush(): Promise<void> {
+    if (this.#writeTask !== undefined) {
+      clearTimeout(this.#writeTask)
+      this.#writeTask = undefined
+    }
+    return this.#drain()
+  }
+
+  #drain(): Promise<void> {
+    if (this.#dirty) {
+      this.#dirty = false
+      // 串行链：save 是异步的，两次覆盖写交错会让旧快照压过新快照
+      const run = this.#writeQueue.then(
+        () => this.#save(),
+        () => this.#save(),
+      )
+      this.#writeQueue = run
+      // 后台定时器路径没有调用方接错误，就地记日志；flush() 的调用方
+      // 拿同一个 promise，照样能收到 rejection
+      void run.catch((error) => {
+        this.ctx.root.logger?.('loader').warn('配置树落库失败')
+        this.ctx.root.logger?.('loader').warn(error)
+      })
+    }
+    return this.#writeQueue
+  }
+
+  async #save(): Promise<void> {
+    // 序列化放在真正写的时刻：root.data 是就地变更的活数组，写入点
+    // 取快照才能保证落的是合并后的最终状态
+    const entries = this.root.data.map((options, index) =>
+      toConfigEntry(options, childPath('', options, index)),
+    )
+    await this.config.store.save(entries)
+  }
+}

--- a/src/kernel/src/index.ts
+++ b/src/kernel/src/index.ts
@@ -10,6 +10,8 @@ export {
   type ConfigEntry,
   type ConfigTreeStore,
 } from './config/tree.ts'
+export { SqliteTree } from './config/sqlite-tree.ts'
+export { BUILTIN_PLUGINS, desktopProbe, registerBuiltins } from './plugins/builtins.ts'
 export {
   ENGINE_CONTAINER,
   LegacyEngineConfig,
@@ -79,3 +81,6 @@ export {
   type UninstallPluginOptions,
 } from './market/install.ts'
 export { Context } from '@deepseek-ai/cordis'
+// 与上一行的 Context 同理：桌面侧建树要 ctx.plugin(Loader)，从 kernel
+// 统一转出，避免 desktop 直接依赖 vendor 包名
+export { Loader } from '@deepseek-ai/cordis-plugin-loader'

--- a/src/kernel/src/plugins/builtins.ts
+++ b/src/kernel/src/plugins/builtins.ts
@@ -1,0 +1,45 @@
+/* ============================================================
+   内置插件注册表（#699，D1/D3）。
+
+   打包态（esbuild + asar）里动态 import 内置插件是 R1 问题的根源，
+   所以内置插件全部走 loader.builtins 查表：配置树条目用 cordis:<键>
+   specifier，EntryTree.import 命中前缀直接查表返回，零动态 import。
+
+   storage 故意不入表（D3）：loader 树本身就持久化在 storage 的
+   SqliteConfigTreeStore 里，storage 是先于 loader 直挂的地基——把它
+   放进树等于「树条目负责拉起存树的地方」，自举成环。
+   本文件必须保持 electron-free（tests/electron-free.test.ts 强制）。
+   ============================================================ */
+
+import { Group, type Loader } from '@deepseek-ai/cordis-plugin-loader'
+import { legacyEngine } from './legacy-engine.ts'
+import { sources } from './sources.ts'
+
+/**
+ * 空探针插件：存在本身就证明 cordis 插件树被真的建起来了（桌面侧
+ * kernel.status 的 plugins 计数由它兜底 ≥ 1）。原先定义在 desktop 的
+ * kernel.ts，树驱动装载后它必须能按名查表，随 #699 挪进 kernel；
+ * desktop 侧改引用归 PR-2。
+ */
+export const desktopProbe = {
+  name: 'desktop-probe',
+  apply(): void {
+    /* 故意为空：只占一个 registry 名额 */
+  },
+}
+
+/** 键 = cordis: 后面的 specifier 尾巴，如 cordis:legacy-engine。 */
+export const BUILTIN_PLUGINS: Record<string, unknown> = {
+  'desktop-probe': desktopProbe,
+  'legacy-engine': legacyEngine,
+  sources,
+}
+
+/** 把内置插件表灌进 loader.builtins。装 SqliteTree 之前调用。 */
+export function registerBuiltins(loader: Loader): void {
+  Object.assign(loader.builtins, BUILTIN_PLUGINS)
+  // 组插件也要可导入：配置树里的组条目（children）序列化成
+  // name=cordis:group 的行，Entry 初始化照样按 name 查表拿插件。
+  // Group 是 loader 包自带的载体插件，不算 Polaris 内置，故不进上表。
+  loader.builtins['group'] = Group
+}

--- a/src/kernel/tests/sqlite-tree.test.ts
+++ b/src/kernel/tests/sqlite-tree.test.ts
@@ -1,0 +1,249 @@
+/* SqliteTree 的单元测试（#699）。ConfigTreeStore 是接口级契约，内存
+   实现与 SQLite 实现跑同一套关键路径（describe.each，同 storage.test），
+   保证「测试用内存、生产用 SQLite」不会踩语义差。装载/热更/回滚/
+   启停全部走 loader 的 Entry.update 分档策略，测试只从公开面断言。 */
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, describe, expect, it } from 'vitest'
+import type { Context } from '@deepseek-ai/cordis'
+import type { EntryOptions } from '@deepseek-ai/cordis-plugin-loader'
+import {
+  Loader,
+  MemoryConfigTreeStore,
+  SqliteConfigTreeStore,
+  SqliteTree,
+  createKernel,
+  migrate,
+  openStorage,
+  registerBuiltins,
+  type ConfigEntry,
+  type ConfigTreeStore,
+  type Kernel,
+} from '../src/index.ts'
+
+const dir = mkdtempSync(join(tmpdir(), 'kernel-sqlite-tree-'))
+afterAll(() => rmSync(dir, { recursive: true, force: true }))
+
+let seq = 0
+const freshPath = (): string => join(dir, `db-${++seq}.sqlite`)
+
+type StoreFactory = () => { store: ConfigTreeStore; close?: () => void }
+
+const implementations: [string, StoreFactory][] = [
+  ['MemoryConfigTreeStore', () => ({ store: new MemoryConfigTreeStore() })],
+  [
+    'SqliteConfigTreeStore',
+    () => {
+      const db = openStorage(freshPath())
+      migrate(db)
+      return { store: new SqliteConfigTreeStore(db), close: () => db.close() }
+    },
+  ],
+]
+
+/** 起一个装好 Loader + 内置表的 kernel，并注册记副作用的假插件 cordis:fake。 */
+async function bootKernel(): Promise<{
+  kernel: Kernel
+  calls: unknown[]
+  imports: () => number
+}> {
+  const kernel = createKernel({ name: 'sqlite-tree-test' })
+  await kernel.start()
+  await kernel.ctx.plugin(Loader)
+  const loader = kernel.ctx.loader
+  registerBuiltins(loader)
+
+  const calls: unknown[] = []
+  let imports = 0
+  const fakePlugin = {
+    name: 'fake',
+    apply(_ctx: Context, config: unknown): void {
+      calls.push(config)
+    },
+  }
+  // getter 计数：只有 EntryTree.import 真的查表才 +1，`in` 判断不触发，
+  // 借此区分「重新装载（重 import）」与「就地热更（不 import）」
+  Object.defineProperty(loader.builtins, 'fake', {
+    configurable: true,
+    enumerable: true,
+    get() {
+      imports += 1
+      return fakePlugin
+    },
+  })
+  return { kernel, calls, imports: () => imports }
+}
+
+async function mountTree(kernel: Kernel, store: ConfigTreeStore): Promise<SqliteTree> {
+  await kernel.ctx.plugin(SqliteTree, { store })
+  return kernel.ctx.get('configTree') as SqliteTree
+}
+
+const entryIds = (tree: SqliteTree): string[] =>
+  [...tree.entries()].map((entry) => entry.options.id).sort()
+
+describe.each(implementations)('SqliteTree over %s', (_name, make) => {
+  it('roundtrip: seed → mutate → flush → reload restores the same set', async () => {
+    const { store, close } = make()
+    await store.save([
+      { id: 'probe', name: 'cordis:desktop-probe' },
+      {
+        id: 'grp',
+        name: 'cordis:group',
+        children: [{ id: 'fake1', name: 'cordis:fake', config: { a: 1 } }],
+      },
+      { id: 'off', name: 'cordis:fake', disabled: true, config: { c: 3 } },
+    ])
+
+    const { kernel } = await bootKernel()
+    const tree = await mountTree(kernel, store)
+    expect(entryIds(tree)).toEqual(['fake1', 'grp', 'off', 'probe'])
+    expect(tree.resolve('fake1').fiber).toBeTruthy()
+    // disabled 条目：留在树里但不实例化
+    expect(tree.resolve('off').fiber).toBeUndefined()
+
+    const newId = await tree.create({ name: 'cordis:fake', config: { b: 2 } }, 'grp')
+    await tree.update('fake1', { config: { a: 9 } })
+    await tree.remove('probe')
+    await tree.flush()
+
+    const expected: ConfigEntry[] = [
+      {
+        id: 'grp',
+        name: 'cordis:group',
+        children: [
+          { id: 'fake1', name: 'cordis:fake', config: { a: 9 } },
+          { id: newId, name: 'cordis:fake', config: { b: 2 } },
+        ],
+      },
+      { id: 'off', name: 'cordis:fake', disabled: true, config: { c: 3 } },
+    ]
+    expect(await store.load()).toEqual(expected)
+    await kernel.stop()
+
+    // 新 kernel + 新 SqliteTree 重载：恢复同一集合，store 内容不漂移
+    const second = await bootKernel()
+    const tree2 = await mountTree(second.kernel, store)
+    expect(entryIds(tree2)).toEqual(['fake1', 'grp', newId, 'off'].sort())
+    expect(tree2.resolve(newId).fiber).toBeTruthy()
+    await tree2.flush()
+    expect(await store.load()).toEqual(expected)
+    await second.kernel.stop()
+    close?.()
+  })
+
+  it('config-only update hot-swaps in place: same fiber, no re-import', async () => {
+    const { store, close } = make()
+    await store.save([{ id: 'f1', name: 'cordis:fake', config: { a: 1 } }])
+    const { kernel, calls, imports } = await bootKernel()
+    const tree = await mountTree(kernel, store)
+    expect(imports()).toBe(1)
+    expect(calls).toEqual([{ a: 1 }])
+
+    const entry = tree.resolve('f1')
+    const fiber = entry.fiber
+    expect(fiber).toBeTruthy()
+
+    // 深等的 config：Entry.update 短路，apply 完全不重跑
+    await tree.update('f1', { config: { a: 1 } })
+    expect(calls).toHaveLength(1)
+
+    // 真变更：fiber 同引用、不重新 import（不是「重装」），apply 以新
+    // 配置就地重启——这是 cordis fiber.update 的既定热更语义
+    await tree.update('f1', { config: { a: 2 } })
+    expect(entry.fiber).toBe(fiber)
+    expect(imports()).toBe(1)
+    expect(calls.at(-1)).toEqual({ a: 2 })
+
+    await tree.flush()
+    expect(await store.load()).toEqual([{ id: 'f1', name: 'cordis:fake', config: { a: 2 } }])
+    await kernel.stop()
+    close?.()
+  })
+
+  it('bad package rollback: unknown specifier throws before touching the live fiber', async () => {
+    const { store, close } = make()
+    await store.save([{ id: 'f1', name: 'cordis:fake', config: { a: 1 } }])
+    const { kernel, calls } = await bootKernel()
+    const tree = await mountTree(kernel, store)
+    const entry = tree.resolve('f1')
+    const fiber = entry.fiber
+
+    await expect(
+      tree.update('f1', { name: 'cordis:no-such-plugin' } as unknown as Omit<EntryOptions, 'id' | 'name'>),
+    ).rejects.toThrow(/no-such-plugin/)
+
+    // 原 fiber 原样活着：引用未变、apply 未重跑、options 已回滚
+    expect(entry.fiber).toBe(fiber)
+    expect(entry.options.name).toBe('cordis:fake')
+    expect(calls).toHaveLength(1)
+    await tree.flush()
+    expect(await store.load()).toEqual([{ id: 'f1', name: 'cordis:fake', config: { a: 1 } }])
+    await kernel.stop()
+    close?.()
+  })
+
+  it('disabled toggle disposes and rebuilds the fiber', async () => {
+    const { store, close } = make()
+    await store.save([{ id: 'f1', name: 'cordis:fake', config: { a: 1 } }])
+    const { kernel, calls } = await bootKernel()
+    const tree = await mountTree(kernel, store)
+    const entry = tree.resolve('f1')
+    const fiber = entry.fiber
+    expect(fiber).toBeTruthy()
+
+    await tree.update('f1', { disabled: true })
+    expect(entry.fiber).toBeUndefined()
+    await tree.flush()
+    expect(await store.load()).toEqual([
+      { id: 'f1', name: 'cordis:fake', disabled: true, config: { a: 1 } },
+    ])
+
+    // disabled: null 表示删除该键（loader 的 isNullable 语义）→ 重建 fiber
+    await tree.update('f1', { disabled: null })
+    expect(entry.fiber).toBeTruthy()
+    expect(entry.fiber).not.toBe(fiber)
+    expect(calls).toHaveLength(2)
+    await tree.flush()
+    expect(await store.load()).toEqual([{ id: 'f1', name: 'cordis:fake', config: { a: 1 } }])
+    await kernel.stop()
+    close?.()
+  })
+
+  it('rejects __jsExpr nodes at any depth with the offending path', async () => {
+    const { store, close } = make()
+    await store.save([
+      {
+        id: 'evil',
+        name: 'cordis:fake',
+        config: { outer: { inner: { __jsExpr: 'process.exit(1)' } } },
+      } as ConfigEntry,
+    ])
+    const { kernel } = await bootKernel()
+    await expect(kernel.ctx.plugin(SqliteTree, { store })).rejects.toThrow(
+      /evil\.config\.outer\.inner.*__jsExpr/,
+    )
+    await kernel.stop()
+    close?.()
+  })
+})
+
+/* inject/isolate/intercept 拒载只在内存 store 上测：SQLite 的表结构
+   （id/name/config/disabled 四列）天然装不下 loader 扩展字段，这道
+   防线针对的是内存树与后续 importTree（PR-3）之类的整树输入路径。 */
+describe('SqliteTree rejection of loader extension fields', () => {
+  it('rejects an inject field with the offending path', async () => {
+    const store = new MemoryConfigTreeStore()
+    await store.save([
+      {
+        id: 'grp',
+        name: 'cordis:group',
+        children: [{ id: 'bad', name: 'cordis:fake', inject: ['storage'] }],
+      } as unknown as ConfigEntry,
+    ])
+    const { kernel } = await bootKernel()
+    await expect(kernel.ctx.plugin(SqliteTree, { store })).rejects.toThrow(/grp\.bad.*inject/)
+    await kernel.stop()
+  })
+})


### PR DESCRIPTION
Closes #699. Part of #698 (marketplace M1, item PR-1). Kernel-side foundation, electron-free.

Wires the two idle assets together: the vendored loader's transactional entry machinery now runs over the persisted config store.

- `SqliteTree extends EntryTree` in the vendored `Include` form — deliberately not a `Loader` subclass: Loader is a global singleton service with constructor-time hooks, while the Include-shaped persistent subtree is the extension point the vendor's transactional-reconcile/serialization/debounced-write hardening was built around. Usage: `ctx.plugin(Loader)` → `registerBuiltins(ctx.loader)` → `ctx.plugin(SqliteTree, { store })`; the tree provides itself as the `configTree` service
- conversion only at the load/serialize boundary (`children` ⇔ `group:true`+config); loads reject — with a path — unknown fields (inject/isolate/intercept), `__jsExpr` at any depth (the YAML eval surface stays sealed), ids containing `:`, duplicate ids across the flat store, and children+config conflicts; serialization refuses rather than silently dropping fields
- an `import()` override makes unknown `cordis:` builtins fail at import time, so a bad rename rolls back to the live fiber instead of dispose-then-fail
- debounced writes (dirty flag + timeout-0 merge, serialized flush chain; full-replace store semantics mean the last snapshot is the whole truth); `flush()` for tests and shutdown
- builtins registry: desktop-probe (moved into the kernel), legacy-engine, sources; storage deliberately stays out — the tree reads through it
- entry lifecycle rides the loader unchanged: config-only updates patch the same fiber without re-import, disable/enable dispose/rebuild, failed imports roll back options and store

Tests (kernel suite now 62+ with 11 new cases over both store implementations via describe.each): roundtrip with nested groups across kernel restarts, hot-update semantics at both tiers (deep-equal short-circuit vs same-fiber restart), bad-package rollback, enable/disable, deep `__jsExpr` and extension-field rejection; electron-free scan green. Rebased onto #701 (export-block merge).