### PR TITLE
feat: plugins IPC method family and the manage capability

### DIFF
--- a/src/desktop/src/main/capabilities.ts
+++ b/src/desktop/src/main/capabilities.ts
@@ -1,7 +1,8 @@
 /* 能力清单。前端所有「走本地还是走远端」的判断只读这张表。
 
-   一期全部 available: false —— 本地能力还没实现。但 tectonic 的探测是真的做了，
-   一来演练探测这条路，二来第二期接本地编译时这段不用重写。 */
+   本地计算能力（latex/papers/cache）一期全部 available: false —— 还没实现。
+   但 tectonic 的探测是真的做了，一来演练探测这条路，二来第二期接本地编译时
+   这段不用重写。plugins.manage（#705）是第一个真的会翻 true 的能力位。 */
 
 import { app } from 'electron';
 import { execFile } from 'node:child_process';
@@ -11,14 +12,27 @@ import {
   CAPABILITY_LATEX_COMPILE,
   CAPABILITY_PAPER_IMPORT,
   CAPABILITY_PDF_CACHE,
+  CAPABILITY_PLUGINS_MANAGE,
   CONTRACT_VERSION,
   type CapabilityManifest,
   type CapabilityState,
   type HostInfo,
 } from '../shared/contract';
+import { kernelConfigTree } from './kernel';
 
 const execFileAsync = promisify(execFile);
 const PHASE_1_REASON = 'not implemented yet (phase 1 ships the shell only)';
+
+/**
+ * plugins.manage（#705）：kernel 活着且 configTree 服务可达才可用。
+ * 不做缓存——树挂载失败/停机后能力要立刻翻 false，与 plugins.* 方法族的
+ * 门槛（methods.plugins.ts 的 requireTree）读的是同一个访问函数。
+ */
+function pluginsManageState(): CapabilityState {
+  return kernelConfigTree()
+    ? { available: true }
+    : { available: false, reason: 'kernel config tree unavailable' };
+}
 
 let tectonicProbe: CapabilityState['detail'] | undefined;
 let probed = false;
@@ -50,6 +64,7 @@ export async function capabilityManifest(): Promise<CapabilityManifest> {
       },
       [CAPABILITY_PAPER_IMPORT]: { available: false, reason: PHASE_1_REASON },
       [CAPABILITY_PDF_CACHE]: { available: false, reason: PHASE_1_REASON },
+      [CAPABILITY_PLUGINS_MANAGE]: pluginsManageState(),
     },
   };
 }

--- a/src/desktop/src/main/ipc/methods.plugins.ts
+++ b/src/desktop/src/main/ipc/methods.plugins.ts
@@ -1,0 +1,94 @@
+/* ============================================================
+   plugins.* 的实现（#705）：全部是「取 configTree 句柄 → 调 kernel 侧
+   方法」的薄壳。语义都住在 kernel（@polaris/kernel 的 SqliteTree）里，
+   这里只负责三件事：
+   - 能力门槛：树不可达时统一抛 ERR_CAPABILITY_UNAVAILABLE（与能力位
+     plugins.manage 读同一个 kernelConfigTree()，可用性天然一致）；
+   - 把校验错误按契约作为数据返回（PluginValidationResult），把装载
+     失败作为异常抛出——前者是用户输入问题要就地回显，后者是运行故障；
+   - 写操作后 flush：树的 write 是防抖合并的，IPC 返回前落盘，renderer
+     看到成功即已持久。
+   参数形状校验在 router 的手写守卫里（见 router.ts 文件头），这里默认
+   拿到的已是形状正确的值；语义校验（__jsExpr/未知字段/重复 id/schema）
+   由 kernel 层完成——双层校验各管一层，互不重复。
+   ============================================================ */
+
+import type { SqliteTree } from '@polaris/kernel';
+
+import {
+  ERR_CAPABILITY_UNAVAILABLE,
+  ERR_INVALID_PARAMS,
+  type PluginEntryInfo,
+  type PluginTreeExport,
+  type PluginValidationResult,
+} from '../../shared/contract';
+import { kernelConfigTree, kernelPluginMeta } from '../kernel';
+
+function requireTree(): SqliteTree {
+  const tree = kernelConfigTree();
+  if (!tree) {
+    throw new Error(`${ERR_CAPABILITY_UNAVAILABLE}: plugins.manage — kernel 配置树不可用`);
+  }
+  return tree;
+}
+
+/** 变更后的条目回执：让 UI 开关不用再发一次 list 就能拿到最终运行态。 */
+function entryInfo(tree: SqliteTree, id: string): PluginEntryInfo {
+  const info = tree.listEntries().find((entry) => entry.id === id);
+  // resolve 成功过的 id 一定在列表里；防御性兜底只为类型收窄
+  if (!info) throw new Error(`${ERR_INVALID_PARAMS}: unknown plugin entry ${id}`);
+  return info;
+}
+
+export function pluginsList(): PluginEntryInfo[] {
+  return requireTree().listEntries();
+}
+
+export async function pluginsEnable(id: string): Promise<PluginEntryInfo> {
+  const tree = requireTree();
+  // disabled: null = 删除该键（loader 的 isNullable 语义），回到默认启用。
+  // 拉起失败时 Entry.update 自己回滚 options（树不被污染），错误照抛。
+  await tree.update(id, { disabled: null });
+  await tree.flush();
+  return entryInfo(tree, id);
+}
+
+export async function pluginsDisable(id: string): Promise<PluginEntryInfo> {
+  const tree = requireTree();
+  await tree.update(id, { disabled: true });
+  await tree.flush();
+  return entryInfo(tree, id);
+}
+
+export async function pluginsUpdateConfig(
+  id: string,
+  config: unknown,
+): Promise<PluginValidationResult> {
+  const tree = requireTree();
+  const entry = tree.resolve(id); // 未知 id 在这里抛错
+  if (entry.options.group) {
+    // 组条目的 config 是子条目列表（loader 内部表示），从这里改会拆树
+    throw new Error(`${ERR_INVALID_PARAMS}: entry ${id} is a group; groups carry no plugin config`);
+  }
+  const result = tree.validateConfig(entry.options.name, config);
+  // 校验错误是数据不是异常：ok=false 时什么都没改，前端就地回显
+  if (!result.ok) return result;
+  await tree.update(id, { config });
+  await tree.flush();
+  return result;
+}
+
+export function pluginsValidateConfig(name: string, config: unknown): PluginValidationResult {
+  return requireTree().validateConfig(name, config);
+}
+
+export function pluginsExportTree(): PluginTreeExport {
+  // version 是 IPC 契约的事：kernel 只管树本身，这里包上版本号
+  return { version: 1, entries: requireTree().exportTree() };
+}
+
+export async function pluginsImportTree(tree: PluginTreeExport): Promise<void> {
+  // last-good 快照落 PluginMetaStore；storage 失败的内存树会话拿不到
+  // meta，导入照常（本次会话本来就不落盘），见 kernel.ts 的说明
+  await requireTree().importTree(tree.entries, kernelPluginMeta() ?? undefined);
+}

