### PR TITLE
feat: market install IPC with content-hash verification

### DIFF
--- a/src/desktop/src/main/ipc/methods.market.ts
+++ b/src/desktop/src/main/ipc/methods.market.ts
@@ -1,0 +1,132 @@
+/* ============================================================
+   plugins.market.* 的实现（#708）：市场索引 + 安装/卸载 + 源配置。
+
+   语义全部住在 kernel（@polaris/kernel 的 market/）里，这里只负责：
+   - 能力门槛：与 plugins.* 同一事实源（kernelConfigTree），install/
+     uninstall 额外要求 pluginMeta 在位——安装记录进不了持久层，装载前
+     哈希复核链路就是断的，宁可拒装也不装出「无记录安装物」；
+   - install 的长任务化：invoke 立刻返回 JobHandle，kernel 的四个安装
+     阶段（下载/校验/解压/登记）翻译成 job.progress，成败走 job.done/
+     job.error（错误码用 MarketError.code，前端可分流展示）；
+   - 索引源持久化：读写 store.ts 的 marketEndpoint，空串复位官方默认。
+
+   fetch 经模块级变量注入：smoke 测试把它换成离线替身跑完整安装链路，
+   生产路径永远是 globalThis.fetch（不换源不叠代理，网络语义与索引
+   拉取保持一致）。
+   ============================================================ */
+
+import {
+  MarketError,
+  fetchIndex,
+  installAndRegister,
+  uninstallAndRemove,
+  type FetchImpl,
+  type SqliteTree,
+} from '@polaris/kernel';
+
+import {
+  ERR_CAPABILITY_UNAVAILABLE,
+  ERR_INVALID_PARAMS,
+  MARKET_ENDPOINT_DEFAULT,
+  type JobHandle,
+  type MarketEndpoint,
+  type MarketIndexEntry,
+  type MarketUninstallResult,
+} from '../../shared/contract';
+import { kernelConfigTree, kernelPluginMeta, marketPluginsDir } from '../kernel';
+import { readConfig, writeConfig } from '../store';
+import { fail, finish, progress, startJob } from './events';
+
+/** 安装阶段 → job.progress 的进度分子（分母恒为 4）。 */
+const PHASE_STEP: Record<string, number> = { download: 1, verify: 2, extract: 3, register: 4 };
+
+let fetchImpl: FetchImpl | undefined;
+
+/** 仅供 smoke：注入离线 fetch 替身；传 undefined 恢复真实网络。 */
+export function setMarketFetchForTesting(impl: FetchImpl | undefined): void {
+  fetchImpl = impl;
+}
+
+/** 尚未落定的安装任务，仅供 smoke 等待 job 收尾（生产走 job.* 事件）。 */
+const pendingInstalls = new Map<string, Promise<void>>();
+
+export function awaitInstallForTesting(jobId: string): Promise<void> {
+  return pendingInstalls.get(jobId) ?? Promise.resolve();
+}
+
+function requireMarket(): { tree: SqliteTree; meta: NonNullable<ReturnType<typeof kernelPluginMeta>> } {
+  const tree = kernelConfigTree();
+  if (!tree) {
+    throw new Error(`${ERR_CAPABILITY_UNAVAILABLE}: plugins.manage — kernel 配置树不可用`);
+  }
+  const meta = kernelPluginMeta();
+  if (!meta) {
+    // storage 挂载失败的内存树会话：没有持久层就没有安装记录，
+    // 哈希复核无从谈起，市场写操作整体不可用
+    throw new Error(`${ERR_CAPABILITY_UNAVAILABLE}: plugins.market — 持久层不可用，无法记录安装`);
+  }
+  return { tree, meta };
+}
+
+export async function marketFetchIndex(): Promise<MarketIndexEntry[]> {
+  // 读索引不需要树/持久层，网络与校验失败原样抛给前端展示
+  return await fetchIndex(readConfig().marketEndpoint, { fetchImpl });
+}
+
+export function marketInstall(name: string, version: string): JobHandle {
+  const { tree, meta } = requireMarket(); // 门槛在返回 JobHandle 之前查：装不了就立刻报错
+  const jobId = startJob('plugins.market.install');
+  const run = (async () => {
+    try {
+      const { entryId, record } = await installAndRegister({
+        name,
+        version,
+        pluginsDir: marketPluginsDir(),
+        fetchImpl,
+        tree,
+        metaStore: meta,
+        onPhase: (phase) => progress(jobId, phase, PHASE_STEP[phase] ?? 0, 4),
+      });
+      finish(jobId, { entryId, name: record.name, version: record.version });
+    } catch (err) {
+      // MarketError.code 透传给前端分流（integrity-mismatch / registry-http…）
+      const code = err instanceof MarketError ? err.code : 'install-failed';
+      fail(jobId, code, err instanceof Error ? err.message : String(err));
+    } finally {
+      pendingInstalls.delete(jobId);
+    }
+  })();
+  pendingInstalls.set(jobId, run);
+  return { jobId };
+}
+
+export async function marketUninstall(name: string): Promise<MarketUninstallResult> {
+  const { tree, meta } = requireMarket();
+  return await uninstallAndRemove({
+    name,
+    pluginsDir: marketPluginsDir(),
+    tree,
+    metaStore: meta,
+  });
+}
+
+export function marketGetEndpoint(): MarketEndpoint {
+  const endpoint = readConfig().marketEndpoint;
+  return { endpoint, isDefault: endpoint === MARKET_ENDPOINT_DEFAULT };
+}
+
+export function marketSetEndpoint(endpoint: string): MarketEndpoint {
+  // 空串 = 复位默认源（UI 的「恢复官方源」不需要知道默认值是什么）
+  const next = endpoint === '' ? MARKET_ENDPOINT_DEFAULT : endpoint;
+  let parsed: URL;
+  try {
+    parsed = new URL(next);
+  } catch {
+    throw new Error(`${ERR_INVALID_PARAMS}: endpoint must be a valid URL`);
+  }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    throw new Error(`${ERR_INVALID_PARAMS}: endpoint must be http(s)`);
+  }
+  writeConfig({ marketEndpoint: next });
+  return { endpoint: next, isDefault: next === MARKET_ENDPOINT_DEFAULT };
+}

--- a/src/desktop/src/main/ipc/router.ts
+++ b/src/desktop/src/main/ipc/router.ts
@@ -25,6 +25,7 @@ import { engineBootstrapStatus, kernelStatus, localBackend } from '../kernel';
 import { applyUpdate, checkForUpdate } from '../updates';
 import * as host from './methods.host';
 import * as local from './methods.local';
