### PR TITLE
feat: tree-driven kernel mounting with the esbuild import.meta fix

### DIFF
--- a/src/desktop/e2e/e2e.ts
+++ b/src/desktop/e2e/e2e.ts
@@ -167,14 +167,19 @@ async function groupEngine(): Promise<void> {
     await page.waitForURL(/app:\/\/polaris\/t\//, { timeout: 30_000 });
     check('创建课题后进入课题工作台（/t/<id>）', true);
 
-    // 回落地页确认列表可见——整页重载，顺带验证会话在刷新后依然有效
+    // 回落地页确认列表可见——整页重载，顺带验证会话在刷新后依然有效。
+    // .sidebar 先于课题列表出现（列表是异步查询），isVisible() 的立即快照
+    // 必然竞态：用有界等待，断言的语义仍是「重载后新课题可见」。
     await page.goto('app://polaris/start');
     await page.waitForSelector('.sidebar', { timeout: 60_000 });
     const visible = await page
       .getByText(topicName)
       .first()
-      .isVisible()
-      .catch(() => false);
+      .waitFor({ state: 'visible', timeout: 30_000 })
+      .then(
+        () => true,
+        () => false,
+      );
     check('新建课题出现在课题列表', visible, `name=${topicName}`);
   } catch (err) {
     check('壳与免登录组执行完成', false, String(err).slice(0, 400));

--- a/src/desktop/package.json
+++ b/src/desktop/package.json
@@ -7,11 +7,11 @@
   "author": "Polaris contributors <polaris@users.noreply.github.com>",
   "main": "dist/main.cjs",
   "scripts": {
-    "build:main": "esbuild src/main/index.ts --bundle --platform=node --target=node24 --format=cjs --outfile=dist/main.cjs --external:electron",
+    "build:main": "esbuild src/main/index.ts --bundle --platform=node --target=node24 --format=cjs --outfile=dist/main.cjs --external:electron --external:node-addon-require-builtin --define:import.meta.url=__polarisImportMetaUrl --banner:js=\"const __polarisImportMetaUrl = require('node:url').pathToFileURL(__filename).href;\"",
     "build:preload": "esbuild src/preload/index.ts --bundle --platform=node --target=node24 --format=cjs --outfile=dist/preload.cjs --external:electron",
     "build:agent": "esbuild src/agent/main.ts --bundle --platform=node --target=node24 --format=cjs --outfile=dist/agent.cjs --external:electron",
     "build:bootstrap-smoke": "esbuild src/bootstrap-smoke.ts --bundle --platform=node --target=node22 --format=cjs --outfile=dist/bootstrap-smoke.cjs",
-    "build:smoke": "esbuild src/smoke.ts --bundle --platform=node --target=node24 --format=cjs --outfile=dist/smoke.cjs --external:electron",
+    "build:smoke": "esbuild src/smoke.ts --bundle --platform=node --target=node24 --format=cjs --outfile=dist/smoke.cjs --external:electron --external:node-addon-require-builtin --define:import.meta.url=__polarisImportMetaUrl --banner:js=\"const __polarisImportMetaUrl = require('node:url').pathToFileURL(__filename).href;\"",
     "build": "pnpm run build:main && pnpm run build:preload && pnpm run build:agent && pnpm run build:bootstrap-smoke",
     "smoke": "pnpm run build:preload && pnpm run build:agent && pnpm run build:smoke && electron dist/smoke.cjs",
     "dev": "pnpm run build && electron .",

--- a/src/desktop/src/main/kernel.ts
+++ b/src/desktop/src/main/kernel.ts
@@ -6,27 +6,36 @@
    ready 时 start，退出路径 stop（fiber.dispose 级联回收所有插件注册
    的副作用——计时器、监听器、子进程）。
 
-   装载列表：
-   - desktop-probe：空探针，存在本身就证明 cordis 插件树被真的建起来了
-     （kernel.status 的 plugins 计数由它兜底 ≥ 1）。
-   - storage（#608/#609）：SQLite 持久层，配置树落在 userData/kernel/ 下。
-     插件用的是 Electron 内嵌 Node 的 node:sqlite（要求 Node ≥ 22），这正是
-     Electron 必须升到 44 的原因——33 内嵌 Node 20，装载即 ERR_UNKNOWN_BUILTIN_MODULE。
-   - legacy-engine：把 Python 后端作为本地子进程拉起（desktop 档位单进程，
-     见 #583）。配置来源按优先级：
+   装载结构（#703 起树驱动）：
+   - storage（#608/#609）：SQLite 持久层，唯一直挂的地基插件——loader
+     的配置树本身就存在它的 SqliteConfigTreeStore 里，进树会自举成环
+     （见 kernel 的 builtins.ts 文件头）。插件用的是 Electron 内嵌 Node 的
+     node:sqlite（要求 Node ≥ 22），这正是 Electron 必须升到 44 的原因——
+     33 内嵌 Node 20，装载即 ERR_UNKNOWN_BUILTIN_MODULE。
+   - Loader + SqliteTree（#699/#703）：其余插件一律由持久化配置树驱动，
+     条目名走 cordis:<键> 查 loader.builtins 表，打包态零动态 import。
+     首启种下 desktop-probe / sources / legacy-engine 三条目；此后树内容
+     以用户状态为真相，启动时不再增删改写。
+   - legacy-engine：树上只是 disabled 占位条目，引擎参数每次启动现算后
+     动态注入（见 startKernel 内注释）。配置来源按优先级：
        1. POLARIS_DESKTOP_ENGINE 显式指定（开发/调试，行为与从前完全一致）
        2. 打包态自动引导（#607）：安装包自带 uv + 后端源码，首启在 userData
           里装出 venv 后以 command 模式拉起——用户机器不需要 Python/docker
-     两者都不成立（开发态未设 env）时不装引擎，保持远端服务器流程。
+     两者都不成立（开发态未设 env）时不注入，条目保持 disabled，走远端流程。
    ============================================================ */
 
 import { app } from 'electron';
 import { join } from 'node:path';
 
 import {
+  Loader,
+  MemoryConfigTreeStore,
+  SqliteTree,
   createKernel,
-  legacyEngine,
+  registerBuiltins,
   storage,
+  type ConfigEntry,
+  type ConfigTreeStore,
   type Kernel,
   type LegacyEngineConfig,
   type StorageService,
@@ -44,13 +53,17 @@ let kernel: Kernel | null = null;
  */
 let bootstrapStatus: EngineBootstrapStatus = { phase: 'idle', done: false };
 
-/** 空探针插件。命名走 kebab-case，与 config-tree / legacy-engine 一致。 */
-const desktopProbe = {
-  name: 'desktop-probe',
-  apply(): void {
-    /* 故意为空：只占一个 registry 名额 */
-  },
-};
+/**
+ * 首启种子树。只在 store 完全为空时写入：树是用户状态的真相，任何非空
+ * 内容都不做「补齐」——那会把用户显式删掉的条目悄悄种回来。
+ * legacy-engine 种成 disabled 占位：引擎能不能起、以什么参数起，每次
+ * 启动才知道（env / 打包引导），树里只留位置不留答案。
+ */
+const SEED_ENTRIES: ConfigEntry[] = [
+  { id: 'desktop-probe', name: 'cordis:desktop-probe' },
+  { id: 'sources', name: 'cordis:sources' },
+  { id: 'legacy-engine', name: 'cordis:legacy-engine', disabled: true },
+];
 
 /**
  * POLARIS_DESKTOP_ENGINE 的取值：
@@ -114,17 +127,34 @@ async function bootstrapPackagedEngine(): Promise<LegacyEngineConfig | null> {
 export async function startKernel(): Promise<Kernel> {
   if (kernel) return kernel;
   const instance = createKernel({ name: 'polaris-desktop' });
-  instance.ctx.plugin(desktopProbe);
 
-  // 持久层先于其他插件：后装的插件才能在 apply 里拿到 storage 服务。
-  // 失败不阻断启动——没有持久层壳仍然可用（配置树退化为不落盘），
-  // kernel.status 的 storage=false 会把这件事暴露给渲染层与冒烟测试。
+  // 持久层先于 loader 直挂：配置树就存在这里。失败不阻断启动——树退化
+  // 为内存 store（见下），壳仍可用；kernel.status 的 storage=false 会把
+  // 这件事暴露给渲染层与冒烟测试。
   try {
     await instance.ctx.plugin(storage, {
       path: join(app.getPath('userData'), 'kernel', 'storage.db'),
     });
   } catch (err) {
     console.error('[kernel] storage 持久层挂载失败，本次会话不落盘：', err);
+  }
+
+  // storage 挂载失败时的降级：MemoryConfigTreeStore 让 loader 树照常
+  // 工作（首启种子也照种），只是这次会话的改动不落盘。
+  const storageSvc = instance.ctx.get('storage') as StorageService | undefined;
+  const store: ConfigTreeStore = storageSvc?.configTree ?? new MemoryConfigTreeStore();
+
+  let configTree: SqliteTree | undefined;
+  try {
+    if ((await store.load()).length === 0) await store.save(SEED_ENTRIES);
+    await instance.ctx.plugin(Loader);
+    registerBuiltins(instance.ctx.loader);
+    await instance.ctx.plugin(SqliteTree, { store });
+    configTree = instance.ctx.get('configTree') as SqliteTree | undefined;
+  } catch (err) {
+    // 树挂不上（数据损坏 / 某条目装载失败整树回滚）只损失插件能力，壳必须
+    // 照常起：configTree 留空，引擎注入被跳过，前端按 localBackend=null 回落远端。
+    console.error('[kernel] 配置树装载失败，本次会话无插件树：', err);
   }
 
   let engine = parseEngineSpec(process.env.POLARIS_DESKTOP_ENGINE);
@@ -140,16 +170,29 @@ export async function startKernel(): Promise<Kernel> {
   if (!engine && app.isPackaged) {
     engine = await bootstrapPackagedEngine();
   }
-  if (engine) {
-    // 等到健康（或失败）再返回：窗口在 startKernel 之后才创建，这样
-    // kernel.localBackend 与 CSP 在首个页面请求时就已是最终答案，渲染层
-    // 不用处理「先远端后本地」的中途切换。失败不阻断启动——记录错误后
-    // 回落远端服务器流程（localBackend 返回 null）。
-    try {
-      await instance.ctx.plugin(legacyEngine, engine);
-    } catch (err) {
-      console.error('[kernel] 本地引擎启动失败，回落远端流程：', err);
+  if (engine && configTree) {
+    // 引擎注入走 entry.update 而不是 tree.update：后者会把 enabled+spec
+    // 写进持久树，下次启动 env 变了树还按旧答案自启引擎；entry.update 只
+    // 改内存态并同步拉起 fiber，磁盘上始终是 disabled 占位——树保存用户
+    // 意图（要不要这个插件），引擎参数每次启动现算注入。
+    // entry.update 内部 init → fiber.await()：resolve 返回时引擎已健康或
+    // 已抛错。窗口在 startKernel 之后才创建，所以 kernel.localBackend 与
+    // CSP 在首个页面请求时就已是最终答案（与旧直挂语义一致）。
+    const entry = configTree.store['legacy-engine'];
+    if (entry) {
+      try {
+        await entry.update({ config: engine, disabled: null });
+      } catch (err) {
+        // 失败时 Entry.update 自己把 options 回滚到 disabled 且不落库，
+        // 用户树不被污染；这里照旧记录错误后回落远端服务器流程。
+        console.error('[kernel] 本地引擎启动失败，回落远端流程：', err);
+      }
+    } else {
+      // 条目被用户从树里删掉：用户状态即真相，不偷偷种回去
+      console.warn('[kernel] 配置树没有 legacy-engine 条目，跳过本地引擎');
     }
+  } else if (engine) {
+    console.error('[kernel] 配置树不可用，本地引擎无法注入，回落远端流程');
   }
 
   await instance.start();
@@ -157,7 +200,12 @@ export async function startKernel(): Promise<Kernel> {
   return instance;
 }
 
-/** 停机：dispose 根 fiber，级联回收（含本地引擎子进程）。幂等，未启动时是 no-op。 */
+/**
+ * 停机：dispose 根 fiber，级联回收（含本地引擎子进程）。幂等，未启动时是
+ * no-op。落盘顺序由 disposer 的逆序执行保证：SqliteTree 比 storage 后装，
+ * 先被 dispose——其 stop() 里 root.stop() 之后有最后一次 flush——storage
+ * 关库排在其后，不需要在这里显式 flush。
+ */
 export async function stopKernel(): Promise<void> {
   const instance = kernel;
   kernel = null;
@@ -167,7 +215,9 @@ export async function stopKernel(): Promise<void> {
 /**
  * kernel.status 的实现。plugins 用 ctx.registry.size —— cordis 公开文档口径
  * 「已注册插件 runtime 的数量」（vendor/deepseek-cordis/cordis/src/registry.ts），
- * 不数 fiber：同一插件多次装载仍算一个 runtime，作为「插件树活着」的指标更稳。
+ * 不数 fiber：同一插件多次装载仍算一个 runtime。树驱动后名额包括直挂的
+ * storage、Loader（连带其内部 isolate）、SqliteTree，以及树条目拉起的
+ * desktop-probe / sources（legacy-engine 视注入结果而定）。
  */
 export function kernelStatus(): KernelStatus {
   return {

--- a/src/desktop/src/shared/contract.ts
+++ b/src/desktop/src/shared/contract.ts
@@ -79,7 +79,9 @@ export interface UpdateInfo {
 
 /**
  * 内核运行状态。plugins = cordis registry 里已注册的插件 runtime 数量
- * （ctx.registry.size，公开口径）；一期只有探针插件，恒 ≥ 1 即为健康。
+ * （ctx.registry.size，公开口径）。树驱动装载（#703）后名额包括直挂的
+ * storage、Loader（连带其内部 isolate）、SqliteTree，以及配置树条目拉起的
+ * 内置插件（desktop-probe / sources 等），恒 ≥ 5 即为健康。
  */
 export interface KernelStatus {
   started: boolean;

--- a/src/desktop/src/smoke.ts
+++ b/src/desktop/src/smoke.ts
@@ -22,7 +22,7 @@ import { tmpdir } from 'node:os';
 import { gzipSync } from 'node:zlib';
 import { join } from 'node:path';
 
-import type { StorageService } from '@polaris/kernel';
+import type { SqliteTree, StorageService } from '@polaris/kernel';
 
 import { pingAgent, stopAgent } from './main/agent/supervisor';
 import { localBackend, startKernel, stopKernel } from './main/kernel';
@@ -377,7 +377,30 @@ void app.whenReady().then(async () => {
   check('kernel.status 经 IPC 往返返回', kernelState.error === undefined, kernelState.error ?? '');
   check('内核已启动（started=true）', kernelState.started === true);
   check('实例名为 polaris-desktop', kernelState.name === 'polaris-desktop', `name=${kernelState.name}`);
-  check('探针插件已注册（plugins ≥ 1）', (kernelState.plugins ?? 0) >= 1, `plugins=${kernelState.plugins}`);
+  // 树驱动装载（#703）后 registry 至少有：storage、Loader（连带其内部
+  // isolate）、SqliteTree、树条目 desktop-probe / sources 五个 runtime——
+  // 引擎条目默认 disabled 不占名额。计数只会随插件增多而涨，用 ≥ 兜底。
+  check('插件树已建立（plugins ≥ 5）', (kernelState.plugins ?? 0) >= 5, `plugins=${kernelState.plugins}`);
+
+  // 树驱动装载（#703）：内核插件不再硬编码直挂，而是首启种进配置树、
+  // 由 loader 按树拉起。断言种子条目真的在树里、真的驱动出了 fiber 与服务，
+  // 再改一条配置留给下面的重启组验证持久性。
+  console.log('\n树驱动装载');
+  const tree = kernelInstance.ctx.get('configTree') as SqliteTree | undefined;
+  check('configTree 服务可从 ctx 读到', tree != null);
+  if (tree) {
+    check('种子条目 desktop-probe 已装载', tree.store['desktop-probe']?.fiber != null);
+    check('种子条目 sources 已装载', tree.store['sources']?.fiber != null);
+    const engineEntry = tree.store['legacy-engine'];
+    check(
+      '种子条目 legacy-engine 保持 disabled 占位',
+      engineEntry != null && engineEntry.fiber == null && engineEntry.options.disabled === true,
+    );
+    check('树驱动的 sources 服务已挂出', kernelInstance.ctx.get('sources') != null);
+    // 改一条目的 config：write 是防抖合并的，必须 flush 才保证在重启前落库
+    await tree.update('desktop-probe', { config: { smokeTouched: true } });
+    await tree.flush();
+  }
 
   // storage 持久层（#609）：就绪性经 IPC 可见，数据要真的穿过一次「停机 →
   // 重启」仍然在——这正是配置树持久化存在的意义，光断言服务挂着不够。
@@ -391,8 +414,13 @@ void app.whenReady().then(async () => {
     `path=${storageSvc?.path}`,
   );
   if (storageSvc) {
+    // 追加而不是整树覆盖：树现在是真实的装载来源，覆盖掉种子会让重启后的
+    // 树驱动断言测不到恢复路径。disabled: true 让这行假插件名（smoke-plugin
+    // 并不存在）在重启装载时不会被 import。
+    const current = await storageSvc.configTree.load();
     await storageSvc.configTree.save([
-      { id: 'smoke-entry', name: 'smoke-plugin', config: { touched: true } },
+      ...current,
+      { id: 'smoke-entry', name: 'smoke-plugin', disabled: true, config: { touched: true } },
     ]);
   }
 
@@ -411,6 +439,25 @@ void app.whenReady().then(async () => {
     ),
     `entries=${JSON.stringify(entries)}`,
   );
+
+  // 树驱动恢复：重启后同一集合被重新装载，且上面那次条目配置修改仍在。
+  // 顺带证明「非空树不再种子」——smoke-entry 若被种子覆盖就不会在这里了。
+  const reopenedTree = reopened.ctx.get('configTree') as SqliteTree | undefined;
+  check('重启后配置树重新驱动装载', reopenedTree != null);
+  if (reopenedTree) {
+    check(
+      '重启后种子集合恢复（probe/sources 活、engine 仍 disabled）',
+      reopenedTree.store['desktop-probe']?.fiber != null
+        && reopenedTree.store['sources']?.fiber != null
+        && reopenedTree.store['legacy-engine'] != null
+        && reopenedTree.store['legacy-engine'].fiber == null,
+    );
+    const probeConfig = reopenedTree.store['desktop-probe']?.options.config as
+      | { smokeTouched?: boolean }
+      | undefined;
+    check('重启后条目配置修改仍在', probeConfig?.smokeTouched === true, `config=${JSON.stringify(probeConfig)}`);
+    check('非空树未被重新种子（smoke-entry 仍在树中）', reopenedTree.store['smoke-entry'] != null);
+  }
   await stopKernel();
 
   stopAgent();


### PR DESCRIPTION
Closes #703. Part of #698 (marketplace M1, item PR-2).

The desktop shell stops hardcoding plugin mounts: storage mounts directly (the tree reads through it, falling back to the in-memory store so the shell stays usable), then Loader + builtins + `SqliteTree` take over — the persisted tree is now the single source of truth for what runs.

- first-start seeds three entries (desktop-probe enabled, sources enabled, legacy-engine disabled placeholder); a non-empty tree is never reseeded — user state is truth, including a deleted engine entry (injection then skips with a warning)
- the engine spec keeps being computed per session and is injected via **entry-level** `update({config, disabled: null})`, whose promise resolves only after the plugin's health poll — identical "localBackend settled before the window" semantics; deliberately not a tree-level update, so **disk always keeps the disabled placeholder** and a later env-less boot can never auto-start from a stale spec; failure rolls the entry back and falls to remote as before
- esbuild fix for the vendored loader under CJS: `--define:import.meta.url` + a banner computing it from `__filename` + `--external:node-addon-require-builtin` (not installed — the optional native addon's require throws into the vendor's try/catch, disabling the internal module loader we don't want); verified zero `import.meta` in the bundle
- smoke: thresholds move to ≥ (Loader/isolate/SqliteTree occupy registry slots), a new tree-driven group (seeds, fibers, sources service, restart recovery with a persisted config edit), and the storage group now appends a disabled row instead of clobbering the live tree
- packaged verification: `dist:mac`, launched with temp userData and a fast-fail engine command — the asar loader path exercises `Entry.update → init` with no import.meta/createRequire errors, remote fallback logged, and the packaged SQLite holds exactly the three seed rows
- e2e both groups pass with the real docker engine; one pre-existing harness race (visibility snapshot vs async topics query) fixed with a bounded waitFor

No backend changes; kernel tests 73/73, frontend build, desktop lint/build/smoke green.