### PR TITLE
feat: settings plugins tab

### DIFF
--- a/src/frontend/src/features/settings/PluginsSettings.tsx
+++ b/src/frontend/src/features/settings/PluginsSettings.tsx
@@ -1,0 +1,341 @@
+/* 设置页「插件」tab（#707，插件市场计划 PR-4 的前端面）。
+
+   数据全部走桌面宿主桥的 plugins.* IPC（lib/host.ts，#706）：列表、启停、
+   配置校验/保存、整树导出导入。这个 tab 只在 plugins.manage 能力可用时
+   出现（SettingsPage 里判），所以这里的「桥不可用」分支只是兜底。 */
+import { useRef, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { ConfirmModal } from '../../components/ui/ConfirmModal';
+import { EmptyState } from '../../components/ui/EmptyState';
+import { Icon } from '../../components/ui/Icon';
+import { Modal } from '../../components/ui/Modal';
+import { Switch } from '../../components/ui/Switch';
+import { toast } from '../../components/ui/Toast';
+import { tr } from '../../lib/i18n';
+import {
+  disablePlugin,
+  enablePlugin,
+  exportPluginTree,
+  hasHost,
+  importPluginTree,
+  listPlugins,
+  updatePluginConfig,
+  validatePluginConfig,
+  type PluginEntryInfo,
+  type PluginTreeExport,
+} from '../../lib/host';
+import { saveBlob } from '../wiki/shared';
+import { parseConfigDraft, parseTreeFile, pluginBadge, validationErrorLines } from './pluginsView';
+
+function errMsg(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+export function PluginsSettings() {
+  const queryClient = useQueryClient();
+  const bridged = hasHost();
+  const { data, isLoading, isError, refetch } = useQuery({
+    queryKey: ['plugins'],
+    queryFn: () => listPlugins(),
+    enabled: bridged,
+    retry: false,
+  });
+
+  // —— 配置编辑弹窗 ——
+  const [configFor, setConfigFor] = useState<PluginEntryInfo | null>(null);
+  const [draft, setDraft] = useState('');
+  // 统一的错误行：JSON 语法错、schema 校验错都落到这里，红字逐行渲染
+  const [errorLines, setErrorLines] = useState<string[]>([]);
+
+  // —— 树导入 ——
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [pendingImport, setPendingImport] = useState<PluginTreeExport | null>(null);
+  const [exporting, setExporting] = useState(false);
+
+  const invalidate = () => void queryClient.invalidateQueries({ queryKey: ['plugins'] });
+
+  const toggleMutation = useMutation({
+    mutationFn: (p: PluginEntryInfo) => (p.disabled ? enablePlugin(p.id) : disablePlugin(p.id)),
+    onSuccess: (updated) => {
+      // 返回值就是变更后的条目：先就地写回让开关立刻到位，再 invalidate 兜住
+      // 主进程侧可能连带变化的其他条目（比如级联停用）
+      if (updated) {
+        queryClient.setQueryData<PluginEntryInfo[] | null>(['plugins'], (prev) =>
+          prev ? prev.map((p) => (p.id === updated.id ? updated : p)) : prev,
+        );
+      }
+      invalidate();
+    },
+    onError: (e) => {
+      toast(`${tr('操作失败', 'Failed')}：${errMsg(e)}`, 'error');
+      invalidate(); // 启动失败时主进程已回滚，拉一次拿到真实状态（可能带 error）
+    },
+  });
+
+  const validateMutation = useMutation({
+    mutationFn: (input: { name: string; config: Record<string, unknown> }) =>
+      validatePluginConfig(input.name, input.config),
+    onSuccess: (result) => {
+      if (!result) return;
+      if (result.ok) {
+        setErrorLines([]);
+        toast(tr('配置没问题', 'Config looks good'), 'ok');
+      } else {
+        setErrorLines(validationErrorLines(result.errors));
+      }
+    },
+    onError: (e) => setErrorLines([errMsg(e)]),
+  });
+
+  const saveMutation = useMutation({
+    mutationFn: (input: { id: string; config: Record<string, unknown> }) =>
+      updatePluginConfig(input.id, input.config),
+    onSuccess: (result) => {
+      if (!result) return;
+      if (result.ok) {
+        toast(tr('配置已保存', 'Config saved'), 'ok');
+        setConfigFor(null);
+        invalidate();
+      } else {
+        // 没过 schema：错误回显在弹窗里，不关窗，用户接着改
+        setErrorLines(validationErrorLines(result.errors));
+      }
+    },
+    onError: (e) => setErrorLines([errMsg(e)]),
+  });
+
+  const importMutation = useMutation({
+    mutationFn: (tree: PluginTreeExport) => importPluginTree(tree),
+    onSuccess: () => {
+      toast(tr('插件配置已导入', 'Plugin config imported'), 'ok');
+      setPendingImport(null);
+      invalidate();
+    },
+    onError: (e) => {
+      toast(`${tr('导入失败', 'Import failed')}：${errMsg(e)}`, 'error');
+      setPendingImport(null);
+      invalidate(); // 主进程失败时已用快照回滚，刷新拿到回滚后的状态
+    },
+  });
+
+  const openConfig = (p: PluginEntryInfo) => {
+    setConfigFor(p);
+    setDraft(JSON.stringify(p.config ?? {}, null, 2));
+    setErrorLines([]);
+  };
+
+  /** 校验/保存共用的前置：先在前端把 JSON 语法兜住，别拿语法错去打 IPC。 */
+  const parsedDraft = (): Record<string, unknown> | null => {
+    const parsed = parseConfigDraft(draft);
+    if (!parsed.ok) {
+      setErrorLines([tr(parsed.errorZh, parsed.errorEn)]);
+      return null;
+    }
+    return parsed.config;
+  };
+
+  const doExport = async () => {
+    setExporting(true);
+    try {
+      const tree = await exportPluginTree();
+      if (!tree) return;
+      saveBlob(
+        new Blob([JSON.stringify(tree, null, 2)], { type: 'application/json' }),
+        'polaris-plugins-tree.json',
+      );
+    } catch (e) {
+      toast(`${tr('导出失败', 'Export failed')}：${errMsg(e)}`, 'error');
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const pickImportFile = async (file: File) => {
+    let text: string;
+    try {
+      text = await file.text();
+    } catch (e) {
+      toast(`${tr('读不了这个文件', 'Could not read the file')}：${errMsg(e)}`, 'error');
+      return;
+    }
+    const parsed = parseTreeFile(text);
+    if (!parsed.ok) {
+      toast(tr(parsed.errorZh, parsed.errorEn), 'error');
+      return;
+    }
+    setPendingImport(parsed.tree); // 先确认再动手：导入是全量替换
+  };
+
+  const plugins = data ?? [];
+  const modalBusy = validateMutation.isPending || saveMutation.isPending;
+
+  return (
+    <div className="card card-pad">
+      <div className="row" style={{ justifyContent: 'space-between', marginBottom: 6, flexWrap: 'wrap', gap: 8 }}>
+        <span className="section-h">
+          <Icon name="layers" size={15} style={{ color: 'var(--accent)' }} />
+          {tr('插件', 'Plugins')}
+        </span>
+        <div className="row gap8">
+          <button className="btn btn-soft sm" disabled={!bridged || exporting} onClick={() => void doExport()}>
+            <Icon name="download" size={12} />
+            {exporting ? tr('导出中…', 'Exporting…') : tr('导出全部配置', 'Export all config')}
+          </button>
+          <button
+            className="btn btn-soft sm"
+            disabled={!bridged || importMutation.isPending}
+            onClick={() => fileInputRef.current?.click()}
+          >
+            <Icon name="file" size={12} />
+            {tr('从文件导入', 'Import from file')}
+          </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="application/json,.json"
+            style={{ display: 'none' }}
+            onChange={(e) => {
+              const f = e.target.files?.[0];
+              if (f) void pickImportFile(f);
+              e.target.value = ''; // 允许连续选同一个文件
+            }}
+          />
+        </div>
+      </div>
+      <div style={{ fontSize: 11.5, color: 'var(--text-3)', marginBottom: 14, lineHeight: 1.5 }}>
+        {tr(
+          '管理这台电脑上装的插件：随时停用或启用，改配置立即生效。导出的配置文件可以拿到另一台电脑上导入。',
+          'Manage plugins installed on this machine: enable or disable them anytime; config changes apply immediately. Exported config files can be imported on another machine.',
+        )}
+      </div>
+
+      {!bridged ? (
+        <EmptyState
+          icon="layers"
+          title={tr('插件管理不可用', 'Plugin management unavailable')}
+          desc={tr('这个功能只在桌面客户端里可用。', 'This feature is only available in the desktop app.')}
+        />
+      ) : isLoading ? (
+        <div className="empty" style={{ padding: 24 }}>{tr('加载中…', 'Loading…')}</div>
+      ) : isError || data == null ? (
+        <EmptyState
+          icon="layers"
+          title={tr('插件列表加载失败', 'Failed to load plugins')}
+          action={
+            <button className="btn btn-soft sm" onClick={() => void refetch()}>{tr('重试', 'Retry')}</button>
+          }
+        />
+      ) : plugins.length === 0 ? (
+        <EmptyState
+          icon="layers"
+          title={tr('还没有装任何插件', 'No plugins installed yet')}
+          desc={tr('装上插件后，可以在这里启停和改配置。', 'Once plugins are installed, you can manage them here.')}
+        />
+      ) : (
+        <div className="settings-list">
+          {plugins.map((p) => {
+            const badge = pluginBadge(p);
+            const busy = toggleMutation.isPending && toggleMutation.variables?.id === p.id;
+            return (
+              <div key={p.id} className="settings-row" style={{ gap: 12 }}>
+                <div className="settings-row-text" style={{ minWidth: 0 }}>
+                  <div className="row gap8" style={{ alignItems: 'center' }}>
+                    <span style={{ fontSize: 13, fontWeight: 600 }}>{p.name}</span>
+                    <span className="pill sm" style={{ background: badge.bg, color: badge.tx }} title={badge.title}>
+                      {tr(badge.zh, badge.en)}
+                    </span>
+                  </div>
+                  {p.state === 'error' && p.error && (
+                    <div style={{ fontSize: 11.5, color: 'var(--danger-tx)', marginTop: 3, lineHeight: 1.5 }}>
+                      {p.error}
+                    </div>
+                  )}
+                </div>
+                <div className="row gap10" style={{ alignItems: 'center', flexShrink: 0 }}>
+                  <button className="btn btn-soft sm" onClick={() => openConfig(p)}>
+                    <Icon name="sliders" size={12} />
+                    {tr('配置', 'Configure')}
+                  </button>
+                  <Switch
+                    checked={!p.disabled}
+                    disabled={busy}
+                    onChange={() => toggleMutation.mutate(p)}
+                    aria-label={tr(`启停插件 ${p.name}`, `Toggle plugin ${p.name}`)}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* —— 配置编辑弹窗：JSON 文本域 + 校验 + 保存 —— */}
+      <Modal
+        open={configFor !== null}
+        onClose={() => setConfigFor(null)}
+        width={560}
+        title={configFor ? tr(`配置：${configFor.name}`, `Configure: ${configFor.name}`) : ''}
+        footer={
+          <>
+            <button className="btn btn-ghost" onClick={() => setConfigFor(null)}>{tr('取消', 'Cancel')}</button>
+            <button
+              className="btn btn-soft"
+              disabled={modalBusy}
+              onClick={() => {
+                const config = parsedDraft();
+                if (config && configFor) validateMutation.mutate({ name: configFor.name, config });
+              }}
+            >
+              {validateMutation.isPending ? tr('校验中…', 'Checking…') : tr('校验', 'Check')}
+            </button>
+            <button
+              className="btn btn-primary"
+              disabled={modalBusy}
+              onClick={() => {
+                const config = parsedDraft();
+                if (config && configFor) saveMutation.mutate({ id: configFor.id, config });
+              }}
+            >
+              {saveMutation.isPending ? tr('保存中…', 'Saving…') : tr('保存', 'Save')}
+            </button>
+          </>
+        }
+      >
+        <div style={{ fontSize: 12, color: 'var(--text-3)', marginBottom: 8, lineHeight: 1.5 }}>
+          {tr('配置是一段 JSON。保存前会先按插件的要求检查，不合规不会生效。', 'Config is a JSON object. It is checked against the plugin schema before it takes effect.')}
+        </div>
+        <textarea
+          className="textarea mono"
+          style={{ minHeight: 220, fontSize: 12, width: '100%' }}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          spellCheck={false}
+        />
+        {errorLines.length > 0 && (
+          <div style={{ marginTop: 10, fontSize: 12, color: 'var(--danger-tx)', lineHeight: 1.6 }}>
+            {errorLines.map((line, i) => (
+              <div key={i} className="mono">{line}</div>
+            ))}
+          </div>
+        )}
+      </Modal>
+
+      {/* —— 导入确认：全量替换，先说清楚再动手 —— */}
+      <ConfirmModal
+        open={pendingImport !== null}
+        onClose={() => setPendingImport(null)}
+        title={tr('从文件导入插件配置', 'Import plugin config from file')}
+        message={tr(
+          `将替换全部插件配置（文件里有 ${pendingImport?.entries.length ?? 0} 个插件），当前配置会自动备份一份，导入失败会自动恢复。`,
+          `This replaces all plugin config (${pendingImport?.entries.length ?? 0} plugin(s) in the file). Your current config is backed up automatically and restored if the import fails.`,
+        )}
+        confirmText={tr('替换并导入', 'Replace and import')}
+        danger
+        busy={importMutation.isPending}
+        onConfirm={() => {
+          if (pendingImport) importMutation.mutate(pendingImport);
+        }}
+      />
+    </div>
+  );
+}

--- a/src/frontend/src/features/settings/SettingsPage.tsx
+++ b/src/frontend/src/features/settings/SettingsPage.tsx
@@ -39,6 +39,8 @@ import {
 import { BuddySettings } from './BuddySettings';
 import { ExtensionApiKeySettings } from './ExtensionApiKeySettings';
 import { FullExportSettings } from './FullExportSettings';
+import { PluginsSettings } from './PluginsSettings';
+import { CAPABILITY_PLUGINS_MANAGE, hasHost, isCapabilityAvailable, loadCapabilities } from '../../lib/host';
 import { AdminSpeechSettings, PersonalSpeechSettings } from './SpeechSettings';
 
 /* ============================================================
@@ -2286,7 +2288,7 @@ function MyUsageTab() {
 // ---------------- 页面 ----------------
 
 /** 普通用户设置的标签页（管理员那组在 /admin，见 AdminSettingsPage）。 */
-type Tab = 'personal' | 'prefs' | 'buddy' | 'speech' | 'bots' | 'ssh' | 'myusage' | 'extension' | 'mcp' | 'export';
+type Tab = 'personal' | 'prefs' | 'buddy' | 'speech' | 'bots' | 'ssh' | 'myusage' | 'extension' | 'mcp' | 'export' | 'plugins';
 
 /** 旧的 /settings?tab=xxx 深链里属于管理员组的值 → 统一改跳 /admin。 */
 export const ADMIN_TABS = ['llm', 'daily', 'usage'] as const;
@@ -2717,7 +2719,7 @@ export function DailyCategoriesTab() {
   );
 }
 
-const PERSONAL_TABS: Tab[] = ['personal', 'prefs', 'buddy', 'speech', 'bots', 'ssh', 'myusage', 'extension', 'mcp', 'export'];
+const PERSONAL_TABS: Tab[] = ['personal', 'prefs', 'buddy', 'speech', 'bots', 'ssh', 'myusage', 'extension', 'mcp', 'export', 'plugins'];
 
 export function SettingsPage() {
   // 支持 /settings?tab=mcp 这类深链（如旧 /mcp-tools 路由的重定向）
@@ -2726,6 +2728,25 @@ export function SettingsPage() {
   const [tab, setTab] = useState<Tab>(() =>
     param !== null && PERSONAL_TABS.includes(param as Tab) ? (param as Tab) : 'personal',
   );
+
+  // 「插件」tab 只在桌面端 plugins.manage 能力可用时出现。能力清单由 App.tsx
+  // 启动时异步拉取，本页可能先于它渲染完——这里自己再 loadCapabilities() 一次
+  // （主进程侧就是读内存清单，重复调用便宜）并在拿到结果后重读，避免首次进
+  // 设置页时 tab 闪失。web 端无桥，直接维持 false，零请求。
+  const [pluginsAvailable, setPluginsAvailable] = useState(() => isCapabilityAvailable(CAPABILITY_PLUGINS_MANAGE));
+  useEffect(() => {
+    if (pluginsAvailable || !hasHost()) return;
+    let alive = true;
+    void loadCapabilities().then(() => {
+      if (alive) setPluginsAvailable(isCapabilityAvailable(CAPABILITY_PLUGINS_MANAGE));
+    });
+    return () => {
+      alive = false;
+    };
+  }, [pluginsAvailable]);
+  // 深链 ?tab=plugins 在能力缺失（web 端、清单未就绪）时回落默认 tab，不崩也不留空白；
+  // 清单稍后就绪且能力在，effectiveTab 自动切回 plugins。
+  const effectiveTab: Tab = tab === 'plugins' && !pluginsAvailable ? 'personal' : tab;
 
   // 旧的管理员深链（/settings?tab=llm）改跳新的管理页；
   // 「我的模型」自管轨并入平台配置后（#621），旧深链也指到那里
@@ -2747,24 +2768,26 @@ export function SettingsPage() {
     { v: 'extension', label: tr('Polaris 扩展', 'Polaris extension') },
     { v: 'mcp', label: tr('MCP 接入', 'MCP access') },
     { v: 'export', label: tr('数据导出', 'Data export') },
+    ...(pluginsAvailable ? [{ v: 'plugins' as Tab, label: tr('插件', 'Plugins') }] : []),
   ];
 
   return (
     <div className="page fadeup">
       <PageHead eyebrow="Polaris · Settings" title={tr('设置', 'Settings')} />
       <div className="row" style={{ gap: 12, marginBottom: 22, flexWrap: 'wrap', alignItems: 'center' }}>
-        <Segmented options={items} value={tab} onChange={setTab} />
+        <Segmented options={items} value={effectiveTab} onChange={setTab} />
       </div>
-      {tab === 'personal' && <PersonalTab />}
-      {tab === 'prefs' && <PreferencesTab />}
-      {tab === 'buddy' && <BuddySettings />}
-      {tab === 'speech' && <PersonalSpeechSettings />}
-      {tab === 'bots' && <ChatBotsTab />}
-      {tab === 'ssh' && <SshTab />}
-      {tab === 'myusage' && <MyUsageTab />}
-      {tab === 'extension' && <ExtensionApiKeySettings />}
-      {tab === 'mcp' && <McpToolsContent />}
-      {tab === 'export' && <FullExportSettings />}
+      {effectiveTab === 'personal' && <PersonalTab />}
+      {effectiveTab === 'prefs' && <PreferencesTab />}
+      {effectiveTab === 'buddy' && <BuddySettings />}
+      {effectiveTab === 'speech' && <PersonalSpeechSettings />}
+      {effectiveTab === 'bots' && <ChatBotsTab />}
+      {effectiveTab === 'ssh' && <SshTab />}
+      {effectiveTab === 'myusage' && <MyUsageTab />}
+      {effectiveTab === 'extension' && <ExtensionApiKeySettings />}
+      {effectiveTab === 'mcp' && <McpToolsContent />}
+      {effectiveTab === 'export' && <FullExportSettings />}
+      {effectiveTab === 'plugins' && <PluginsSettings />}
     </div>
   );
 }

--- a/src/frontend/src/features/settings/__tests__/pluginsView.test.ts
+++ b/src/frontend/src/features/settings/__tests__/pluginsView.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseConfigDraft, parseTreeFile, pluginBadge, validationErrorLines } from '../pluginsView';
+
+/* ============================================================
+   设置页「插件」tab 的纯函数（#707）：
+   ① 状态徽章映射——四种运行态各有其色，error 把详情带进 title；
+   ② 配置文本域解析——语法错/非对象在前端就拦下，不去打 IPC；
+   ③ 校验错误渲染——path 在前逐行拼；
+   ④ 导入文件形状检查——version/entries 不对就直接拒。
+   ============================================================ */
+
+describe('pluginBadge', () => {
+  it('四种状态映射到不同的文案与配色', () => {
+    expect(pluginBadge({ state: 'active' })).toMatchObject({ zh: '运行中', bg: 'var(--ok-bg)' });
+    expect(pluginBadge({ state: 'disabled' })).toMatchObject({ zh: '已停用', bg: 'var(--surface-3)' });
+    expect(pluginBadge({ state: 'pending' })).toMatchObject({ zh: '启动中', bg: 'var(--warn-bg)' });
+    expect(pluginBadge({ state: 'error' })).toMatchObject({ zh: '出错', bg: 'var(--danger-bg)' });
+  });
+
+  it('出错时错误详情进 title，供悬停查看', () => {
+    expect(pluginBadge({ state: 'error', error: 'boom' }).title).toBe('boom');
+    expect(pluginBadge({ state: 'error' }).title).toBeUndefined();
+    expect(pluginBadge({ state: 'active', error: 'stale' }).title).toBeUndefined();
+  });
+});
+
+describe('parseConfigDraft', () => {
+  it('空文本视作空配置，合法对象原样返回', () => {
+    expect(parseConfigDraft('   ')).toEqual({ ok: true, config: {} });
+    expect(parseConfigDraft('{"a": 1}')).toEqual({ ok: true, config: { a: 1 } });
+  });
+
+  it('语法错与非对象（数组/标量/null）都在前端拦下', () => {
+    expect(parseConfigDraft('{oops').ok).toBe(false);
+    expect(parseConfigDraft('[1, 2]').ok).toBe(false);
+    expect(parseConfigDraft('"str"').ok).toBe(false);
+    expect(parseConfigDraft('null').ok).toBe(false);
+  });
+});
+
+describe('validationErrorLines', () => {
+  it('path 在前拼一行；没有 path 只剩 message', () => {
+    expect(
+      validationErrorLines([
+        { path: 'timeout', message: 'must be a number' },
+        { path: '', message: 'unknown key "foo"' },
+      ]),
+    ).toEqual(['timeout: must be a number', 'unknown key "foo"']);
+  });
+});
+
+describe('parseTreeFile', () => {
+  it('只接受 version=1 且 entries 为数组的载荷', () => {
+    expect(parseTreeFile('{"version": 1, "entries": []}').ok).toBe(true);
+    expect(parseTreeFile('{"version": 2, "entries": []}').ok).toBe(false);
+    expect(parseTreeFile('{"entries": []}').ok).toBe(false);
+    expect(parseTreeFile('{"version": 1}').ok).toBe(false);
+    expect(parseTreeFile('not json').ok).toBe(false);
+  });
+});

--- a/src/frontend/src/features/settings/pluginsView.ts
+++ b/src/frontend/src/features/settings/pluginsView.ts
@@ -1,0 +1,101 @@
+/* 设置页「插件」tab 的纯展示逻辑（#707）。
+
+   抽成独立模块有两个原因：
+   ① 状态徽章映射、JSON 解析这类东西不依赖 React，抽出来 vitest 直接测；
+   ② 文案不能在模块顶层 tr()（语言切换后不更新，见 lib/i18n 注释），
+      所以这里一律返回 {zh, en}，由组件在渲染处再 tr。 */
+
+import type { PluginEntryInfo, PluginTreeExport, PluginValidationError } from '../../lib/host';
+
+export interface PluginBadge {
+  zh: string;
+  en: string;
+  /** 徽章底色 / 文字色（design token 变量名）。 */
+  bg: string;
+  tx: string;
+  /** 出错时把错误详情放 title（悬停可看全文）。 */
+  title?: string;
+}
+
+/** 插件运行状态 → 徽章样式与文案。未知状态按「出错」兜底，宁可显眼也别静默。 */
+export function pluginBadge(entry: Pick<PluginEntryInfo, 'state' | 'error'>): PluginBadge {
+  switch (entry.state) {
+    case 'active':
+      return { zh: '运行中', en: 'Running', bg: 'var(--ok-bg)', tx: 'var(--ok-tx)' };
+    case 'disabled':
+      return { zh: '已停用', en: 'Disabled', bg: 'var(--surface-3)', tx: 'var(--text-3)' };
+    case 'pending':
+      return { zh: '启动中', en: 'Starting', bg: 'var(--warn-bg)', tx: 'var(--warn-tx)' };
+    case 'error':
+    default:
+      return {
+        zh: '出错',
+        en: 'Error',
+        bg: 'var(--danger-bg)',
+        tx: 'var(--danger-tx)',
+        ...(entry.error ? { title: entry.error } : {}),
+      };
+  }
+}
+
+export type ConfigParse =
+  | { ok: true; config: Record<string, unknown> }
+  | { ok: false; errorZh: string; errorEn: string };
+
+/** 配置文本域 → JSON 对象。空文本视作空配置；非对象（数组/字符串等）也算错，
+    因为主进程的 updateConfig 只收对象，提前在前端拦下来能给出更明白的话。 */
+export function parseConfigDraft(text: string): ConfigParse {
+  const trimmed = text.trim();
+  if (trimmed === '') return { ok: true, config: {} };
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch (e) {
+    return {
+      ok: false,
+      errorZh: `不是合法的 JSON：${e instanceof Error ? e.message : String(e)}`,
+      errorEn: `Not valid JSON: ${e instanceof Error ? e.message : String(e)}`,
+    };
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return {
+      ok: false,
+      errorZh: '配置必须是一个 JSON 对象（{ … }）',
+      errorEn: 'Config must be a JSON object ({ … })',
+    };
+  }
+  return { ok: true, config: parsed as Record<string, unknown> };
+}
+
+/** 校验错误 → 每条一行的展示文本（path 在前，没有 path 就只剩 message）。 */
+export function validationErrorLines(errors: PluginValidationError[]): string[] {
+  return errors.map((e) => (e.path ? `${e.path}: ${e.message}` : e.message));
+}
+
+export type TreeFileParse =
+  | { ok: true; tree: PluginTreeExport }
+  | { ok: false; errorZh: string; errorEn: string };
+
+/** 导入文件内容 → 配置树载荷。只做形状检查（version=1、entries 是数组），
+    每个条目的合法性由主进程校验——那边有 schema，这里重复一遍只会两处漂移。 */
+export function parseTreeFile(text: string): TreeFileParse {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return {
+      ok: false,
+      errorZh: '这个文件不是 JSON，确认选的是之前导出的配置文件',
+      errorEn: 'This file is not JSON — make sure it is a previously exported config file',
+    };
+  }
+  const tree = parsed as { version?: unknown; entries?: unknown };
+  if (tree === null || typeof tree !== 'object' || tree.version !== 1 || !Array.isArray(tree.entries)) {
+    return {
+      ok: false,
+      errorZh: '文件格式不对：应当是「导出全部配置」生成的文件',
+      errorEn: 'Unexpected file format — expected a file produced by “Export all config”',
+    };
+  }
+  return { ok: true, tree: parsed as PluginTreeExport };
+}


### PR DESCRIPTION
Closes #707. Part of #698 (marketplace M1, item PR-4). Frontend-only — the first desktop-only settings tab, and the precedent for how one is gated.

- `pluginsView.ts` pure layer (badge mapping with error tooltips, config-draft parsing that catches syntax/shape errors before the bridge, validation-error line rendering, tree-file shape check — entry semantics stay in the kernel so the rules never drift into a second copy) with 6 vitest cases
- `PluginsSettings.tsx`: entry list with state badges and toggles (mutation results update in place, then invalidate for cascade effects), a config modal with kernel-side schemastery validation echoed as data, tree export via the existing blob-save helper, and tree import behind a danger-confirm dialog whose copy states the full replace, the automatic backup, and the rollback-on-failure
- visibility reads `isCapabilityAvailable('plugins.manage')` — never the platform; since the capability manifest loads asynchronously and nothing subscribes to it today, the tab derives an `effectiveTab` (a `?tab=plugins` deep link shows the default tab until the manifest lands, then switches over — no blank, no crash)
- three-state empty handling (no bridge / load failure / empty list); plain-language `tr(zh,en)` copy throughout

Build (tsc + vite) and vitest 164 green; kernel/desktop/backend untouched.