--- a/src/desktop/src/main/ipc/router.ts
+++ b/src/desktop/src/main/ipc/router.ts
@@ -17,6 +17,7 @@ import {
   IPC_CHANNEL_INFO_SYNC,
   IPC_CHANNEL_RPC,
   type MethodName,
+  type PluginTreeExport,
   type RpcRequest,
 } from '../../shared/contract';
 import { capabilityManifest } from '../capabilities';
@@ -24,6 +25,7 @@ import { engineBootstrapStatus, kernelStatus, localBackend } from '../kernel';
 import { applyUpdate, checkForUpdate } from '../updates';
 import * as host from './methods.host';
 import * as local from './methods.local';
+import * as plugins from './methods.plugins';
 
 function asString(params: unknown, key: string): string {
   const value = (params as Record<string, unknown> | null)?.[key];
@@ -41,6 +43,67 @@ function asNumber(params: unknown, key: string): number {
   return value;
 }
 
+/**
+ * 插件配置载荷：一律是纯对象。数组/原始值/null 在 schema 层面没有合法
+ * 形状，在 IPC 边界先挡掉；对象内部的语义（__jsExpr、schema 匹配）归
+ * kernel 层校验——两层各管一层，见 methods.plugins.ts 文件头。
+ */
+function asPluginConfig(params: unknown): Record<string, unknown> {
+  const value = (params as Record<string, unknown> | null)?.['config'];
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${ERR_INVALID_PARAMS}: config must be a plain object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+/** 树导入嵌套上限。真实树两三层，16 层只为拦住构造出来的深递归载荷。 */
+const MAX_TREE_DEPTH = 16;
+
+function assertTreeEntryShape(value: unknown, path: string, depth: number): void {
+  if (depth > MAX_TREE_DEPTH) {
+    throw new Error(`${ERR_INVALID_PARAMS}: ${path} exceeds max tree depth ${MAX_TREE_DEPTH}`);
+  }
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${ERR_INVALID_PARAMS}: ${path} must be an object`);
+  }
+  const entry = value as Record<string, unknown>;
+  if (typeof entry.id !== 'string' || !entry.id) {
+    throw new Error(`${ERR_INVALID_PARAMS}: ${path}.id must be a non-empty string`);
+  }
+  if (typeof entry.name !== 'string' || !entry.name) {
+    throw new Error(`${ERR_INVALID_PARAMS}: ${path}.name must be a non-empty string`);
+  }
+  if (entry.disabled !== undefined && typeof entry.disabled !== 'boolean') {
+    throw new Error(`${ERR_INVALID_PARAMS}: ${path}.disabled must be a boolean`);
+  }
+  if (entry.children !== undefined) {
+    if (!Array.isArray(entry.children)) {
+      throw new Error(`${ERR_INVALID_PARAMS}: ${path}.children must be an array`);
+    }
+    entry.children.forEach((child, index) =>
+      assertTreeEntryShape(child, `${path}.children[${index}]`, depth + 1),
+    );
+  }
+  // 多余字段/重复 id/__jsExpr 故意不在这里查：那是语义校验，kernel 的
+  // importTree 会用与装载完全相同的一套规则拒绝（校验不复制两份）
+}
+
+function asPluginTreeExport(params: unknown): PluginTreeExport {
+  const value = (params as Record<string, unknown> | null)?.['tree'];
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${ERR_INVALID_PARAMS}: tree must be an object`);
+  }
+  const tree = value as Record<string, unknown>;
+  if (tree.version !== 1) {
+    throw new Error(`${ERR_INVALID_PARAMS}: unsupported tree export version ${String(tree.version)}`);
+  }
+  if (!Array.isArray(tree.entries)) {
+    throw new Error(`${ERR_INVALID_PARAMS}: tree.entries must be an array`);
+  }
+  tree.entries.forEach((entry, index) => assertTreeEntryShape(entry, `entries[${index}]`, 0));
+  return value as unknown as PluginTreeExport;
+}
+
 type Handler = (params: unknown) => unknown | Promise<unknown>;
 
 const HANDLERS: Record<MethodName, Handler> = {
@@ -56,6 +119,15 @@ const HANDLERS: Record<MethodName, Handler> = {
   'kernel.status': () => kernelStatus(),
   'kernel.localBackend': () => localBackend(),
   'kernel.engineBootstrapStatus': () => engineBootstrapStatus(),
+  // plugins.*：能力门槛（树不可达 → ERR_CAPABILITY_UNAVAILABLE）在实现里统一做
+  'plugins.list': () => plugins.pluginsList(),
+  'plugins.enable': (p) => plugins.pluginsEnable(asString(p, 'id')),
+  'plugins.disable': (p) => plugins.pluginsDisable(asString(p, 'id')),
+  'plugins.updateConfig': (p) => plugins.pluginsUpdateConfig(asString(p, 'id'), asPluginConfig(p)),
+  'plugins.validateConfig': (p) =>
+    plugins.pluginsValidateConfig(asString(p, 'name'), asPluginConfig(p)),
+  'plugins.exportTree': () => plugins.pluginsExportTree(),
+  'plugins.importTree': (p) => plugins.pluginsImportTree(asPluginTreeExport(p)),
   // local.* 一期全部走到 agent 再以 ERR_CAPABILITY_UNAVAILABLE 结束（见 methods.local.ts）
   'local.latex.compile': (p) => local.latexCompile(p),
   'local.fs.pickFolder': (p) => local.pickFolder(p),

--- a/src/desktop/src/main/kernel.ts
+++ b/src/desktop/src/main/kernel.ts
@@ -38,6 +38,7 @@ import {
   type ConfigTreeStore,
   type Kernel,
   type LegacyEngineConfig,
+  type PluginMetaStore,
   type StorageService,
 } from '@polaris/kernel';
 
@@ -233,6 +234,23 @@ export function kernelStatus(): KernelStatus {
 /** kernel.engineBootstrapStatus 的实现：内嵌引擎引导进度（诊断/进度条用）。 */
 export function engineBootstrapStatus(): EngineBootstrapStatus {
   return bootstrapStatus;
+}
+
+/**
+ * plugins.* IPC 与 plugins.manage 能力位共用的树句柄。reflect 严格模式
+ * 保证：kernel 没起、SqliteTree 没装、或其 fiber 不在 ACTIVE，这里一律
+ * 拿到 null——能力位与方法族的「可用」判断因此天然是同一个事实。
+ */
+export function kernelConfigTree(): SqliteTree | null {
+  return (kernel?.ctx.get('configTree') as SqliteTree | undefined) ?? null;
+}
+
+/**
+ * importTree 存 last-good 快照的落点。storage 挂载失败（内存树会话）时为
+ * null，导入照常进行只是少一层持久保险——树本身这次会话也不落盘。
+ */
+export function kernelPluginMeta(): PluginMetaStore | null {
+  return (kernel?.ctx.get('storage') as StorageService | undefined)?.pluginMeta ?? null;
 }
 
 /**

--- a/src/desktop/src/shared/contract.ts
+++ b/src/desktop/src/shared/contract.ts
@@ -46,6 +46,8 @@ export interface CapabilityManifest {
 export const CAPABILITY_LATEX_COMPILE = 'latex.compile';
 export const CAPABILITY_PAPER_IMPORT = 'papers.import';
 export const CAPABILITY_PDF_CACHE = 'cache.pdf';
+/** 插件管理（#705）：kernel 活着且配置树服务可达时可用，设置页插件 tab 读它显隐。 */
+export const CAPABILITY_PLUGINS_MANAGE = 'plugins.manage';
 
 /** 长任务句柄：invoke 立刻返回它，进度经事件通道推。 */
 export interface JobHandle {
@@ -110,6 +112,53 @@ export interface EngineBootstrapStatus {
   done: boolean;
 }
 
+/* ---- plugins.*（#705）：配置树管理的载荷类型 ---- */
+
+/**
+ * 单个插件条目的运行时视图（kernel 侧 SqliteTree.listEntries 的镜像）。
+ * disabled 是树上的持久开关（用户意图），state 才是运行事实：
+ * active=fiber 已装载；disabled=按开关未实例化；error=fiber 启动/运行失败；
+ * pending=在等依赖服务（或树刚建还没跑完）。
+ */
+export interface PluginEntryInfo {
+  id: string;
+  /** 装载 specifier，内置插件形如 cordis:sources。 */
+  name: string;
+  disabled: boolean;
+  state: 'active' | 'disabled' | 'error' | 'pending';
+  /** 仅 state='error' 时存在：fiber 记录的失败原因。 */
+  error?: string;
+  /** 条目当前配置。组条目（children 容器）不暴露 config。 */
+  config?: unknown;
+}
+
+/** schemastery 校验结果：错误作为数据返回而不是抛异常，前端就地回显。 */
+export interface PluginValidationError {
+  /** 出错字段路径；解析不出来时为空串，message 里带完整描述。 */
+  path: string;
+  message: string;
+}
+
+export interface PluginValidationResult {
+  ok: boolean;
+  errors: PluginValidationError[];
+}
+
+/** 整树导出条目（kernel ConfigEntry 的镜像形状）。 */
+export interface PluginTreeEntry {
+  id: string;
+  name: string;
+  config?: unknown;
+  disabled?: boolean;
+  children?: PluginTreeEntry[];
+}
+
+/** 整树导出/导入载荷。version 定死为 1，导入时不认识的版本直接拒绝。 */
+export interface PluginTreeExport {
+  version: 1;
+  entries: PluginTreeEntry[];
+}
+
 /** 服务器连通性探测结果（打 GET {url}/api/health）。 */
 export type ServerProbe =
   | { ok: true; version: string }
@@ -139,6 +188,26 @@ export interface Methods {
   'kernel.localBackend': { params: void; result: LocalBackendInfo };
   /** 内嵌引擎引导进度；首启 bootstrap 期间轮询可得阶段信息。 */
   'kernel.engineBootstrapStatus': { params: void; result: EngineBootstrapStatus };
+
+  /* ---- plugins.*：配置树管理（#705）。能力位 plugins.manage 不可用
+     （kernel 没起来 / 配置树挂载失败）时全族抛 ERR_CAPABILITY_UNAVAILABLE。
+     校验分两层：router 只做 IPC 形状（字符串/对象/递归树形），语义校验
+     （__jsExpr、未知字段、重复 id、schema）在 kernel 进程内完成。 ---- */
+
+  /** 全部条目 + 运行态。 */
+  'plugins.list': { params: void; result: PluginEntryInfo[] };
+  /** 启用条目（删掉树上的 disabled 键并拉起 fiber）；失败抛错且树回滚。 */
+  'plugins.enable': { params: { id: string }; result: PluginEntryInfo };
+  /** 禁用条目（fiber 级联 dispose，树上留 disabled 占位）。 */
+  'plugins.disable': { params: { id: string }; result: PluginEntryInfo };
+  /** 校验并应用配置。ok=false 表示 schema 未过、什么都没改。 */
+  'plugins.updateConfig': { params: { id: string; config: unknown }; result: PluginValidationResult };
+  /** 只校验不应用（配置编辑器的实时回显）。 */
+  'plugins.validateConfig': { params: { name: string; config: unknown }; result: PluginValidationResult };
+  /** 导出当前整树（备份/迁移）。 */
+  'plugins.exportTree': { params: void; result: PluginTreeExport };
+  /** 全量替换整树。导入前 kernel 自动留 last-good 快照，失败回滚。 */
+  'plugins.importTree': { params: { tree: PluginTreeExport }; result: void };
 
   /* ---- local.*：第二期的本地计算能力 ----
      现在全部声明但不实现（一律抛 ERR_CAPABILITY_UNAVAILABLE），目的是把

--- a/src/desktop/src/smoke.ts
+++ b/src/desktop/src/smoke.ts
@@ -28,6 +28,7 @@ import { pingAgent, stopAgent } from './main/agent/supervisor';
 import { localBackend, startKernel, stopKernel } from './main/kernel';
 import { capabilityManifest } from './main/capabilities';
 import { installIpc } from './main/ipc/router';
+import { pluginsDisable, pluginsEnable, pluginsExportTree, pluginsList } from './main/ipc/methods.plugins';
 import { extractTarGz } from './main/updates/tar';
 import { compareVersions, stagedSupersedes } from './main/updates/version';
 import { APP_INDEX, buildCsp, handleAppProtocol, registerAppScheme } from './main/protocol';
@@ -341,8 +342,16 @@ void app.whenReady().then(async () => {
   const manifest = await capabilityManifest();
   check('契约版本已声明', manifest.contract >= 1);
   check(
-    '所有本地能力一期均为不可用',
-    Object.values(manifest.capabilities).every((c) => !c.available),
+    '本地计算能力一期均为不可用',
+    Object.entries(manifest.capabilities)
+      .filter(([key]) => key !== 'plugins.manage')
+      .every(([, c]) => !c.available),
+  );
+  // plugins.manage（#705）是第一个真可用的能力位：kernel 已起、树已就绪
+  check(
+    'plugins.manage 能力位可用（配置树已就绪）',
+    manifest.capabilities['plugins.manage']?.available === true,
+    JSON.stringify(manifest.capabilities['plugins.manage']),
   );
   check(
     'tectonic 探测已真的执行（第二期直接用）',
@@ -401,6 +410,40 @@ void app.whenReady().then(async () => {
     await tree.update('desktop-probe', { config: { smokeTouched: true } });
     await tree.flush();
   }
+
+  // plugins.* IPC（#705）：与 kernel.status 同款调用路径——直接调 router
+  // 背后的具名实现（router 只做参数形状分发）。语义细节在 kernel 的
+  // plugins-manage.test 里测全，这里只验「桌面接线真的驱动 loader」。
+  console.log('\nplugins.* IPC');
+  const pluginList = pluginsList();
+  const pluginIds = pluginList.map((info) => info.id);
+  check(
+    'plugins.list 返回全部种子条目',
+    ['desktop-probe', 'sources', 'legacy-engine'].every((id) => pluginIds.includes(id)),
+    `ids=${pluginIds.join(',')}`,
+  );
+  check(
+    '状态映射：desktop-probe=active / legacy-engine=disabled',
+    pluginList.find((info) => info.id === 'desktop-probe')?.state === 'active'
+      && pluginList.find((info) => info.id === 'legacy-engine')?.state === 'disabled',
+  );
+  const treeExport = pluginsExportTree();
+  check(
+    'plugins.exportTree 带版本号且含种子条目',
+    treeExport.version === 1 && treeExport.entries.some((entry) => entry.id === 'sources'),
+  );
+  const probeDisabled = await pluginsDisable('desktop-probe');
+  check(
+    'plugins.disable 停掉 fiber',
+    probeDisabled.state === 'disabled' && tree?.store['desktop-probe']?.fiber == null,
+    `state=${probeDisabled.state}`,
+  );
+  const probeEnabled = await pluginsEnable('desktop-probe');
+  check(
+    'plugins.enable 重建 fiber',
+    probeEnabled.state === 'active' && tree?.store['desktop-probe']?.fiber != null,
+    `state=${probeEnabled.state}`,
+  );
 
   // storage 持久层（#609）：就绪性经 IPC 可见，数据要真的穿过一次「停机 →
   // 重启」仍然在——这正是配置树持久化存在的意义，光断言服务挂着不够。

--- a/src/frontend/src/lib/host.ts
+++ b/src/frontend/src/lib/host.ts
@@ -175,3 +175,98 @@ export function onHostEvent(handler: (event: HostEvent) => void): () => void {
   const id = b.subscribe(handler);
   return () => b.unsubscribe(id);
 }
+
+/* —— 插件管理（plugins.*，#705；contract.ts 的手工镜像）——
+   仅桌面端有意义：设置页插件 tab 的显隐读 plugins.manage 能力位，
+   web 端（无桥）所有调用都是安全的 null/no-op、零请求。 */
+
+/** 插件管理能力键（isCapabilityAvailable 用）。 */
+export const CAPABILITY_PLUGINS_MANAGE = 'plugins.manage';
+
+/** 单个插件条目的运行时视图。disabled 是持久开关（用户意图），state 是运行事实。 */
+export interface PluginEntryInfo {
+  id: string;
+  name: string;
+  disabled: boolean;
+  state: 'active' | 'disabled' | 'error' | 'pending';
+  error?: string;
+  config?: unknown;
+}
+
+export interface PluginValidationError {
+  path: string;
+  message: string;
+}
+
+/** 配置校验结果：错误是数据（就地回显），装载失败才是异常。 */
+export interface PluginValidationResult {
+  ok: boolean;
+  errors: PluginValidationError[];
+}
+
+export interface PluginTreeEntry {
+  id: string;
+  name: string;
+  config?: unknown;
+  disabled?: boolean;
+  children?: PluginTreeEntry[];
+}
+
+/** 整树导出/导入载荷；version 不为 1 的载荷主进程直接拒绝。 */
+export interface PluginTreeExport {
+  version: 1;
+  entries: PluginTreeEntry[];
+}
+
+/** 全部插件条目 + 运行态；web 端返回 null。 */
+export async function listPlugins(): Promise<PluginEntryInfo[] | null> {
+  const b = bridge();
+  if (!b) return null;
+  return (await b.invoke('plugins.list')) as PluginEntryInfo[];
+}
+
+/** 启用插件，返回变更后的条目；启动失败时抛错（主进程侧树已回滚）。 */
+export async function enablePlugin(id: string): Promise<PluginEntryInfo | null> {
+  const b = bridge();
+  if (!b) return null;
+  return (await b.invoke('plugins.enable', { id })) as PluginEntryInfo;
+}
+
+/** 禁用插件（fiber 级联回收），返回变更后的条目。 */
+export async function disablePlugin(id: string): Promise<PluginEntryInfo | null> {
+  const b = bridge();
+  if (!b) return null;
+  return (await b.invoke('plugins.disable', { id })) as PluginEntryInfo;
+}
+
+/** 校验并应用配置：ok=false 表示 schema 未过、什么都没改。 */
+export async function updatePluginConfig(
+  id: string,
+  config: Record<string, unknown>,
+): Promise<PluginValidationResult | null> {
+  const b = bridge();
+  if (!b) return null;
+  return (await b.invoke('plugins.updateConfig', { id, config })) as PluginValidationResult;
+}
+
+/** 只校验不应用（配置编辑器实时回显）。 */
+export async function validatePluginConfig(
+  name: string,
+  config: Record<string, unknown>,
+): Promise<PluginValidationResult | null> {
+  const b = bridge();
+  if (!b) return null;
+  return (await b.invoke('plugins.validateConfig', { name, config })) as PluginValidationResult;
+}
+
+/** 导出整棵配置树（备份/迁移）；web 端返回 null。 */
+export async function exportPluginTree(): Promise<PluginTreeExport | null> {
+  const b = bridge();
+  if (!b) return null;
+  return (await b.invoke('plugins.exportTree')) as PluginTreeExport;
+}
+
+/** 全量替换整树。主进程导入前自动留 last-good 快照、失败回滚。 */
+export async function importPluginTree(tree: PluginTreeExport): Promise<void> {
+  await bridge()?.invoke('plugins.importTree', { tree });
+}

--- a/src/kernel/src/config/sqlite-tree.ts
+++ b/src/kernel/src/config/sqlite-tree.ts
@@ -21,9 +21,60 @@
    本文件必须保持 electron-free（tests/electron-free.test.ts 强制）。
    ============================================================ */
 
-import { Context, Service } from '@deepseek-ai/cordis'
+import { Context, Service, type Fiber } from '@deepseek-ai/cordis'
 import { EntryGroup, EntryTree, type EntryOptions } from '@deepseek-ai/cordis-plugin-loader'
 import type { ConfigEntry, ConfigTreeStore } from './tree.ts'
+
+/** importTree 存 last-good 快照用的 PluginMetaStore 键（#705）。 */
+export const CONFIG_TREE_LAST_GOOD_KEY = 'config-tree:last-good'
+
+/** last-good 快照的最小落点：结构化成接口以免测试必须拉一整个 SQLite。 */
+export interface LastGoodSink {
+  set(key: string, value: unknown): void
+}
+
+/** plugins.list 的单条视图。桌面 contract.ts 手工镜像本形状，改动需两边同步。 */
+export interface PluginEntryInfo {
+  id: string
+  name: string
+  /** 树上的持久开关（用户意图）；state 才是运行事实。 */
+  disabled: boolean
+  state: 'active' | 'disabled' | 'error' | 'pending'
+  error?: string
+  config?: unknown
+}
+
+export interface PluginValidationError {
+  path: string
+  message: string
+}
+
+/** 校验错误作为数据返回（不抛异常）：前端配置编辑器要就地回显。 */
+export interface PluginValidationResult {
+  ok: boolean
+  errors: PluginValidationError[]
+}
+
+/**
+ * 条目运行态推导。FiberState 是 const enum——对开启 isolatedModules 的
+ * 消费方（desktop 的 tsc）它是 ambient、成员不可引用，所以这里不 import
+ * 枚举，而是照 Fiber._getState 的同一套事实源推导：_error 非空 = FAILED；
+ * uid 未清且 store 已建 = 已装载（ACTIVE）；其余都算等待中。_error 是
+ * 私有字段，但 FAILED 状态下它就是唯一的错误事实源（fiber.await() 会
+ * rethrow 同一个值），这里只读不改。
+ */
+export function describeEntryState(
+  fiber: Fiber | undefined,
+  disabled: boolean,
+): { state: PluginEntryInfo['state']; error?: string } {
+  if (!fiber) return { state: disabled ? 'disabled' : 'pending' }
+  const raw = (fiber as unknown as { _error?: unknown })._error
+  if (raw !== undefined) {
+    return { state: 'error', error: raw instanceof Error ? raw.message : String(raw) }
+  }
+  if (fiber.uid !== null && fiber.store !== undefined) return { state: 'active' }
+  return { state: 'pending' }
+}
 
 /** ConfigEntry 允许的键。多出来的一律拒载，见 assertEntryKeys。 */
 const CONFIG_ENTRY_KEYS = new Set(['id', 'name', 'config', 'disabled', 'children'])
@@ -193,6 +244,107 @@ export class SqliteTree extends EntryTree {
     return super.import(name, getOuterStack)
   }
 
+  /** plugins.list（#705）：树条目 + 运行态的扁平视图。 */
+  listEntries(): PluginEntryInfo[] {
+    return [...this.entries()].map((entry) => {
+      const { state, error } = describeEntryState(entry.fiber, entry.disabled)
+      const info: PluginEntryInfo = {
+        id: entry.id,
+        name: entry.options.name,
+        disabled: Boolean(entry.options.disabled),
+        state,
+      }
+      if (error !== undefined) info.error = error
+      // 组条目的 config 是子条目列表（loader 内部表示），不当作插件配置暴露
+      if (!entry.options.group && entry.options.config !== undefined) {
+        info.config = entry.options.config
+      }
+      return info
+    })
+  }
+
+  /**
+   * plugins.validateConfig（#705）：在 kernel 进程内做 schema 校验，错误
+   * 作为数据返回。内置插件（cordis:）从 loader.builtins 查 Config schema；
+   * 插件没有 Config 或是非内置 specifier（三方 npm 包，拿不到 schema）时
+   * 无校验即通过——装载时 cordis 还会用插件自己的 Config 再校一遍兜底。
+   */
+  validateConfig(name: string, config: unknown): PluginValidationResult {
+    const errors: PluginValidationError[] = []
+    const push = (cause: unknown): void => {
+      // path 统一留空：schemastery 的报错文案自带字段路径，拆出来反而丢上下文
+      errors.push({ path: '', message: cause instanceof Error ? cause.message : String(cause) })
+    }
+    try {
+      // D5：__jsExpr 在任何入口都封死，校验层也要把它当错误回显而不是放过
+      assertNoJsExpr(config, 'config')
+    } catch (cause) {
+      push(cause)
+    }
+    if (name.startsWith('cordis:')) {
+      const plugin = this.ctx.loader.builtins[name.slice(7)] as { Config?: unknown } | undefined
+      if (!plugin) {
+        push(new Error(`未知的内置插件 "${name}"（未在 loader.builtins 注册）`))
+      } else if (typeof plugin.Config === 'function') {
+        // schemastery 的 schema 本身可调用：调用即校验（返回补全默认值的
+        // 副本）。这里只收集错误，不把补全后的值写回树——树存用户写的原文。
+        try {
+          ;(plugin.Config as (value: unknown) => unknown)(config)
+        } catch (cause) {
+          push(cause)
+        }
+      }
+    }
+    return { ok: errors.length === 0, errors }
+  }
+
+  /** plugins.exportTree（#705）：当前树的序列化快照（与落库走同一变换）。 */
+  exportTree(): ConfigEntry[] {
+    return this.root.data.map((options, index) =>
+      toConfigEntry(options, childPath('', options, index)),
+    )
+  }
+
+  /**
+   * plugins.importTree（#705）：全量替换整树。
+   *
+   * 三步走，顺序即安全设计：
+   * 1. 语义校验完全复用装载边界的 toEntryOptions（__jsExpr / 未知字段 /
+   *    重复 id / 形状错误一律抛错）——校验不过时树没有被碰过；
+   * 2. 把替换前的树快照写进 last-good（PluginMetaStore），这是「全量覆盖
+   *    可以清空配置」这条风险的持久保险：哪怕后面的回滚也失败，用户数据
+   *    仍然躺在 KV 里可以人工恢复；
+   * 3. root.update 事务化 reconcile。它失败时自己会把内存树滚回旧状态，
+   *    这里再按 last-good 重放一次做兜底（覆盖「内部回滚半途而废」的残局）。
+   */
+  async importTree(entries: ConfigEntry[], lastGood?: LastGoodSink): Promise<void> {
+    const seen = new Set<string>()
+    const next = entries.map((entry, index) =>
+      toEntryOptions(entry, childPath('', entry, index), seen),
+    )
+    const snapshot = this.exportTree()
+    lastGood?.set(CONFIG_TREE_LAST_GOOD_KEY, snapshot)
+    try {
+      await this.root.update(next)
+    } catch (error) {
+      try {
+        await this.root.update(
+          snapshot.map((entry, index) => toEntryOptions(entry, childPath('', entry, index), new Set())),
+        )
+      } catch (rollbackError) {
+        throw new AggregateError([error, rollbackError], '导入失败且 last-good 回滚未完全成功')
+      }
+      // 回滚成功后同样落一次库：部分拉起可能已触发过 write，把磁盘拉回真相
+      this.write()
+      await this.flush().catch(() => {
+        /* flush 内部已记日志；这里不让落库失败盖掉导入失败的原始错误 */
+      })
+      throw error
+    }
+    this.write()
+    await this.flush()
+  }
+
   /**
    * 防抖合并写（why：写放大）。loader 的每个树操作都会调一次 write——
    * create/update/remove 各一次，internal/update 钩子回写 config 又一次，
@@ -239,9 +391,6 @@ export class SqliteTree extends EntryTree {
   async #save(): Promise<void> {
     // 序列化放在真正写的时刻：root.data 是就地变更的活数组，写入点
     // 取快照才能保证落的是合并后的最终状态
-    const entries = this.root.data.map((options, index) =>
-      toConfigEntry(options, childPath('', options, index)),
-    )
-    await this.config.store.save(entries)
+    await this.config.store.save(this.exportTree())
   }
 }

--- a/src/kernel/src/index.ts
+++ b/src/kernel/src/index.ts
@@ -10,7 +10,15 @@ export {
   type ConfigEntry,
   type ConfigTreeStore,
 } from './config/tree.ts'
-export { SqliteTree } from './config/sqlite-tree.ts'
+export {
+  CONFIG_TREE_LAST_GOOD_KEY,
+  SqliteTree,
+  describeEntryState,
+  type LastGoodSink,
+  type PluginEntryInfo,
+  type PluginValidationError,
+  type PluginValidationResult,
+} from './config/sqlite-tree.ts'
 export { BUILTIN_PLUGINS, desktopProbe, registerBuiltins } from './plugins/builtins.ts'
 export {
   ENGINE_CONTAINER,

--- a/src/kernel/tests/plugins-manage.test.ts
+++ b/src/kernel/tests/plugins-manage.test.ts
@@ -1,0 +1,267 @@
+/* plugins.* IPC 方法族的 kernel 侧支撑（#705）：SqliteTree 的
+   listEntries / validateConfig / exportTree / importTree。桌面 IPC 层只是
+   薄壳，语义全在这里——所以状态映射、schema 校验、恶意载荷拒绝与
+   last-good 回滚都在 kernel 面测完，desktop smoke 只验接线。 */
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, describe, expect, it } from 'vitest'
+import Schema from '@deepseek-ai/schemastery'
+import type { Context, Fiber } from '@deepseek-ai/cordis'
+import {
+  CONFIG_TREE_LAST_GOOD_KEY,
+  Loader,
+  MemoryConfigTreeStore,
+  PluginMetaStore,
+  SqliteTree,
+  createKernel,
+  describeEntryState,
+  migrate,
+  openStorage,
+  registerBuiltins,
+  type ConfigEntry,
+  type ConfigTreeStore,
+  type Kernel,
+} from '../src/index.ts'
+
+const dir = mkdtempSync(join(tmpdir(), 'kernel-plugins-manage-'))
+afterAll(() => rmSync(dir, { recursive: true, force: true }))
+
+let seq = 0
+const freshPath = (): string => join(dir, `db-${++seq}.sqlite`)
+
+/**
+ * 起一个装好 Loader + 内置表的 kernel，另注册三个测试插件：
+ * - cordis:fake     无 Config，装载即成功（active 状态样本）
+ * - cordis:confy    带 schemastery Config（校验正反用例）
+ * - cordis:stuck    声明依赖不存在的服务（fiber 停在 PENDING 的样本）
+ */
+async function bootKernel(): Promise<Kernel> {
+  const kernel = createKernel({ name: 'plugins-manage-test' })
+  await kernel.start()
+  await kernel.ctx.plugin(Loader)
+  const loader = kernel.ctx.loader
+  registerBuiltins(loader)
+  loader.builtins['fake'] = { name: 'fake', apply(): void {} }
+  loader.builtins['confy'] = {
+    name: 'confy',
+    Config: Schema.object({
+      port: Schema.number().required(),
+      host: Schema.string().default('127.0.0.1'),
+    }),
+    apply(_ctx: Context, _config: unknown): void {},
+  }
+  loader.builtins['stuck'] = {
+    name: 'stuck',
+    inject: ['no-such-service'],
+    apply(): void {},
+  }
+  return kernel
+}
+
+async function mountTree(kernel: Kernel, store: ConfigTreeStore): Promise<SqliteTree> {
+  await kernel.ctx.plugin(SqliteTree, { store })
+  return kernel.ctx.get('configTree') as SqliteTree
+}
+
+describe('listEntries', () => {
+  it('maps entry runtime to state and surfaces config for plain entries only', async () => {
+    const store = new MemoryConfigTreeStore()
+    await store.save([
+      { id: 'up', name: 'cordis:fake', config: { a: 1 } },
+      { id: 'off', name: 'cordis:fake', disabled: true, config: { b: 2 } },
+      { id: 'wait', name: 'cordis:stuck' },
+      { id: 'grp', name: 'cordis:group', children: [{ id: 'child', name: 'cordis:fake' }] },
+    ])
+    const kernel = await bootKernel()
+    const tree = await mountTree(kernel, store)
+
+    const byId = new Map(tree.listEntries().map((info) => [info.id, info]))
+    expect([...byId.keys()].sort()).toEqual(['child', 'grp', 'off', 'up', 'wait'])
+
+    expect(byId.get('up')).toMatchObject({
+      name: 'cordis:fake',
+      disabled: false,
+      state: 'active',
+      config: { a: 1 },
+    })
+    expect(byId.get('off')).toMatchObject({ disabled: true, state: 'disabled', config: { b: 2 } })
+    // 依赖不存在的服务：fiber 建了但等在 PENDING
+    expect(byId.get('wait')?.state).toBe('pending')
+    // 组条目的 config 是子条目列表（内部表示），不作为插件配置暴露
+    expect(byId.get('grp')?.config).toBeUndefined()
+    expect(byId.get('child')?.state).toBe('active')
+    await kernel.stop()
+  })
+
+  it('describeEntryState reports error with the fiber failure message', () => {
+    // FAILED 态难以从公开面稳定构造（装载失败会整树回滚），状态推导函数
+    // 单独可测：用与真实 Fiber 同形的桩子覆盖 error 分支
+    const failed = { uid: 1, store: undefined, _error: new Error('boom') } as unknown as Fiber
+    expect(describeEntryState(failed, false)).toEqual({ state: 'error', error: 'boom' })
+    const active = { uid: 1, store: {} } as unknown as Fiber
+    expect(describeEntryState(active, false)).toEqual({ state: 'active' })
+    expect(describeEntryState(undefined, true)).toEqual({ state: 'disabled' })
+    expect(describeEntryState(undefined, false)).toEqual({ state: 'pending' })
+  })
+})
+
+describe('validateConfig', () => {
+  it('passes a valid config and one without a schema', async () => {
+    const kernel = await bootKernel()
+    const tree = await mountTree(kernel, new MemoryConfigTreeStore())
+    expect(tree.validateConfig('cordis:confy', { port: 3000 })).toEqual({ ok: true, errors: [] })
+    // 无 Config 的插件与非内置 specifier（拿不到 schema）都视为通过
+    expect(tree.validateConfig('cordis:fake', { anything: true }).ok).toBe(true)
+    expect(tree.validateConfig('some-npm-plugin', { anything: true }).ok).toBe(true)
+    await kernel.stop()
+  })
+
+  it('collects schema errors, unknown builtins and __jsExpr as data', async () => {
+    const kernel = await bootKernel()
+    const tree = await mountTree(kernel, new MemoryConfigTreeStore())
+
+    const badType = tree.validateConfig('cordis:confy', { port: 'not-a-number' })
+    expect(badType.ok).toBe(false)
+    expect(badType.errors.length).toBeGreaterThan(0)
+
+    const missing = tree.validateConfig('cordis:confy', {})
+    expect(missing.ok).toBe(false)
+
+    const unknown = tree.validateConfig('cordis:no-such-plugin', {})
+    expect(unknown.ok).toBe(false)
+    expect(unknown.errors[0]!.message).toMatch(/no-such-plugin/)
+
+    // D5：__jsExpr 在校验层同样封死，且错误里带具体路径
+    const evil = tree.validateConfig('cordis:confy', {
+      port: 3000,
+      nested: { __jsExpr: 'process.exit(1)' },
+    })
+    expect(evil.ok).toBe(false)
+    expect(evil.errors.some((e) => e.message.includes('__jsExpr'))).toBe(true)
+    await kernel.stop()
+  })
+})
+
+describe('exportTree / importTree', () => {
+  const seedEntries: ConfigEntry[] = [
+    { id: 'up', name: 'cordis:fake', config: { a: 1 } },
+    { id: 'off', name: 'cordis:fake', disabled: true },
+    { id: 'grp', name: 'cordis:group', children: [{ id: 'child', name: 'cordis:fake' }] },
+  ]
+
+  /** 真 SQLite 的 PluginMetaStore：last-good 的持久语义要在真实现上验。 */
+  function makeMeta(): { meta: PluginMetaStore; close: () => void } {
+    const db = openStorage(freshPath())
+    migrate(db)
+    return { meta: new PluginMetaStore(db), close: () => db.close() }
+  }
+
+  it('roundtrips: export from one tree, import into an empty one', async () => {
+    const storeA = new MemoryConfigTreeStore()
+    await storeA.save(seedEntries)
+    const kernelA = await bootKernel()
+    const treeA = await mountTree(kernelA, storeA)
+    const exported = treeA.exportTree()
+    expect(exported).toEqual(seedEntries)
+    await kernelA.stop()
+
+    const { meta, close } = makeMeta()
+    const storeB = new MemoryConfigTreeStore()
+    const kernelB = await bootKernel()
+    const treeB = await mountTree(kernelB, storeB)
+    await treeB.importTree(exported, meta)
+
+    // 导入即装载：active/disabled 状态与源树一致，且已 flush 落库
+    const byId = new Map(treeB.listEntries().map((info) => [info.id, info]))
+    expect(byId.get('up')?.state).toBe('active')
+    expect(byId.get('off')?.state).toBe('disabled')
+    expect(byId.get('child')?.state).toBe('active')
+    expect(await storeB.load()).toEqual(seedEntries)
+    // 导入前的树是空的，last-good 记录的就是空树
+    expect(meta.get(CONFIG_TREE_LAST_GOOD_KEY)).toEqual([])
+    await kernelB.stop()
+    close()
+  })
+
+  it('replaces the whole tree and snapshots the previous one as last-good', async () => {
+    const store = new MemoryConfigTreeStore()
+    await store.save(seedEntries)
+    const kernel = await bootKernel()
+    const tree = await mountTree(kernel, store)
+    const { meta, close } = makeMeta()
+
+    const next: ConfigEntry[] = [{ id: 'solo', name: 'cordis:fake', config: { fresh: true } }]
+    await tree.importTree(next, meta)
+
+    expect(tree.listEntries().map((info) => info.id)).toEqual(['solo'])
+    expect(await store.load()).toEqual(next)
+    expect(meta.get(CONFIG_TREE_LAST_GOOD_KEY)).toEqual(seedEntries)
+    await kernel.stop()
+    close()
+  })
+
+  it('rejects malicious payloads before touching the live tree', async () => {
+    const store = new MemoryConfigTreeStore()
+    await store.save(seedEntries)
+    const kernel = await bootKernel()
+    const tree = await mountTree(kernel, store)
+    const { meta, close } = makeMeta()
+
+    const cases: [string, ConfigEntry[], RegExp][] = [
+      [
+        '__jsExpr',
+        [{ id: 'evil', name: 'cordis:fake', config: { x: { __jsExpr: 'process.exit(1)' } } }],
+        /__jsExpr/,
+      ],
+      [
+        'loader extension field',
+        [{ id: 'evil', name: 'cordis:fake', inject: ['storage'] } as unknown as ConfigEntry],
+        /inject/,
+      ],
+      [
+        'duplicate id',
+        [
+          { id: 'dup', name: 'cordis:fake' },
+          { id: 'dup', name: 'cordis:fake' },
+        ],
+        /重复/,
+      ],
+      ['reserved separator in id', [{ id: 'a:b', name: 'cordis:fake' }], /:/],
+    ]
+    for (const [, payload, pattern] of cases) {
+      await expect(tree.importTree(payload, meta)).rejects.toThrow(pattern)
+    }
+
+    // 校验在动树之前：原树原样活着、last-good 没被写（快照晚于校验）
+    expect(new Map(tree.listEntries().map((i) => [i.id, i.state])).get('up')).toBe('active')
+    expect(tree.exportTree()).toEqual(seedEntries)
+    expect(meta.get(CONFIG_TREE_LAST_GOOD_KEY)).toBeUndefined()
+    await kernel.stop()
+    close()
+  })
+
+  it('rolls back to last-good when a valid-looking payload fails to load', async () => {
+    const store = new MemoryConfigTreeStore()
+    await store.save(seedEntries)
+    const kernel = await bootKernel()
+    const tree = await mountTree(kernel, store)
+    const { meta, close } = makeMeta()
+
+    // 形状合法但装不上：未知内置插件在 import 阶段抛错（启用条目才触发）
+    const payload: ConfigEntry[] = [
+      { id: 'ok', name: 'cordis:fake' },
+      { id: 'broken', name: 'cordis:no-such-plugin' },
+    ]
+    await expect(tree.importTree(payload, meta)).rejects.toThrow(/no-such-plugin/)
+
+    // 快照已落 KV（替换动手之前），内存树滚回旧集合、fiber 活着，库里也是旧树
+    expect(meta.get(CONFIG_TREE_LAST_GOOD_KEY)).toEqual(seedEntries)
+    const byId = new Map(tree.listEntries().map((info) => [info.id, info]))
+    expect([...byId.keys()].sort()).toEqual(['child', 'grp', 'off', 'up'])
+    expect(byId.get('up')?.state).toBe('active')
+    expect(await store.load()).toEqual(seedEntries)
+    await kernel.stop()
+    close()
+  })
+})


### PR DESCRIPTION
Closes #705. Part of #698 (marketplace M1, item PR-3).

The renderer gets a management surface over the plugin tree.

- seven methods on the single-channel contract: `plugins.list` (entries with runtime state derived from the same facts as the fiber state machine), `enable`/`disable` (returning the updated entry so toggles skip a re-list), `updateConfig`/`validateConfig` (schemastery runs in the kernel and errors come back as data), `exportTree`/`importTree`
- validation is layered, not duplicated: IPC guards check shape only (version, recursion with a depth cap); semantic rules — `__jsExpr` sealing, unknown fields, duplicate ids, reserved separators — run in the kernel by reusing the exact load-boundary code from #702
- `importTree` is a three-step full replace: semantic validation first (a bad payload never touches the tree), the current tree snapshots to `PluginMetaStore` as last-good, then a transactional replace whose failure rolls back via the group transaction with a last-good replay as the backstop, original error rethrown
- `plugins.manage` capability (available = kernel + tree alive); host.ts mirrors per convention; preload untouched
- kernel suite grows to 81 (8 new: state mapping, validation both ways, roundtrip, four-way malicious payload rejection with the tree untouched, real-SQLite last-good rollback); desktop smoke gains a plugins group (list/disable/enable through the same named exports as kernelStatus) and asserts the capability

No backend changes; kernel lint/test, frontend build, desktop lint/build/smoke all green.