+import * as market from './methods.market';
 import * as plugins from './methods.plugins';
 
 function asString(params: unknown, key: string): string {
@@ -128,6 +129,13 @@ const HANDLERS: Record<MethodName, Handler> = {
     plugins.pluginsValidateConfig(asString(p, 'name'), asPluginConfig(p)),
   'plugins.exportTree': () => plugins.pluginsExportTree(),
   'plugins.importTree': (p) => plugins.pluginsImportTree(asPluginTreeExport(p)),
+  // plugins.market.*（#708）：包名/版本的语义校验（合法 npm 名、无路径字符）
+  // 在 kernel 的安装引擎里，这里只做 IPC 形状
+  'plugins.market.fetchIndex': () => market.marketFetchIndex(),
+  'plugins.market.install': (p) => market.marketInstall(asString(p, 'name'), asString(p, 'version')),
+  'plugins.market.uninstall': (p) => market.marketUninstall(asString(p, 'name')),
+  'plugins.market.getEndpoint': () => market.marketGetEndpoint(),
+  'plugins.market.setEndpoint': (p) => market.marketSetEndpoint(asString(p, 'endpoint')),
   // local.* 一期全部走到 agent 再以 ERR_CAPABILITY_UNAVAILABLE 结束（见 methods.local.ts）
   'local.latex.compile': (p) => local.latexCompile(p),
   'local.fs.pickFolder': (p) => local.pickFolder(p),

--- a/src/desktop/src/main/kernel.ts
+++ b/src/desktop/src/main/kernel.ts
@@ -26,16 +26,20 @@
 
 import { app } from 'electron';
 import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 import {
   Loader,
   MemoryConfigTreeStore,
   SqliteTree,
+  createImportGuard,
   createKernel,
   registerBuiltins,
   storage,
+  verifyInstalledEntries,
   type ConfigEntry,
   type ConfigTreeStore,
+  type InstallVerifyIssue,
   type Kernel,
   type LegacyEngineConfig,
   type PluginMetaStore,
@@ -46,6 +50,15 @@ import type { EngineBootstrapStatus, KernelStatus, LocalBackendInfo } from '../s
 import { bootstrapEngine } from './engine-bootstrap';
 
 let kernel: Kernel | null = null;
+
+/**
+ * 市场安装物的落盘根（#708）：userData/plugins/<包名>/<版本>/。刻意在
+ * asar 之外——打包态 asar 内容不可写，且 loader 对三方包走真实的动态
+ * import，必须是文件系统上的普通路径。
+ */
+export function marketPluginsDir(): string {
+  return join(app.getPath('userData'), 'plugins');
+}
 
 /**
  * 内嵌引擎引导进度，kernel.engineBootstrapStatus 直接读它。
@@ -144,14 +157,54 @@ export async function startKernel(): Promise<Kernel> {
   // 工作（首启种子也照种），只是这次会话的改动不落盘。
   const storageSvc = instance.ctx.get('storage') as StorageService | undefined;
   const store: ConfigTreeStore = storageSvc?.configTree ?? new MemoryConfigTreeStore();
+  const pluginMeta = storageSvc?.pluginMeta;
+
+  // 三方插件动态 import 的解析基准（#708）：vendor loader 对相对 specifier
+  // 用 new URL(name, ctx.baseUrl) 解析（也是 internal loader 的 parentURL），
+  // EntryTree 构造时从父 ctx 拷贝，所以必须赶在 Loader/SqliteTree 装载之前
+  // 设到根 ctx 上。市场条目虽然存的是绝对 file:// URL 不依赖它，但这让
+  // 手写的相对条目（开发者本地插件）也有明确语义。尾部斜杠是 URL 基准
+  // 目录的规矩，少了最后一段会被当文件名换掉。
+  instance.ctx.baseUrl = `${pathToFileURL(marketPluginsDir()).href}/`;
+
+  // 装载前哈希复核（#708）主挂点：树装载之前扫一遍安装记录，被篡改的
+  // 安装物在打包态直接改持久树为 disabled——树装载用的是事务化 reconcile，
+  // 单条目 import 抛错会整树回滚，只有装载前改 store 能做到「坏的禁掉、
+  // 其余照常」。开发态仅告警（本地改入口文件是正常开发动作）。
+  let installIssues: InstallVerifyIssue[] = [];
+  if (pluginMeta) {
+    try {
+      installIssues = await verifyInstalledEntries({
+        metaStore: pluginMeta,
+        store,
+        strict: app.isPackaged,
+      });
+      for (const issue of installIssues) console.warn(`[kernel] ${issue.message}`);
+    } catch (err) {
+      console.error('[kernel] 安装记录哈希复核失败（跳过，不阻断启动）：', err);
+    }
+  }
 
   let configTree: SqliteTree | undefined;
   try {
     if ((await store.load()).length === 0) await store.save(SEED_ENTRIES);
     await instance.ctx.plugin(Loader);
     registerBuiltins(instance.ctx.loader);
-    await instance.ctx.plugin(SqliteTree, { store });
+    await instance.ctx.plugin(SqliteTree, {
+      store,
+      // 第二道闸：会话运行中被篡改、用户再点启用时在 import 阶段拒绝
+      //（enable 是单条目 update，失败只回滚它自己，错误经 IPC 给用户）
+      guardImport: pluginMeta
+        ? createImportGuard({
+            metaStore: pluginMeta,
+            strict: app.isPackaged,
+            warn: (message) => console.warn(`[kernel] ${message}`),
+          })
+        : undefined,
+    });
     configTree = instance.ctx.get('configTree') as SqliteTree | undefined;
+    // 扫描结论挂到条目注记上：被强制禁用的条目要在插件列表里说清原因
+    for (const issue of installIssues) configTree?.warnings.set(issue.entryId, issue.message);
   } catch (err) {
     // 树挂不上（数据损坏 / 某条目装载失败整树回滚）只损失插件能力，壳必须
     // 照常起：configTree 留空，引擎注入被跳过，前端按 localBackend=null 回落远端。

--- a/src/desktop/src/main/store.ts
+++ b/src/desktop/src/main/store.ts
@@ -8,6 +8,8 @@ import { app } from 'electron';
 import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
+import { MARKET_ENDPOINT_DEFAULT } from '../shared/contract';
+
 export interface WindowState {
   x?: number;
   y?: number;
@@ -20,12 +22,15 @@ export interface DesktopConfig {
   /** 空串 = 尚未配置，前端进入首启配置页。 */
   serverUrl: string;
   window: WindowState;
+  /** 插件市场索引源（#708）。可换源是一等能力，故进持久配置而不是写死。 */
+  marketEndpoint: string;
 }
 
 /** 内部分发时可用 POLARIS_DEFAULT_SERVER_URL 预填默认服务器，避免把内网地址写死进源码。 */
 const DEFAULTS: DesktopConfig = {
   serverUrl: process.env.POLARIS_DEFAULT_SERVER_URL ?? '',
   window: { width: 1440, height: 900, maximized: false },
+  marketEndpoint: MARKET_ENDPOINT_DEFAULT,
 };
 
 let cache: DesktopConfig | null = null;
@@ -41,6 +46,11 @@ export function readConfig(): DesktopConfig {
     cache = {
       serverUrl: typeof raw.serverUrl === 'string' ? raw.serverUrl : DEFAULTS.serverUrl,
       window: { ...DEFAULTS.window, ...(raw.window ?? {}) },
+      // 空串不保留：历史配置文件没有该键或被清空时一律回官方默认源
+      marketEndpoint:
+        typeof raw.marketEndpoint === 'string' && raw.marketEndpoint
+          ? raw.marketEndpoint
+          : DEFAULTS.marketEndpoint,
     };
   } catch {
     // 首次启动或文件损坏：回默认值，不阻断启动

--- a/src/desktop/src/shared/contract.ts
+++ b/src/desktop/src/shared/contract.ts
@@ -126,7 +126,8 @@ export interface PluginEntryInfo {
   name: string;
   disabled: boolean;
   state: 'active' | 'disabled' | 'error' | 'pending';
-  /** 仅 state='error' 时存在：fiber 记录的失败原因。 */
+  /** state='error' 时是 fiber 记录的失败原因；disabled 条目上也可能携带
+      诊断注记（#708：安装物哈希不符被强制禁用的解释）。 */
   error?: string;
   /** 条目当前配置。组条目（children 容器）不暴露 config。 */
   config?: unknown;
@@ -158,6 +159,39 @@ export interface PluginTreeExport {
   version: 1;
   entries: PluginTreeEntry[];
 }
+
+/* ---- plugins.market.*（#708）：官方插件市场的载荷类型 ---- */
+
+/** 官方市场索引源的默认地址（主仓 market/index.json 的 raw URL）。 */
+export const MARKET_ENDPOINT_DEFAULT =
+  'https://raw.githubusercontent.com/ZJU-REAL/Polaris/main/market/index.json';
+
+/** 市场索引单条目（kernel 侧 MarketIndexEntry 的镜像形状）。 */
+export interface MarketIndexEntry {
+  /** npm 包名（polaris-plugin-* / @scope/polaris-plugin-*）。 */
+  name: string;
+  /** 上架版本；安装时按此精确版本向 registry 解析。 */
+  version: string;
+  kind: 'datasource' | 'record-kind' | 'runner' | 'agent-tool' | 'workflow' | 'discipline' | 'panel';
+  description: string;
+  publisher: string;
+  /** 权限摘要：如实展示，v1 不 enforcement。 */
+  permissions: { network?: boolean; filesystem?: boolean };
+  tier: 'bronze' | 'silver' | 'gold' | 'platinum';
+  /** 治理徽章（official/verified/preview…），开放枚举。 */
+  badges: string[];
+}
+
+/** 当前市场索引源。isDefault 供 UI 显示「官方源/自定义源」。 */
+export interface MarketEndpoint {
+  endpoint: string;
+  isDefault: boolean;
+}
+
+/** 卸载结果作为数据返回：enabled 拒卸是业务分支，不是异常。 */
+export type MarketUninstallResult =
+  | { ok: true }
+  | { ok: false; code: 'plugin-enabled' | 'not-installed'; message: string };
 
 /** 服务器连通性探测结果（打 GET {url}/api/health）。 */
 export type ServerProbe =
@@ -208,6 +242,22 @@ export interface Methods {
   'plugins.exportTree': { params: void; result: PluginTreeExport };
   /** 全量替换整树。导入前 kernel 自动留 last-good 快照，失败回滚。 */
   'plugins.importTree': { params: { tree: PluginTreeExport }; result: void };
+
+  /* ---- plugins.market.*（#708）：官方源市场。能力门槛同上（plugins.manage），
+     且 install/uninstall 还要求持久层在位（安装记录必须落库，否则哈希
+     复核链路断裂）。 ---- */
+
+  /** 拉取并校验市场索引（源地址读 getEndpoint 的持久配置）。 */
+  'plugins.market.fetchIndex': { params: void; result: MarketIndexEntry[] };
+  /** 安装插件：返回 JobHandle，下载/校验/解压/登记四个进度点走 job.* 事件。
+      装/启分离：装完只在树上挂 disabled 条目，代码一行不执行。 */
+  'plugins.market.install': { params: { name: string; version: string }; result: JobHandle };
+  /** 卸载插件。树条目仍启用时拒绝（错误作为数据返回，先禁用再卸）。 */
+  'plugins.market.uninstall': { params: { name: string }; result: MarketUninstallResult };
+  /** 当前索引源。 */
+  'plugins.market.getEndpoint': { params: void; result: MarketEndpoint };
+  /** 设置索引源；空串 = 复位官方默认源。 */
+  'plugins.market.setEndpoint': { params: { endpoint: string }; result: MarketEndpoint };
 
   /* ---- local.*：第二期的本地计算能力 ----
      现在全部声明但不实现（一律抛 ERR_CAPABILITY_UNAVAILABLE），目的是把

--- a/src/desktop/src/smoke.ts
+++ b/src/desktop/src/smoke.ts
@@ -16,19 +16,30 @@
 
 import { BrowserWindow, app } from 'electron';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { gzipSync } from 'node:zlib';
 import { join } from 'node:path';
 
-import type { SqliteTree, StorageService } from '@polaris/kernel';
+import type { FetchImpl, SqliteTree, StorageService } from '@polaris/kernel';
 
 import { pingAgent, stopAgent } from './main/agent/supervisor';
-import { localBackend, startKernel, stopKernel } from './main/kernel';
+import { kernelPluginMeta, localBackend, marketPluginsDir, startKernel, stopKernel } from './main/kernel';
 import { capabilityManifest } from './main/capabilities';
 import { installIpc } from './main/ipc/router';
+import {
+  awaitInstallForTesting,
+  marketFetchIndex,
+  marketGetEndpoint,
+  marketInstall,
+  marketSetEndpoint,
+  marketUninstall,
+  setMarketFetchForTesting,
+} from './main/ipc/methods.market';
 import { pluginsDisable, pluginsEnable, pluginsExportTree, pluginsList } from './main/ipc/methods.plugins';
+import { MARKET_ENDPOINT_DEFAULT } from './shared/contract';
 import { extractTarGz } from './main/updates/tar';
 import { compareVersions, stagedSupersedes } from './main/updates/version';
 import { APP_INDEX, buildCsp, handleAppProtocol, registerAppScheme } from './main/protocol';
@@ -444,6 +455,147 @@ void app.whenReady().then(async () => {
     probeEnabled.state === 'active' && tree?.store['desktop-probe']?.fiber != null,
     `state=${probeEnabled.state}`,
   );
+
+  // 插件市场（#708）：源配置持久化 + 全离线的「安装→启用→拒卸→卸载」
+  // 闭环。fetch 换成进程内替身（registry packument + tarball 都是现造的），
+  // 但其余全是真的：真解压落盘到 userData/plugins、真写 PluginMetaStore、
+  // 真在配置树上挂 file:// 条目、启用时真的动态 import——这条断言顺带
+  // 守住 esbuild CJS 打包必须保留原生 import() 的前提（R1 家族）。
+  console.log('\n插件市场（plugins.market.*）');
+  check(
+    '默认索引源为官方 raw URL',
+    marketGetEndpoint().endpoint === MARKET_ENDPOINT_DEFAULT && marketGetEndpoint().isDefault,
+  );
+  marketSetEndpoint('https://mirror.example.edu/market/index.json');
+  check(
+    'setEndpoint 持久化并回读（isDefault=false）',
+    marketGetEndpoint().endpoint === 'https://mirror.example.edu/market/index.json'
+      && !marketGetEndpoint().isDefault,
+  );
+  marketSetEndpoint('');
+  check('空串复位官方默认源', marketGetEndpoint().isDefault);
+
+  // 现造一个合法的 npm 发布包（ustar 头带校验和：市场解包器会验，
+  // 上面更新包用的 tarEntry 不带校验和，不能复用）
+  const marketTar = (name: string, body: string): Buffer => {
+    const data = Buffer.from(body, 'utf8');
+    const header = Buffer.alloc(512);
+    header.write(name, 0, 100, 'utf8');
+    header.write('0000644\0', 100);
+    header.write('0000000\0', 108);
+    header.write('0000000\0', 116);
+    header.write(data.length.toString(8).padStart(11, '0') + '\0', 124);
+    header.write('00000000000\0', 136);
+    header.write('        ', 148);
+    header.write('0', 156);
+    header.write('ustar\0', 257);
+    header.write('00', 263);
+    let sum = 0;
+    for (const byte of header) sum += byte;
+    header.write(sum.toString(8).padStart(6, '0') + '\0 ', 148);
+    const padded = Buffer.alloc(Math.ceil(data.length / 512) * 512);
+    data.copy(padded);
+    return Buffer.concat([header, padded]);
+  };
+  const HELLO = 'polaris-plugin-hello';
+  const helloPkgJson = JSON.stringify({
+    name: HELLO,
+    version: '1.0.0',
+    description: 'A tiny smoke plugin',
+    polaris: { kind: 'panel', entry: 'index.js' },
+  });
+  const helloEntry = "module.exports = { name: 'hello-smoke', apply() {} };\n";
+  const helloTgz = gzipSync(
+    Buffer.concat([
+      marketTar('package/package.json', helloPkgJson),
+      marketTar('package/index.js', helloEntry),
+      Buffer.alloc(1024),
+    ]),
+  );
+  const tarballUrl = `https://registry.npmjs.org/${HELLO}/-/${HELLO}-1.0.0.tgz`;
+  const indexEntry = {
+    name: HELLO,
+    version: '1.0.0',
+    kind: 'panel',
+    description: 'A tiny smoke plugin',
+    publisher: 'polaris',
+    permissions: {},
+    tier: 'bronze',
+    badges: ['official'],
+  };
+  setMarketFetchForTesting((async (input: unknown) => {
+    const url = String(input);
+    if (url === MARKET_ENDPOINT_DEFAULT) {
+      return Response.json({ schemaVersion: 1, plugins: [indexEntry] });
+    }
+    if (url === `https://registry.npmjs.org/${HELLO}`) {
+      return Response.json({
+        name: HELLO,
+        versions: {
+          '1.0.0': {
+            dist: {
+              tarball: tarballUrl,
+              integrity: `sha512-${createHash('sha512').update(helloTgz).digest('base64')}`,
+            },
+          },
+        },
+      });
+    }
+    if (url === tarballUrl) return new Response(new Uint8Array(helloTgz));
+    return new Response('not found', { status: 404 });
+  }) as FetchImpl);
+
+  try {
+    const indexEntries = await marketFetchIndex().catch((err) => `threw: ${String(err)}`);
+    check(
+      'fetchIndex 返回校验后的条目',
+      Array.isArray(indexEntries) && indexEntries.length === 1 && indexEntries[0].name === HELLO,
+      typeof indexEntries === 'string' ? indexEntries : `count=${indexEntries.length}`,
+    );
+
+    const handle = marketInstall(HELLO, '1.0.0');
+    await awaitInstallForTesting(handle.jobId);
+    const meta = kernelPluginMeta();
+    check('安装记录已落 PluginMetaStore', meta?.get(`market:install:${HELLO}`) != null);
+    const installed = tree?.store[HELLO];
+    check(
+      '安装后树条目 = file:// 入口 + disabled（装/启分离）',
+      installed != null
+        && installed.options.name.startsWith('file://')
+        && installed.options.disabled === true
+        && installed.fiber == null,
+      `name=${installed?.options.name} disabled=${installed?.options.disabled}`,
+    );
+    check(
+      'plugins.list 可见安装物且 state=disabled',
+      pluginsList().find((info) => info.id === HELLO)?.state === 'disabled',
+    );
+
+    const helloEnabled = await pluginsEnable(HELLO).catch((err) => `threw: ${String(err)}`);
+    check(
+      '安装物可启用（file:// 动态 import 在打包主进程真实走通）',
+      typeof helloEnabled !== 'string' && helloEnabled.state === 'active',
+      typeof helloEnabled === 'string' ? helloEnabled : `state=${helloEnabled.state}`,
+    );
+
+    const refused = await marketUninstall(HELLO);
+    check(
+      'enabled 状态拒卸（错误作为数据返回）',
+      refused.ok === false && refused.code === 'plugin-enabled',
+      JSON.stringify(refused),
+    );
+
+    await pluginsDisable(HELLO);
+    const removed = await marketUninstall(HELLO);
+    check('禁用后卸载成功', removed.ok === true, JSON.stringify(removed));
+    check(
+      '卸载后树条目与盘面均已清理',
+      tree?.store[HELLO] == null && !existsSync(join(marketPluginsDir(), HELLO)),
+    );
+    check('卸载后安装记录已删', meta?.get(`market:install:${HELLO}`) === undefined);
+  } finally {
+    setMarketFetchForTesting(undefined);
+  }
 
   // storage 持久层（#609）：就绪性经 IPC 可见，数据要真的穿过一次「停机 →
   // 重启」仍然在——这正是配置树持久化存在的意义，光断言服务挂着不够。

--- a/src/frontend/src/lib/host.ts
+++ b/src/frontend/src/lib/host.ts
@@ -270,3 +270,69 @@ export async function exportPluginTree(): Promise<PluginTreeExport | null> {
 export async function importPluginTree(tree: PluginTreeExport): Promise<void> {
   await bridge()?.invoke('plugins.importTree', { tree });
 }
+
+/* —— 插件市场（plugins.market.*，#708；contract.ts 的手工镜像）——
+   显隐同样读 plugins.manage 能力位；web 端（无桥）一律 null/no-op。 */
+
+/** 市场索引单条目（desktop contract.ts 的 MarketIndexEntry 镜像）。 */
+export interface MarketIndexEntry {
+  name: string;
+  version: string;
+  kind: 'datasource' | 'record-kind' | 'runner' | 'agent-tool' | 'workflow' | 'discipline' | 'panel';
+  description: string;
+  publisher: string;
+  /** 权限摘要：如实展示，v1 不 enforcement。 */
+  permissions: { network?: boolean; filesystem?: boolean };
+  tier: 'bronze' | 'silver' | 'gold' | 'platinum';
+  badges: string[];
+}
+
+/** 当前市场索引源；isDefault 供 UI 显示「官方源/自定义源」。 */
+export interface MarketEndpoint {
+  endpoint: string;
+  isDefault: boolean;
+}
+
+/** 卸载结果是数据：enabled 拒卸提示用户先禁用，不当异常抛。 */
+export type MarketUninstallResult =
+  | { ok: true }
+  | { ok: false; code: 'plugin-enabled' | 'not-installed'; message: string };
+
+/** 拉取市场索引（源地址是主进程的持久配置）；web 端返回 null。 */
+export async function fetchMarketIndex(): Promise<MarketIndexEntry[] | null> {
+  const b = bridge();
+  if (!b) return null;
+  return (await b.invoke('plugins.market.fetchIndex')) as MarketIndexEntry[];
+}
+
+/** 安装插件：返回 JobHandle，下载/校验/解压/登记进度走 job.* 事件。
+    装/启分离：装完是 disabled 条目，用户在插件列表里显式启用。 */
+export async function installMarketPlugin(
+  name: string,
+  version: string,
+): Promise<{ jobId: string } | null> {
+  const b = bridge();
+  if (!b) return null;
+  return (await b.invoke('plugins.market.install', { name, version })) as { jobId: string };
+}
+
+/** 卸载插件；条目仍启用时返回 ok:false（先禁用再卸）。 */
+export async function uninstallMarketPlugin(name: string): Promise<MarketUninstallResult | null> {
+  const b = bridge();
+  if (!b) return null;
+  return (await b.invoke('plugins.market.uninstall', { name })) as MarketUninstallResult;
+}
+
+/** 当前索引源；web 端返回 null。 */
+export async function getMarketEndpoint(): Promise<MarketEndpoint | null> {
+  const b = bridge();
+  if (!b) return null;
+  return (await b.invoke('plugins.market.getEndpoint')) as MarketEndpoint;
+}
+
+/** 设置索引源；空串复位官方默认源。 */
+export async function setMarketEndpoint(endpoint: string): Promise<MarketEndpoint | null> {
+  const b = bridge();
+  if (!b) return null;
+  return (await b.invoke('plugins.market.setEndpoint', { endpoint })) as MarketEndpoint;
+}

--- a/src/kernel/src/config/sqlite-tree.ts
+++ b/src/kernel/src/config/sqlite-tree.ts
@@ -193,6 +193,12 @@ export namespace SqliteTree {
   export interface Config {
     /** 树的持久化后座：SqliteConfigTreeStore（生产）或 Memory（测试）。 */
     store: ConfigTreeStore
+    /**
+     * import 前置闸（#708）：非 cordis: 的 specifier 在真正 import 之前
+     * 先过它，抛错即拒绝装载。市场安装物的哈希复核（createImportGuard）
+     * 挂在这里；树本身不关心闸的语义，保持通用。
+     */
+    guardImport?: (name: string) => void | Promise<void>
   }
 }
 
@@ -208,6 +214,13 @@ export class SqliteTree extends EntryTree {
   #dirty = false
   #writeTask: NodeJS.Timeout | undefined
   #writeQueue: Promise<void> = Promise.resolve()
+
+  /**
+   * 条目级诊断注记（#708）：装载路径之外得出的警告（如启动扫描发现
+   * 安装物哈希不符被强制禁用）。listEntries 把它并进 error 面——条目
+   * 没有 fiber（disabled）时这是唯一能到达前端的解释渠道。
+   */
+  readonly warnings = new Map<string, string>()
 
   constructor(ctx: Context, public config: SqliteTree.Config) {
     super(ctx)
@@ -238,10 +251,20 @@ export class SqliteTree extends EntryTree {
     // 走到 Entry.update「先 dispose 旧 fiber 再 start」之后才炸，回滚只能
     // 重建一个新 fiber。在 import 阶段就抛错，Entry.update 会在动手前
     // 失败——原 fiber 原样活着，这正是坏包回滚想要的语义。
-    if (name.startsWith('cordis:') && !(name.slice(7) in this.ctx.loader.builtins)) {
-      throw new Error(`未知的内置插件 "${name}"（未在 loader.builtins 注册）`)
+    if (name.startsWith('cordis:')) {
+      if (!(name.slice(7) in this.ctx.loader.builtins)) {
+        throw new Error(`未知的内置插件 "${name}"（未在 loader.builtins 注册）`)
+      }
+      return super.import(name, getOuterStack)
     }
-    return super.import(name, getOuterStack)
+    // 非内置 specifier 先过 guardImport（见 Config 注释）：闸抛错发生在
+    // import 阶段，享受与上面同款的「动手前失败、原 fiber 原样活着」语义
+    const guard = this.config.guardImport
+    if (!guard) return super.import(name, getOuterStack)
+    return (async () => {
+      await guard(name)
+      return super.import(name, getOuterStack)
+    })()
   }
 
   /** plugins.list（#705）：树条目 + 运行态的扁平视图。 */
@@ -255,6 +278,11 @@ export class SqliteTree extends EntryTree {
         state,
       }
       if (error !== undefined) info.error = error
+      else {
+        // 无运行时错误才看注记：fiber 真实失败的信息优先级更高
+        const warning = this.warnings.get(entry.id)
+        if (warning !== undefined) info.error = warning
+      }
       // 组条目的 config 是子条目列表（loader 内部表示），不当作插件配置暴露
       if (!entry.options.group && entry.options.config !== undefined) {
         info.config = entry.options.config

--- a/src/kernel/src/index.ts
+++ b/src/kernel/src/index.ts
@@ -85,9 +85,28 @@ export {
   parseTar,
   uninstallPlugin,
   verifyEntryHash,
+  type InstallPhase,
   type InstallPluginOptions,
   type UninstallPluginOptions,
 } from './market/install.ts'
+export {
+  INSTALL_RECORD_PREFIX,
+  createImportGuard,
+  entryFileUrl,
+  installAndRegister,
+  installRecordKey,
+  packageEntryId,
+  uninstallAndRemove,
+  verifyInstalledEntries,
+  type ImportGuardOptions,
+  type InstallAndRegisterOptions,
+  type InstallAndRegisterResult,
+  type InstallVerifyIssue,
+  type PluginMetaLike,
+  type UninstallAndRemoveOptions,
+  type UninstallOutcome,
+  type VerifyInstalledOptions,
+} from './market/lifecycle.ts'
 export { Context } from '@deepseek-ai/cordis'
 // 与上一行的 Context 同理：桌面侧建树要 ctx.plugin(Loader)，从 kernel
 // 统一转出，避免 desktop 直接依赖 vendor 包名

--- a/src/kernel/src/market/index-client.ts
+++ b/src/kernel/src/market/index-client.ts
@@ -14,7 +14,7 @@ import { MarketError, validateMarketIndex, type MarketIndexEntry } from './contr
 
 /** 官方索引的 raw URL（主仓 market/index.json）。 */
 export const OFFICIAL_INDEX_URL =
-  'https://raw.githubusercontent.com/tricktreat/Polaris/main/market/index.json'
+  'https://raw.githubusercontent.com/ZJU-REAL/Polaris/main/market/index.json'
 
 const DEFAULT_TIMEOUT_MS = 15_000
 

--- a/src/kernel/src/market/install.ts
+++ b/src/kernel/src/market/install.ts
@@ -30,6 +30,11 @@ import {
 
 export const NPM_REGISTRY = 'https://registry.npmjs.org'
 
+/** 安装阶段（#708）：桌面侧把它翻译成 job.progress 的进度点。
+    前三个由 installPlugin 在各阶段起点回调；register（记录落库 + 树上
+    挂条目）由 lifecycle.ts 的 installAndRegister 回调。 */
+export type InstallPhase = 'download' | 'verify' | 'extract' | 'register'
+
 /* ---------- 极简 tar 解析 ----------
 
    tar 是 512 字节块的序列：每个成员 = 1 个头块 + ceil(size/512) 个
@@ -145,6 +150,8 @@ export interface InstallPluginOptions {
   /** 插件根目录（桌面侧是 userData/plugins），本包不预设位置。 */
   pluginsDir: string
   fetchImpl?: FetchImpl
+  /** 阶段回调（#708）：长任务进度上报用，纯通知、抛错不接。 */
+  onPhase?: (phase: InstallPhase) => void
 }
 
 /** registry packument 里用到的字段。 */
@@ -173,6 +180,7 @@ export async function installPlugin(options: InstallPluginOptions): Promise<Inst
   }
 
   // 1. packument：scoped 包的 / 要转义（registry 的既定形状）
+  options.onPhase?.('download')
   const packumentUrl = `${registryUrl}/${name.replace('/', '%2f')}`
   const metaRes = await fetchImpl(packumentUrl)
   if (!metaRes.ok) {
@@ -207,6 +215,7 @@ export async function installPlugin(options: InstallPluginOptions): Promise<Inst
     throw new MarketError('tarball-http', `tarball download failed with HTTP ${tarballRes.status}: ${tarballUrl}`)
   }
   const tarball = Buffer.from(await tarballRes.arrayBuffer())
+  options.onPhase?.('verify')
   const actualSri = `sha512-${createHash('sha512').update(tarball).digest('base64')}`
   if (actualSri !== expectedSri) {
     throw new MarketError(
@@ -217,6 +226,7 @@ export async function installPlugin(options: InstallPluginOptions): Promise<Inst
 
   // 3. 解压解析（内存中完成全部路径校验，再统一落盘：
   //    路径穿越在写第一个字节之前就会被拒）
+  options.onPhase?.('extract')
   let tar: Buffer
   try {
     tar = gunzipSync(tarball)

--- a/src/kernel/src/market/lifecycle.ts
+++ b/src/kernel/src/market/lifecycle.ts
@@ -1,0 +1,258 @@
+/* ============================================================
+   安装生命周期接线（#708，市场 PR-6）：把 #700 的纯函数安装引擎接到
+   持久层与配置树上。
+
+   职责边界：
+   - installPlugin/uninstallPlugin 只管盘面（#700，保持纯函数）；
+   - 本模块负责「装完之后」的三件事：InstallRecord 落 PluginMetaStore、
+     配置树挂 disabled 条目（装/启分离：安装绝不自动运行代码）、卸载时
+     反向拆干净；
+   - 装载前哈希复核分两个挂点（why 见各函数头注）：启动扫描
+     verifyInstalledEntries（树装载之前跑，能安全地强制 disabled）+
+     createImportGuard（enable 时刻的最后一道闸，覆盖会话中途被篡改）。
+
+   metaStore 用结构化接口（PluginMetaLike）而不是直接依赖 storage 插件：
+   测试给个 Map 就能跑全链路，也保住 market/ 子树不依赖 node:sqlite。
+   本文件必须保持 electron-free（tests/electron-free.test.ts 强制）。
+   ============================================================ */
+
+import type { EntryOptions } from '@deepseek-ai/cordis-plugin-loader'
+import { rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import type { SqliteTree } from '../config/sqlite-tree.ts'
+import type { ConfigEntry, ConfigTreeStore } from '../config/tree.ts'
+import { MarketError, type InstallRecord } from './contract.ts'
+import { installPlugin, uninstallPlugin, verifyEntryHash, type InstallPluginOptions } from './install.ts'
+
+/** InstallRecord 在 PluginMetaStore 里的键前缀；每个包一条记录（单版本策略）。 */
+export const INSTALL_RECORD_PREFIX = 'market:install:'
+
+export function installRecordKey(name: string): string {
+  return `${INSTALL_RECORD_PREFIX}${name}`
+}
+
+/** PluginMetaStore 的结构化子集（storage/store.ts 的 PluginMetaStore 天然满足）。 */
+export interface PluginMetaLike {
+  get(key: string): unknown
+  set(key: string, value: unknown): void
+  delete(key: string): boolean
+  list(): string[]
+}
+
+/**
+ * npm 包名 → 树条目 id。':' 是 loader 的子树分隔符、'/' 会让 id 读起来
+ * 像路径，都不能进 id；scoped 包剥掉 @、'/' 换 '--'（双横线在合法包名里
+ * 不会与单横线歧义到产生实际碰撞）。
+ */
+export function packageEntryId(name: string): string {
+  return name.replace(/^@/, '').replace(/\//g, '--')
+}
+
+/** 安装记录对应的入口文件 file:// URL——树条目的 name 就存它。 */
+export function entryFileUrl(record: InstallRecord): string {
+  return pathToFileURL(join(record.dir, record.entry)).href
+}
+
+function readRecord(metaStore: PluginMetaLike, name: string): InstallRecord | undefined {
+  const raw = metaStore.get(installRecordKey(name))
+  if (!raw || typeof raw !== 'object') return undefined
+  const record = raw as Partial<InstallRecord>
+  // KV 里的值可能被外部改坏；字段不齐的记录当不存在处理，宁可重装
+  for (const key of ['name', 'version', 'entry', 'tarballSha512', 'entrySha256', 'dir'] as const) {
+    if (typeof record[key] !== 'string' || !record[key]) return undefined
+  }
+  return record as InstallRecord
+}
+
+export interface InstallAndRegisterOptions extends InstallPluginOptions {
+  tree: SqliteTree
+  metaStore: PluginMetaLike
+}
+
+export interface InstallAndRegisterResult {
+  record: InstallRecord
+  /** 配置树条目 id（packageEntryId(name)）。 */
+  entryId: string
+}
+
+/**
+ * 安装并登记：installPlugin → InstallRecord 落 metaStore → 树上挂
+ * disabled 条目。装/启分离（Koishi 惯例）：安装后的代码一行都不执行，
+ * 由用户在插件列表里显式启用。
+ *
+ * 同名重装（含升级）取单版本策略：新版本装成后删旧版本目录、树条目
+ * 改指新入口，并且**强制回到 disabled**——升级得到的是新代码，自动
+ * 沿用旧的启用状态等于「更新即执行」，正是装启分离要挡的事。多版本
+ * 并存对 v1 没有消费方（树条目只有一个 name），只会留下孤儿目录。
+ */
+export async function installAndRegister(options: InstallAndRegisterOptions): Promise<InstallAndRegisterResult> {
+  const { tree, metaStore, ...installOptions } = options
+  const previous = readRecord(metaStore, installOptions.name)
+
+  const record = await installPlugin(installOptions)
+  installOptions.onPhase?.('register')
+
+  // 旧版本目录在新版本完整落盘之后才删：中途失败时旧安装保持可用
+  if (previous && previous.dir !== record.dir) {
+    await rm(previous.dir, { recursive: true, force: true })
+  }
+  metaStore.set(installRecordKey(record.name), record)
+
+  const entryId = packageEntryId(record.name)
+  const url = entryFileUrl(record)
+  const existing = tree.store[entryId]
+  if (existing) {
+    // 就地更新而不是 remove+create：保住条目的 config 与树上的位置。
+    // 直接调 Entry.update（force）——EntryTree.update 不接受 name 变更。
+    // 条目若在运行，disabled: true 会让它先被安全地停掉。
+    await existing.update({ name: url, disabled: true }, false, true)
+    tree.write()
+  } else {
+    // ensureId 尊重传入的 id：条目 id 用包名规范化，卸载/复核都能反查
+    const entryOptions: EntryOptions = { id: entryId, name: url, disabled: true }
+    await tree.create(entryOptions)
+  }
+  await tree.flush()
+  return { record, entryId }
+}
+
+export interface UninstallAndRemoveOptions {
+  name: string
+  pluginsDir: string
+  tree: SqliteTree
+  metaStore: PluginMetaLike
+}
+
+/** 卸载结果作为数据返回：enabled 拒卸是正常业务分支，不是异常。 */
+export type UninstallOutcome =
+  | { ok: true }
+  | { ok: false; code: 'plugin-enabled' | 'not-installed'; message: string }
+
+/**
+ * 卸载并拆登记：树条目仍处于启用态时拒绝（用户先禁用、看清后果再卸，
+ * 也避免「卸载顺手停掉正在运行的东西」这种隐式副作用）；disabled 或
+ * 条目已被用户删掉时：移除树条目 → 删安装目录 → 删记录。
+ */
+export async function uninstallAndRemove(options: UninstallAndRemoveOptions): Promise<UninstallOutcome> {
+  const { name, pluginsDir, tree, metaStore } = options
+  const entryId = packageEntryId(name)
+  const entry = tree.store[entryId]
+  const record = readRecord(metaStore, name)
+
+  if (!entry && !record) {
+    return { ok: false, code: 'not-installed', message: `插件 ${name} 未安装` }
+  }
+  if (entry && !entry.options.disabled) {
+    return { ok: false, code: 'plugin-enabled', message: `插件 ${name} 仍处于启用状态，请先禁用再卸载` }
+  }
+  if (entry) await tree.remove(entryId)
+  await uninstallPlugin({ name, pluginsDir })
+  metaStore.delete(installRecordKey(name))
+  await tree.flush()
+  return { ok: true }
+}
+
+export interface VerifyInstalledOptions {
+  metaStore: PluginMetaLike
+  /** 直接操作持久 store（树装载之前跑），不经过活树。 */
+  store: ConfigTreeStore
+  /** 打包态 true：哈希不符强制 disabled；开发态 false：仅报告。 */
+  strict: boolean
+}
+
+export interface InstallVerifyIssue {
+  name: string
+  entryId: string
+  message: string
+  /** strict 下是否真的把树条目改成了 disabled（条目不存在/本就 disabled 时 false）。 */
+  forcedDisabled: boolean
+}
+
+function tamperMessage(record: InstallRecord): string {
+  return `插件 ${record.name}@${record.version} 的入口文件与安装记录的哈希不符（文件被改动或删除），拒绝装载`
+}
+
+/**
+ * 启动扫描（哈希复核的主挂点）：遍历 metaStore 全部安装记录逐条
+ * verifyEntryHash，不符的在**树装载之前**把持久 store 里指向该入口的
+ * 条目改成 disabled。
+ *
+ * 为什么选启动扫描而不是只靠 import 覆写：SqliteTree 初始化用
+ * EntryGroup.update 的事务化 reconcile，启动时任何一个条目 import 抛错
+ * 会让整树回滚（kernel.ts：本次会话无插件树）——被篡改的应当只有它
+ * 自己被禁用，不能拖垮其他插件。在树装载前改 store 是唯一能表达
+ * 「强制 disabled + 其余照常」的位置。import 覆写（createImportGuard）
+ * 作为第二道闸保留，盯的是会话中途篡改后再 enable 的窗口。
+ */
+export async function verifyInstalledEntries(options: VerifyInstalledOptions): Promise<InstallVerifyIssue[]> {
+  const { metaStore, store, strict } = options
+  const issues: InstallVerifyIssue[] = []
+  let entries: ConfigEntry[] | undefined
+  let mutated = false
+
+  const disableMatching = (list: ConfigEntry[], entryId: string, url: string): boolean => {
+    let changed = false
+    for (const entry of list) {
+      // 双判据：id 是安装时登记的规范化包名，name 是入口 URL——
+      // 用户手工复制过条目时按 name 也能兜住
+      if ((entry.id === entryId || entry.name === url) && entry.disabled !== true) {
+        entry.disabled = true
+        changed = true
+      }
+      if (entry.children && disableMatching(entry.children, entryId, url)) changed = true
+    }
+    return changed
+  }
+
+  for (const key of metaStore.list()) {
+    if (!key.startsWith(INSTALL_RECORD_PREFIX)) continue
+    const record = readRecord(metaStore, key.slice(INSTALL_RECORD_PREFIX.length))
+    if (!record) continue
+    if (await verifyEntryHash(record)) continue
+
+    const entryId = packageEntryId(record.name)
+    let forcedDisabled = false
+    if (strict) {
+      entries ??= await store.load()
+      if (disableMatching(entries, entryId, entryFileUrl(record))) {
+        forcedDisabled = true
+        mutated = true
+      }
+    }
+    issues.push({ name: record.name, entryId, message: tamperMessage(record), forcedDisabled })
+  }
+  if (mutated && entries) await store.save(entries)
+  return issues
+}
+
+export interface ImportGuardOptions {
+  metaStore: PluginMetaLike
+  /** 打包态 true：不符直接拒绝 import；开发态 false：仅 warn 后放行。 */
+  strict: boolean
+  warn?: (message: string) => void
+}
+
+/**
+ * enable 时刻的复核闸（哈希复核的第二挂点），挂在 SqliteTree.Config 的
+ * guardImport 上。启动扫描盖不住的窗口是「会话运行中文件被篡改、用户
+ * 随后点启用」——enable 走单条目的 Entry.update，import 抛错只回滚它
+ * 自己（options 滚回 disabled），错误经 IPC 原样交给用户，没有整树
+ * 回滚的风险。不在安装记录里的 specifier（内置/开发者手挂的本地文件）
+ * 不归它管，直接放行。
+ */
+export function createImportGuard(options: ImportGuardOptions): (name: string) => Promise<void> {
+  const { metaStore, strict, warn } = options
+  return async (name: string) => {
+    if (!name.startsWith('file:')) return
+    for (const key of metaStore.list()) {
+      if (!key.startsWith(INSTALL_RECORD_PREFIX)) continue
+      const record = readRecord(metaStore, key.slice(INSTALL_RECORD_PREFIX.length))
+      if (!record || entryFileUrl(record) !== name) continue
+      if (await verifyEntryHash(record)) return
+      if (strict) throw new MarketError('integrity-mismatch', tamperMessage(record))
+      warn?.(tamperMessage(record))
+      return
+    }
+  }
+}

--- a/src/kernel/tests/helpers/market-fixture.ts
+++ b/src/kernel/tests/helpers/market-fixture.ts
@@ -1,0 +1,117 @@
+/* 市场测试共用 fixture（#700 引入，#708 抽出共享）：手写 ustar 头现场
+   生成 .tgz + fetch 替身。零真网、零预生成二进制——想改 fixture 改代码
+   即可，diff 可读，顺便当 install.ts 里 tar 解析器的对拍实现。 */
+import { createHash } from 'node:crypto'
+import { gzipSync } from 'node:zlib'
+import type { FetchImpl } from '../../src/index.ts'
+
+export interface TarSpec {
+  name: string
+  data?: string
+  /** '0'=文件 '2'=软链 '5'=目录 …；默认文件。 */
+  typeflag?: string
+}
+
+export function tarHeader(name: string, size: number, typeflag: string): Buffer {
+  const block = Buffer.alloc(512)
+  block.write(name, 0, 100, 'utf8')
+  block.write('0000644\0', 100) // mode
+  block.write('0000000\0', 108) // uid
+  block.write('0000000\0', 116) // gid
+  block.write(size.toString(8).padStart(11, '0') + '\0', 124)
+  block.write('00000000000\0', 136) // mtime
+  block.write('        ', 148) // chksum 先占 8 个空格参与求和
+  block.write(typeflag, 156)
+  block.write('ustar\0', 257)
+  block.write('00', 263)
+  let sum = 0
+  for (const byte of block) sum += byte
+  block.write(sum.toString(8).padStart(6, '0') + '\0 ', 148)
+  return block
+}
+
+export function makeTgz(specs: TarSpec[]): Buffer {
+  const blocks: Buffer[] = []
+  for (const spec of specs) {
+    const data = Buffer.from(spec.data ?? '', 'utf8')
+    const typeflag = spec.typeflag ?? '0'
+    blocks.push(tarHeader(spec.name, typeflag === '0' ? data.length : 0, typeflag))
+    if (typeflag === '0' && data.length) {
+      const padded = Buffer.alloc(Math.ceil(data.length / 512) * 512)
+      data.copy(padded)
+      blocks.push(padded)
+    }
+  }
+  blocks.push(Buffer.alloc(1024)) // 结尾两个零块
+  return gzipSync(Buffer.concat(blocks))
+}
+
+export const HELLO_ENTRY = "module.exports = { name: 'hello', apply() {} }\n"
+
+/** polaris=null 表示整个字段省略（manifest-missing 用例）。 */
+export function helloPkg(
+  polaris: Record<string, unknown> | null,
+  description = 'A tiny hello plugin',
+  version = '1.0.0',
+): string {
+  const pkg: Record<string, unknown> = { name: 'polaris-plugin-hello', version, description }
+  if (polaris !== null) pkg.polaris = polaris
+  return JSON.stringify(pkg, null, 2)
+}
+
+export const GOOD_POLARIS = {
+  kind: 'panel',
+  entry: 'index.js',
+  description: { zh: '示例面板插件', en: 'An example panel plugin' },
+  permissions: { network: false },
+  runtime: 'in-process',
+  locales: ['zh', 'en'],
+}
+
+export function helloTgz(overrides: {
+  polaris?: Record<string, unknown> | null
+  description?: string
+  specs?: TarSpec[]
+  version?: string
+  entryData?: string
+}): Buffer {
+  return makeTgz(
+    overrides.specs ?? [
+      {
+        name: 'package/package.json',
+        data: helloPkg(
+          overrides.polaris === undefined ? GOOD_POLARIS : overrides.polaris,
+          overrides.description,
+          overrides.version,
+        ),
+      },
+      { name: 'package/index.js', data: overrides.entryData ?? HELLO_ENTRY },
+    ],
+  )
+}
+
+/* ---------- fetch 替身：packument JSON + tarball 二进制 ---------- */
+
+export const REGISTRY = 'https://registry.test'
+export const TARBALL_URL = `${REGISTRY}/polaris-plugin-hello/-/polaris-plugin-hello-1.0.0.tgz`
+
+export function registryFetch(
+  tgz: Buffer,
+  opts: { integrity?: string; version?: string; registryUrl?: string } = {},
+): FetchImpl {
+  const version = opts.version ?? '1.0.0'
+  const registryUrl = opts.registryUrl ?? REGISTRY
+  const tarballUrl = `${registryUrl}/polaris-plugin-hello/-/polaris-plugin-hello-${version}.tgz`
+  const integrity = opts.integrity ?? `sha512-${createHash('sha512').update(tgz).digest('base64')}`
+  return (async (input: unknown) => {
+    const url = String(input)
+    if (url === `${registryUrl}/polaris-plugin-hello`) {
+      return Response.json({
+        name: 'polaris-plugin-hello',
+        versions: { [version]: { dist: { tarball: tarballUrl, integrity } } },
+      })
+    }
+    if (url === tarballUrl) return new Response(new Uint8Array(tgz))
+    return new Response('not found', { status: 404 })
+  }) as FetchImpl
+}

--- a/src/kernel/tests/market-lifecycle.test.ts
+++ b/src/kernel/tests/market-lifecycle.test.ts
@@ -1,0 +1,290 @@
+/* 安装生命周期（#708）的单元测试：fixture registry（helpers/market-fixture）
+   + 真 Loader/SqliteTree（Memory store）+ Map 版 PluginMetaLike，跑
+   「安装→登记→启用→复核→卸载」的完整链路。打包态/开发态语义用
+   strict 参数注入模拟，不依赖 electron。 */
+import { existsSync } from 'node:fs'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  INSTALL_RECORD_PREFIX,
+  Loader,
+  MemoryConfigTreeStore,
+  SqliteTree,
+  createImportGuard,
+  createKernel,
+  entryFileUrl,
+  installAndRegister,
+  installRecordKey,
+  packageEntryId,
+  registerBuiltins,
+  uninstallAndRemove,
+  verifyInstalledEntries,
+  type ConfigEntry,
+  type InstallPhase,
+  type InstallRecord,
+  type Kernel,
+  type PluginMetaLike,
+} from '../src/index.ts'
+import { HELLO_ENTRY, helloTgz, registryFetch, REGISTRY } from './helpers/market-fixture.ts'
+
+const NAME = 'polaris-plugin-hello'
+const KEY = installRecordKey(NAME)
+
+/* ---------- 临时目录与 kernel 记账 ---------- */
+
+let dirs: string[] = []
+let kernels: Kernel[] = []
+afterEach(async () => {
+  for (const kernel of kernels) await kernel.stop().catch(() => {})
+  kernels = []
+  await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })))
+  dirs = []
+})
+
+async function freshPluginsDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'polaris-market-lc-'))
+  dirs.push(dir)
+  return dir
+}
+
+function memMeta(): PluginMetaLike {
+  const map = new Map<string, unknown>()
+  return {
+    get: (key) => map.get(key),
+    set: (key, value) => void map.set(key, JSON.parse(JSON.stringify(value))),
+    delete: (key) => map.delete(key),
+    list: () => [...map.keys()].sort(),
+  }
+}
+
+interface Harness {
+  kernel: Kernel
+  tree: SqliteTree
+  store: MemoryConfigTreeStore
+  metaStore: PluginMetaLike
+}
+
+async function bootTree(guardImport?: SqliteTree.Config['guardImport']): Promise<Harness> {
+  const kernel = createKernel({ name: 'market-lifecycle-test' })
+  kernels.push(kernel)
+  await kernel.start()
+  await kernel.ctx.plugin(Loader)
+  registerBuiltins(kernel.ctx.loader)
+  const store = new MemoryConfigTreeStore()
+  await kernel.ctx.plugin(SqliteTree, { store, guardImport })
+  const tree = kernel.ctx.get('configTree') as SqliteTree
+  return { kernel, tree, store, metaStore: memMeta() }
+}
+
+async function installHello(h: Harness, pluginsDir: string, options: {
+  version?: string
+  entryData?: string
+  onPhase?: (phase: InstallPhase) => void
+} = {}) {
+  const version = options.version ?? '1.0.0'
+  return installAndRegister({
+    name: NAME,
+    version,
+    registryUrl: REGISTRY,
+    pluginsDir,
+    fetchImpl: registryFetch(helloTgz({ version, entryData: options.entryData }), { version }),
+    onPhase: options.onPhase,
+    tree: h.tree,
+    metaStore: h.metaStore,
+  })
+}
+
+/* ---------- 安装登记 ---------- */
+
+describe('installAndRegister', () => {
+  it('records to the meta store and adds a disabled tree entry without running code', async () => {
+    const h = await bootTree()
+    const pluginsDir = await freshPluginsDir()
+    const phases: InstallPhase[] = []
+    const { record, entryId } = await installHello(h, pluginsDir, { onPhase: (p) => phases.push(p) })
+
+    // 进度点按顺序各来一次：下载/校验/解压/登记
+    expect(phases).toEqual(['download', 'verify', 'extract', 'register'])
+    expect(entryId).toBe(NAME)
+    expect(h.metaStore.get(KEY)).toMatchObject({ name: NAME, version: '1.0.0' })
+
+    // 装/启分离：条目在树上、指向 file:// 入口、disabled、零 fiber
+    const entry = h.tree.store[NAME]!
+    expect(entry.options.name).toBe(entryFileUrl(record))
+    expect(entry.options.name.startsWith('file://')).toBe(true)
+    expect(entry.options.disabled).toBe(true)
+    expect(entry.fiber).toBeUndefined()
+
+    // flush 已发生：持久 store 里就是这份 disabled 条目
+    const persisted = await h.store.load()
+    expect(persisted).toContainEqual({ id: NAME, name: entryFileUrl(record), disabled: true })
+
+    // 启用后真的能装载（file:// 动态 import 全链路）
+    await h.tree.update(NAME, { disabled: null })
+    expect(h.tree.store[NAME]!.fiber).toBeTruthy()
+  })
+
+  it('reinstalling a newer version drops the old dir, repoints the entry and forces disabled', async () => {
+    const h = await bootTree()
+    const pluginsDir = await freshPluginsDir()
+    const first = await installHello(h, pluginsDir)
+    await h.tree.update(NAME, { disabled: null }) // 用户启用了 1.0.0
+    expect(h.tree.store[NAME]!.fiber).toBeTruthy()
+
+    const second = await installHello(h, pluginsDir, { version: '1.1.0' })
+    // 单版本策略：旧版本目录清掉，记录/树条目全部指向新版本
+    expect(existsSync(first.record.dir)).toBe(false)
+    expect(existsSync(second.record.dir)).toBe(true)
+    expect(h.metaStore.get(KEY)).toMatchObject({ version: '1.1.0' })
+    const entry = h.tree.store[NAME]!
+    expect(entry.options.name).toBe(entryFileUrl(second.record))
+    // 升级 = 新代码，强制回 disabled 由用户重新启用，运行中的旧 fiber 已停
+    expect(entry.options.disabled).toBe(true)
+    expect(entry.fiber).toBeUndefined()
+  })
+})
+
+/* ---------- 卸载 ---------- */
+
+describe('uninstallAndRemove', () => {
+  it('refuses to uninstall while the entry is enabled (error as data)', async () => {
+    const h = await bootTree()
+    const pluginsDir = await freshPluginsDir()
+    const { record } = await installHello(h, pluginsDir)
+    await h.tree.update(NAME, { disabled: null })
+
+    const outcome = await uninstallAndRemove({ name: NAME, pluginsDir, tree: h.tree, metaStore: h.metaStore })
+    expect(outcome).toEqual({ ok: false, code: 'plugin-enabled', message: expect.stringContaining('禁用') })
+    // 拒卸即无副作用：记录、盘面、树条目原样
+    expect(h.metaStore.get(KEY)).toBeDefined()
+    expect(existsSync(record.dir)).toBe(true)
+    expect(h.tree.store[NAME]).toBeDefined()
+  })
+
+  it('uninstalls a disabled plugin: tree entry, files and record all go away', async () => {
+    const h = await bootTree()
+    const pluginsDir = await freshPluginsDir()
+    await installHello(h, pluginsDir)
+
+    const outcome = await uninstallAndRemove({ name: NAME, pluginsDir, tree: h.tree, metaStore: h.metaStore })
+    expect(outcome).toEqual({ ok: true })
+    expect(h.tree.store[NAME]).toBeUndefined()
+    expect(existsSync(join(pluginsDir, NAME))).toBe(false)
+    expect(h.metaStore.get(KEY)).toBeUndefined()
+    expect(await h.store.load()).toEqual([])
+  })
+
+  it('reports a plugin that was never installed as data', async () => {
+    const h = await bootTree()
+    const outcome = await uninstallAndRemove({
+      name: 'polaris-plugin-ghost',
+      pluginsDir: await freshPluginsDir(),
+      tree: h.tree,
+      metaStore: h.metaStore,
+    })
+    expect(outcome).toMatchObject({ ok: false, code: 'not-installed' })
+  })
+})
+
+/* ---------- 启动扫描复核 ---------- */
+
+describe('verifyInstalledEntries', () => {
+  async function tamperedSetup() {
+    const h = await bootTree()
+    const pluginsDir = await freshPluginsDir()
+    const { record } = await installHello(h, pluginsDir)
+    await h.tree.update(NAME, { disabled: null }) // 启用后才有「强制禁用」可言
+    await h.tree.flush()
+    await writeFile(join(record.dir, record.entry), 'module.exports = { name: "evil", apply() {} }\n')
+    return { h, record }
+  }
+
+  it('strict mode force-disables the persisted entry and reports the issue', async () => {
+    const { h } = await tamperedSetup()
+    const issues = await verifyInstalledEntries({ metaStore: h.metaStore, store: h.store, strict: true })
+    expect(issues).toEqual([
+      { name: NAME, entryId: NAME, message: expect.stringContaining('哈希不符'), forcedDisabled: true },
+    ])
+    const persisted = await h.store.load()
+    expect(persisted.find((e: ConfigEntry) => e.id === NAME)?.disabled).toBe(true)
+  })
+
+  it('dev mode only reports and leaves the store untouched', async () => {
+    const { h } = await tamperedSetup()
+    const issues = await verifyInstalledEntries({ metaStore: h.metaStore, store: h.store, strict: false })
+    expect(issues).toMatchObject([{ name: NAME, forcedDisabled: false }])
+    const persisted = await h.store.load()
+    expect(persisted.find((e: ConfigEntry) => e.id === NAME)?.disabled).toBeUndefined()
+  })
+
+  it('an intact install passes without issues', async () => {
+    const h = await bootTree()
+    await installHello(h, await freshPluginsDir())
+    await expect(
+      verifyInstalledEntries({ metaStore: h.metaStore, store: h.store, strict: true }),
+    ).resolves.toEqual([])
+  })
+})
+
+/* ---------- enable 时刻的 import 闸 ---------- */
+
+describe('createImportGuard', () => {
+  it('strict guard rejects enabling a tampered entry; the tree entry stays disabled', async () => {
+    const metaStore = memMeta()
+    const h = await bootTree(createImportGuard({ metaStore, strict: true }))
+    h.metaStore = metaStore
+    const pluginsDir = await freshPluginsDir()
+    const { record } = await installHello(h, pluginsDir)
+    await writeFile(join(record.dir, record.entry), 'module.exports = { name: "evil", apply() {} }\n')
+
+    await expect(h.tree.update(NAME, { disabled: null })).rejects.toThrow(/哈希不符/)
+    // Entry.update 在 import 阶段失败会把 options 滚回原样：仍是 disabled
+    expect(h.tree.store[NAME]!.options.disabled).toBe(true)
+    expect(h.tree.store[NAME]!.fiber).toBeUndefined()
+  })
+
+  it('dev guard only warns and lets the entry load', async () => {
+    const metaStore = memMeta()
+    const warnings: string[] = []
+    const h = await bootTree(createImportGuard({ metaStore, strict: false, warn: (m) => warnings.push(m) }))
+    h.metaStore = metaStore
+    const pluginsDir = await freshPluginsDir()
+    const { record } = await installHello(h, pluginsDir)
+    await writeFile(join(record.dir, record.entry), HELLO_ENTRY + '// dev tweak\n')
+
+    await h.tree.update(NAME, { disabled: null })
+    expect(h.tree.store[NAME]!.fiber).toBeTruthy()
+    expect(warnings).toEqual([expect.stringContaining('哈希不符')])
+  })
+
+  it('ignores specifiers that are not market installs', async () => {
+    const guard = createImportGuard({ metaStore: memMeta(), strict: true })
+    await expect(guard('cordis:sources')).resolves.toBeUndefined()
+    await expect(guard('file:///somewhere/else.js')).resolves.toBeUndefined()
+  })
+})
+
+/* ---------- 诊断注记与 id 规范化 ---------- */
+
+describe('diagnostics', () => {
+  it('listEntries surfaces seeded warnings on entries without runtime errors', async () => {
+    const h = await bootTree()
+    await installHello(h, await freshPluginsDir())
+    h.tree.warnings.set(NAME, '入口文件与安装记录的哈希不符，已强制禁用')
+    const info = h.tree.listEntries().find((e) => e.id === NAME)!
+    expect(info.state).toBe('disabled')
+    expect(info.error).toContain('哈希不符')
+  })
+
+  it('packageEntryId keeps ids loader-safe for plain and scoped names', () => {
+    expect(packageEntryId('polaris-plugin-hello')).toBe('polaris-plugin-hello')
+    expect(packageEntryId('@zju-real/polaris-plugin-x')).toBe('zju-real--polaris-plugin-x')
+    expect(packageEntryId('@a/b').includes(':')).toBe(false)
+  })
+
+  it('install record keys share a stable prefix for scanning', () => {
+    expect(installRecordKey(NAME)).toBe(`${INSTALL_RECORD_PREFIX}${NAME}`)
+  })
+})

--- a/src/kernel/tests/market.test.ts
+++ b/src/kernel/tests/market.test.ts
@@ -1,14 +1,12 @@
 /* 市场契约 + 安装引擎（#700）的单元测试：零真网、零预生成二进制。
 
-   fixture tarball 在测试内用 node:zlib + 手写 ustar 头现场生成——
-   比提交 .tgz 二进制可复现（想改 fixture 改代码即可，diff 可读），
-   也顺便当 install.ts 里 tar 解析器的对拍实现。fetch 一律注入替身。 */
+   fixture tarball 在测试内用 node:zlib + 手写 ustar 头现场生成（#708 起
+   抽到 helpers/market-fixture.ts 与生命周期测试共用）。fetch 一律注入替身。 */
 import { createHash } from 'node:crypto'
 import { existsSync } from 'node:fs'
 import { mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { gzipSync } from 'node:zlib'
 import { afterEach, describe, expect, it } from 'vitest'
 import {
   MarketError,
@@ -22,96 +20,14 @@ import {
   type FetchImpl,
   type MarketErrorCode,
 } from '../src/index.ts'
-
-/* ---------- fixture：手写 ustar 头生成 .tgz ---------- */
-
-interface TarSpec {
-  name: string
-  data?: string
-  /** '0'=文件 '2'=软链 '5'=目录 …；默认文件。 */
-  typeflag?: string
-}
-
-function tarHeader(name: string, size: number, typeflag: string): Buffer {
-  const block = Buffer.alloc(512)
-  block.write(name, 0, 100, 'utf8')
-  block.write('0000644\0', 100) // mode
-  block.write('0000000\0', 108) // uid
-  block.write('0000000\0', 116) // gid
-  block.write(size.toString(8).padStart(11, '0') + '\0', 124)
-  block.write('00000000000\0', 136) // mtime
-  block.write('        ', 148) // chksum 先占 8 个空格参与求和
-  block.write(typeflag, 156)
-  block.write('ustar\0', 257)
-  block.write('00', 263)
-  let sum = 0
-  for (const byte of block) sum += byte
-  block.write(sum.toString(8).padStart(6, '0') + '\0 ', 148)
-  return block
-}
-
-function makeTgz(specs: TarSpec[]): Buffer {
-  const blocks: Buffer[] = []
-  for (const spec of specs) {
-    const data = Buffer.from(spec.data ?? '', 'utf8')
-    const typeflag = spec.typeflag ?? '0'
-    blocks.push(tarHeader(spec.name, typeflag === '0' ? data.length : 0, typeflag))
-    if (typeflag === '0' && data.length) {
-      const padded = Buffer.alloc(Math.ceil(data.length / 512) * 512)
-      data.copy(padded)
-      blocks.push(padded)
-    }
-  }
-  blocks.push(Buffer.alloc(1024)) // 结尾两个零块
-  return gzipSync(Buffer.concat(blocks))
-}
-
-const HELLO_ENTRY = "module.exports = { name: 'hello', apply() {} }\n"
-
-/** polaris=null 表示整个字段省略（manifest-missing 用例）。 */
-function helloPkg(polaris: Record<string, unknown> | null, description = 'A tiny hello plugin') {
-  const pkg: Record<string, unknown> = { name: 'polaris-plugin-hello', version: '1.0.0', description }
-  if (polaris !== null) pkg.polaris = polaris
-  return JSON.stringify(pkg, null, 2)
-}
-
-const GOOD_POLARIS = {
-  kind: 'panel',
-  entry: 'index.js',
-  description: { zh: '示例面板插件', en: 'An example panel plugin' },
-  permissions: { network: false },
-  runtime: 'in-process',
-  locales: ['zh', 'en'],
-}
-
-function helloTgz(overrides: { polaris?: Record<string, unknown> | null; description?: string; specs?: TarSpec[] }) {
-  return makeTgz(
-    overrides.specs ?? [
-      { name: 'package/package.json', data: helloPkg(overrides.polaris === undefined ? GOOD_POLARIS : overrides.polaris, overrides.description) },
-      { name: 'package/index.js', data: HELLO_ENTRY },
-    ],
-  )
-}
-
-/* ---------- fetch 替身：packument JSON + tarball 二进制 ---------- */
-
-const REGISTRY = 'https://registry.test'
-const TARBALL_URL = `${REGISTRY}/polaris-plugin-hello/-/polaris-plugin-hello-1.0.0.tgz`
-
-function registryFetch(tgz: Buffer, opts: { integrity?: string } = {}): FetchImpl {
-  const integrity = opts.integrity ?? `sha512-${createHash('sha512').update(tgz).digest('base64')}`
-  return (async (input: unknown) => {
-    const url = String(input)
-    if (url === `${REGISTRY}/polaris-plugin-hello`) {
-      return Response.json({
-        name: 'polaris-plugin-hello',
-        versions: { '1.0.0': { dist: { tarball: TARBALL_URL, integrity } } },
-      })
-    }
-    if (url === TARBALL_URL) return new Response(new Uint8Array(tgz))
-    return new Response('not found', { status: 404 })
-  }) as FetchImpl
-}
+import {
+  GOOD_POLARIS,
+  HELLO_ENTRY,
+  REGISTRY,
+  helloPkg,
+  helloTgz,
+  registryFetch,
+} from './helpers/market-fixture.ts'
 
 async function expectCode(promise: Promise<unknown>, code: MarketErrorCode): Promise<void> {
   await expect(promise).rejects.toMatchObject({ name: 'MarketError', code })


### PR DESCRIPTION
Closes #708. Part of #698 (marketplace M2, item PR-6).

Connects the install engine (#701) to the shell: install/enable separation becomes mechanical, and content hashes are enforced at load time.

- IPC: `plugins.market.fetchIndex` / `install` (a job over the existing `job.*` events with four phase points: download / verify / extract / register) / `uninstall` / `getEndpoint` / `setEndpoint` (persisted; official raw-URL default in the shared contract)
- `installAndRegister`: install → `InstallRecord` into the plugin meta store → a **disabled** tree entry pointing at the `file://` bundle; upgrades are single-version — the new version lands fully, the old directory is removed, the entry repoints and is **forced back to disabled** (auto-enabling new code on upgrade would be update-equals-execute, breaking install/enable separation)
- `uninstall` refuses while enabled (as data), otherwise removes entry + directory + record
- hash re-verification is two gates, deliberately: a **startup scan** before the tree mounts (a tampered plugin must not trigger the tree's transactional whole-rollback and take every plugin down — it gets forcibly disabled with the reason surfaced on `plugins.list`) plus an **import guard** covering mid-session tampering when the user hits enable (single-entry rollback only); dev builds downgrade both to warnings
- `ctx.baseUrl` set to `file://<userData>/plugins/` before Loader/SqliteTree mount, matching the vendored loader's relative-specifier resolution; the smoke's offline full loop proved the real dynamic `import()` of an installed bundle works under the CJS bundle (the D1 premise, now exercised)
- kernel official-index constant aligned to this repository

Kernel suite 95 (14 new lifecycle cases incl. upgrade semantics, strict/dev gate behavior, tamper scenarios); desktop smoke runs the entire offline loop (endpoint roundtrip → fetchIndex → install job → enable with real import → refuse-uninstall-while-enabled → disable → uninstall cleanup). Frontend build green post-rebase onto #709; no backend changes.