### PR TITLE
feat: plugin market UI

### DIFF
--- a/src/frontend/src/features/settings/PluginsMarketSection.tsx
+++ b/src/frontend/src/features/settings/PluginsMarketSection.tsx
@@ -1,0 +1,440 @@
+/* 设置页插件 tab 的「市场」分区（#711，插件市场计划 PR-7）。
+
+   数据面全走桌面宿主桥的 plugins.market.* IPC（lib/host.ts，#708/#710）：
+   索引、安装（job 进度）、索引源读写。装/启分离：安装完成的插件是
+   disabled 条目，卡片就地给「启用」按钮（plugins.enable，#706），
+   中间态「已安装，尚未启用」必须让用户看见，不静默代启。 */
+import { useEffect, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { EmptyState } from '../../components/ui/EmptyState';
+import { Icon } from '../../components/ui/Icon';
+import { Modal } from '../../components/ui/Modal';
+import { toast } from '../../components/ui/Toast';
+import { invokeJob } from '../../lib/host-jobs';
+import {
+  enablePlugin,
+  fetchMarketIndex,
+  getMarketEndpoint,
+  listPlugins,
+  setMarketEndpoint,
+  type MarketIndexEntry,
+} from '../../lib/host';
+import { tr } from '../../lib/i18n';
+import {
+  installPhaseText,
+  marketEntryState,
+  marketKindLabel,
+  marketPermissionLabels,
+  marketTierBadge,
+  type InstallProgress,
+  type MarketEntryState,
+} from './marketView';
+
+function errMsg(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+/** 安装进度条：四阶段等分，文字直说当前在干什么。 */
+function InstallProgressBar({ progress }: { progress: InstallProgress }) {
+  const phase = installPhaseText(progress.phase);
+  const pct = progress.total > 0 ? Math.round((progress.done / progress.total) * 100) : 0;
+  return (
+    <div style={{ minWidth: 140 }}>
+      <div style={{ fontSize: 11, color: 'var(--text-3)', marginBottom: 4 }}>
+        {tr(phase.zh, phase.en)}（{progress.done}/{progress.total}）
+      </div>
+      <div style={{ height: 4, borderRadius: 2, background: 'var(--surface-3)', overflow: 'hidden' }}>
+        <div style={{ height: '100%', width: `${pct}%`, background: 'var(--accent)', transition: 'width .3s' }} />
+      </div>
+    </div>
+  );
+}
+
+/** 卡片右侧的状态/动作区：态机四态各有其形，中间态给就地「启用」。 */
+function EntryAction({
+  state,
+  onInstall,
+  onEnable,
+  enabling,
+}: {
+  state: MarketEntryState;
+  onInstall: () => void;
+  onEnable: (pluginId: string) => void;
+  enabling: boolean;
+}) {
+  switch (state.kind) {
+    case 'installing':
+      return <InstallProgressBar progress={state.progress} />;
+    case 'installed-disabled':
+      return (
+        <div className="row gap8" style={{ alignItems: 'center' }}>
+          <span className="pill sm" style={{ background: 'var(--warn-bg)', color: 'var(--warn-tx)' }}>
+            {tr('已安装，尚未启用', 'Installed, not enabled')}
+          </span>
+          <button
+            className="btn btn-primary sm"
+            disabled={enabling}
+            onClick={(e) => {
+              e.stopPropagation();
+              onEnable(state.pluginId);
+            }}
+          >
+            {enabling ? tr('启用中…', 'Enabling…') : tr('启用', 'Enable')}
+          </button>
+        </div>
+      );
+    case 'installed-enabled':
+      return (
+        <span className="pill sm" style={{ background: 'var(--ok-bg)', color: 'var(--ok-tx)' }}>
+          {tr('已启用', 'Enabled')}
+        </span>
+      );
+    case 'not-installed':
+    default:
+      return (
+        <button
+          className="btn btn-soft sm"
+          onClick={(e) => {
+            e.stopPropagation();
+            onInstall();
+          }}
+        >
+          <Icon name="download" size={12} />
+          {tr('安装', 'Install')}
+        </button>
+      );
+  }
+}
+
+function MarketCard({
+  entry,
+  state,
+  enabling,
+  onOpen,
+  onInstall,
+  onEnable,
+}: {
+  entry: MarketIndexEntry;
+  state: MarketEntryState;
+  enabling: boolean;
+  onOpen: () => void;
+  onInstall: () => void;
+  onEnable: (pluginId: string) => void;
+}) {
+  const kind = marketKindLabel(entry.kind);
+  const tier = marketTierBadge(entry.tier);
+  return (
+    // 卡片里嵌着「安装/启用」按钮，外层不能再是 button（HTML 不允许按钮套按钮），
+    // 用 div+role 的可点击卡片，内层按钮 stopPropagation
+    <div
+      className="card"
+      role="button"
+      tabIndex={0}
+      onClick={onOpen}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onOpen();
+        }
+      }}
+      style={{ padding: '12px 14px', cursor: 'pointer' }}
+    >
+      <div className="row gap8" style={{ alignItems: 'center', flexWrap: 'wrap' }}>
+        <span style={{ fontSize: 13, fontWeight: 650 }}>{entry.name}</span>
+        <span className="pill sm" style={{ background: 'var(--accent-soft)', color: 'var(--accent-text)' }}>
+          {tr(kind.zh, kind.en)}
+        </span>
+        <span className="pill sm" style={{ background: tier.bg, color: tier.tx }}>
+          {tr(tier.zh, tier.en)}
+        </span>
+        <span className="pill sm" style={{ background: 'var(--surface-3)', color: 'var(--text-3)' }}>
+          v{entry.version}
+        </span>
+        <div style={{ marginLeft: 'auto', flexShrink: 0 }} onClick={(e) => e.stopPropagation()}>
+          <EntryAction state={state} onInstall={onInstall} onEnable={onEnable} enabling={enabling} />
+        </div>
+      </div>
+      <div style={{ fontSize: 12, color: 'var(--text-2)', marginTop: 6, lineHeight: 1.5 }}>{entry.description}</div>
+      <div style={{ fontSize: 11, color: 'var(--text-3)', marginTop: 6 }}>
+        {tr('发布者', 'Publisher')}：{entry.publisher}
+      </div>
+    </div>
+  );
+}
+
+/** 详情弹窗：全字段 + 权限如实展示（v1 只展示声明，未做强制限制——这句必须说）。 */
+function MarketDetailModal({
+  entry,
+  state,
+  enabling,
+  onClose,
+  onInstall,
+  onEnable,
+}: {
+  entry: MarketIndexEntry;
+  state: MarketEntryState;
+  enabling: boolean;
+  onClose: () => void;
+  onInstall: () => void;
+  onEnable: (pluginId: string) => void;
+}) {
+  const kind = marketKindLabel(entry.kind);
+  const tier = marketTierBadge(entry.tier);
+  const perms = marketPermissionLabels(entry.permissions);
+  return (
+    <Modal
+      open
+      onClose={onClose}
+      width={560}
+      title={entry.name}
+      sub={`v${entry.version} · ${tr(kind.zh, kind.en)} · ${tr('发布者', 'publisher')} ${entry.publisher}`}
+      footer={
+        state.kind === 'installing' ? (
+          <InstallProgressBar progress={state.progress} />
+        ) : state.kind === 'installed-disabled' ? (
+          <>
+            <span className="pill sm" style={{ background: 'var(--warn-bg)', color: 'var(--warn-tx)' }}>
+              {tr('已安装，尚未启用', 'Installed, not enabled')}
+            </span>
+            <button className="btn btn-primary" disabled={enabling} onClick={() => onEnable(state.pluginId)}>
+              {enabling ? tr('启用中…', 'Enabling…') : tr('启用', 'Enable')}
+            </button>
+          </>
+        ) : state.kind === 'installed-enabled' ? (
+          <span className="pill sm" style={{ background: 'var(--ok-bg)', color: 'var(--ok-tx)' }}>
+            {tr('已启用', 'Enabled')}
+          </span>
+        ) : (
+          <button className="btn btn-primary" onClick={onInstall}>
+            <Icon name="download" size={13} />
+            {tr('安装', 'Install')}
+          </button>
+        )
+      }
+    >
+      <p style={{ fontSize: 12.5, color: 'var(--text-2)', lineHeight: 1.6, marginBottom: 12 }}>{entry.description}</p>
+      <div className="row gap8" style={{ alignItems: 'center', flexWrap: 'wrap', marginBottom: 12 }}>
+        <span className="pill sm" style={{ background: tier.bg, color: tier.tx }}>
+          {tr(`质量分级：${tier.zh}`, `Tier: ${tier.en}`)}
+        </span>
+        {entry.badges.map((b) => (
+          <span key={b} className="pill sm" style={{ background: 'var(--surface-3)', color: 'var(--text-2)' }}>
+            {b}
+          </span>
+        ))}
+      </div>
+      <div style={{ fontSize: 12, fontWeight: 600, marginBottom: 6 }}>
+        <Icon name="shield" size={12} style={{ marginRight: 4, verticalAlign: -2 }} />
+        {tr('声明的权限', 'Declared permissions')}
+      </div>
+      <div className="row gap8" style={{ alignItems: 'center', flexWrap: 'wrap' }}>
+        {perms.map((p, i) => (
+          <span key={i} className="pill sm" style={{ background: 'var(--surface-3)', color: 'var(--text-2)' }}>
+            {tr(p.zh, p.en)}
+          </span>
+        ))}
+      </div>
+      <div style={{ fontSize: 11, color: 'var(--text-3)', marginTop: 6, lineHeight: 1.5 }}>
+        {tr(
+          '当前版本仅展示插件声明的权限，尚未做强制限制。',
+          'For now these are declarations only — they are not yet enforced.',
+        )}
+      </div>
+    </Modal>
+  );
+}
+
+export function PluginsMarketSection() {
+  const queryClient = useQueryClient();
+
+  const endpointQuery = useQuery({
+    queryKey: ['plugin-market-endpoint'],
+    queryFn: () => getMarketEndpoint(),
+    retry: false,
+  });
+  const indexQuery = useQuery({
+    queryKey: ['plugin-market-index'],
+    queryFn: () => fetchMarketIndex(),
+    retry: false,
+  });
+  // 已装列表与「已安装」视图共用同一个 queryKey，装完 invalidate 两边同时更新
+  const pluginsQuery = useQuery({
+    queryKey: ['plugins'],
+    queryFn: () => listPlugins(),
+    retry: false,
+  });
+
+  // —— 索引源编辑：草稿跟随查询结果，但用户改过后不再覆盖 ——
+  const [endpointDraft, setEndpointDraft] = useState('');
+  const [draftTouched, setDraftTouched] = useState(false);
+  useEffect(() => {
+    if (!draftTouched && endpointQuery.data) setEndpointDraft(endpointQuery.data.endpoint);
+  }, [draftTouched, endpointQuery.data]);
+
+  const endpointMutation = useMutation({
+    mutationFn: (endpoint: string) => setMarketEndpoint(endpoint),
+    onSuccess: (result) => {
+      if (result) queryClient.setQueryData(['plugin-market-endpoint'], result);
+      setDraftTouched(false); // 让草稿重新跟随保存后的真实值（复位默认时尤其需要）
+      toast(tr('索引源已更新，正在刷新列表', 'Source updated; refreshing list'), 'ok');
+      void queryClient.invalidateQueries({ queryKey: ['plugin-market-index'] });
+    },
+    onError: (e) => toast(`${tr('保存索引源失败', 'Failed to save source')}：${errMsg(e)}`, 'error'),
+  });
+
+  const enableMutation = useMutation({
+    mutationFn: (pluginId: string) => enablePlugin(pluginId),
+    onSuccess: () => {
+      toast(tr('插件已启用', 'Plugin enabled'), 'ok');
+      void queryClient.invalidateQueries({ queryKey: ['plugins'] });
+    },
+    onError: (e) => {
+      toast(`${tr('启用失败', 'Enable failed')}：${errMsg(e)}`, 'error');
+      void queryClient.invalidateQueries({ queryKey: ['plugins'] });
+    },
+  });
+
+  // —— 安装：invoke 返回 jobId，进度经 job.* 事件推（invokeJob 已按 jobId 过滤）——
+  // 按插件名记进行中的进度；组件卸载不取消安装（几秒内的本地任务，跑完
+  // invalidate 自然生效），回调里的 toast/invalidate 不依赖组件存活
+  const [installing, setInstalling] = useState<Record<string, InstallProgress | undefined>>({});
+  const clearInstalling = (name: string) =>
+    setInstalling((prev) => {
+      const next = { ...prev };
+      delete next[name];
+      return next;
+    });
+
+  const startInstall = (entry: MarketIndexEntry) => {
+    if (installing[entry.name]) return; // 防连点：同名安装同时只跑一个
+    setInstalling((prev) => ({ ...prev, [entry.name]: { phase: 'download', done: 0, total: 4 } }));
+    invokeJob(
+      'plugins.market.install',
+      { name: entry.name, version: entry.version },
+      {
+        onProgress: (p) => setInstalling((prev) => ({ ...prev, [entry.name]: p })),
+        onDone: () => {
+          clearInstalling(entry.name);
+          toast(tr(`${entry.name} 已安装，尚未启用`, `${entry.name} installed, not yet enabled`), 'ok');
+          void queryClient.invalidateQueries({ queryKey: ['plugins'] });
+        },
+        onError: (code, message) => {
+          clearInstalling(entry.name);
+          // 错误码如实带上（integrity-mismatch / registry-http…），方便照着报问题
+          toast(`${tr('安装失败', 'Install failed')}（${code}）：${message}`, 'error');
+          void queryClient.invalidateQueries({ queryKey: ['plugins'] });
+        },
+      },
+    );
+  };
+
+  const [openEntry, setOpenEntry] = useState<string | null>(null);
+
+  const entries = indexQuery.data ?? [];
+  const plugins = pluginsQuery.data ?? [];
+  const stateOf = (name: string) => marketEntryState(name, plugins, installing);
+  const enablingId = enableMutation.isPending ? enableMutation.variables : null;
+  const opened = openEntry !== null ? entries.find((e) => e.name === openEntry) : undefined;
+  const endpoint = endpointQuery.data;
+
+  return (
+    <div>
+      {/* —— 索引源设置：小输入框 + 保存/恢复默认 + 刷新 —— */}
+      <div className="row gap8" style={{ alignItems: 'center', flexWrap: 'wrap', marginBottom: 6 }}>
+        <span style={{ fontSize: 12, color: 'var(--text-2)', flexShrink: 0 }}>{tr('索引源', 'Source')}</span>
+        <input
+          className="input"
+          style={{ flex: '1 1 220px', minWidth: 180, fontSize: 12 }}
+          value={endpointDraft}
+          placeholder="https://…"
+          onChange={(e) => {
+            setEndpointDraft(e.target.value);
+            setDraftTouched(true);
+          }}
+        />
+        <button
+          className="btn btn-soft sm"
+          disabled={endpointMutation.isPending || endpointDraft.trim() === ''}
+          onClick={() => endpointMutation.mutate(endpointDraft.trim())}
+        >
+          {endpointMutation.isPending ? tr('保存中…', 'Saving…') : tr('保存', 'Save')}
+        </button>
+        {/* 空串 = 主进程复位官方默认源，前端不需要知道默认值是什么 */}
+        <button
+          className="btn btn-ghost sm"
+          disabled={endpointMutation.isPending || endpoint?.isDefault === true}
+          onClick={() => endpointMutation.mutate('')}
+        >
+          {tr('恢复默认', 'Reset to default')}
+        </button>
+        <button
+          className="btn btn-soft sm"
+          disabled={indexQuery.isFetching}
+          onClick={() => void indexQuery.refetch()}
+        >
+          <Icon name="refresh" size={12} />
+          {indexQuery.isFetching ? tr('刷新中…', 'Refreshing…') : tr('刷新', 'Refresh')}
+        </button>
+      </div>
+      <div style={{ fontSize: 11, color: 'var(--text-3)', marginBottom: 14 }}>
+        {endpoint
+          ? endpoint.isDefault
+            ? tr('当前使用官方源。', 'Using the official source.')
+            : tr('当前使用自定义源。', 'Using a custom source.')
+          : null}
+      </div>
+
+      {indexQuery.isLoading ? (
+        <div className="empty" style={{ padding: 24 }}>{tr('加载中…', 'Loading…')}</div>
+      ) : indexQuery.isError || indexQuery.data == null ? (
+        <EmptyState
+          icon="grid"
+          title={tr('市场列表加载失败', 'Failed to load the market')}
+          desc={`${tr('索引源', 'Source')}：${endpoint?.endpoint ?? tr('（未知）', '(unknown)')} — ${errMsg(indexQuery.error ?? tr('没有返回数据', 'No data returned'))}`}
+          action={
+            <button className="btn btn-soft sm" onClick={() => void indexQuery.refetch()}>
+              {tr('重试', 'Retry')}
+            </button>
+          }
+        />
+      ) : entries.length === 0 ? (
+        <EmptyState
+          icon="grid"
+          title={tr('市场里还没有插件', 'No plugins in the market yet')}
+          desc={tr('这个索引源目前是空的。', 'This source has nothing listed right now.')}
+        />
+      ) : (
+        <div style={{ display: 'grid', gap: 10 }}>
+          {entries.map((entry) => {
+            const state = stateOf(entry.name);
+            return (
+              <MarketCard
+                key={`${entry.name}@${entry.version}`}
+                entry={entry}
+                state={state}
+                enabling={state.kind === 'installed-disabled' && enablingId === state.pluginId}
+                onOpen={() => setOpenEntry(entry.name)}
+                onInstall={() => startInstall(entry)}
+                onEnable={(id) => enableMutation.mutate(id)}
+              />
+            );
+          })}
+        </div>
+      )}
+
+      {opened && (
+        <MarketDetailModal
+          entry={opened}
+          state={stateOf(opened.name)}
+          enabling={
+            stateOf(opened.name).kind === 'installed-disabled' &&
+            enablingId === (stateOf(opened.name) as { pluginId?: string }).pluginId
+          }
+          onClose={() => setOpenEntry(null)}
+          onInstall={() => startInstall(opened)}
+          onEnable={(id) => enableMutation.mutate(id)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/features/settings/PluginsSettings.tsx
+++ b/src/frontend/src/features/settings/PluginsSettings.tsx
@@ -1,14 +1,17 @@
-/* 设置页「插件」tab（#707，插件市场计划 PR-4 的前端面）。
+/* 设置页「插件」tab（#707 列表/启停/配置 + #711 市场分区）。
 
    数据全部走桌面宿主桥的 plugins.* IPC（lib/host.ts，#706）：列表、启停、
-   配置校验/保存、整树导出导入。这个 tab 只在 plugins.manage 能力可用时
-   出现（SettingsPage 里判），所以这里的「桥不可用」分支只是兜底。 */
+   配置校验/保存、整树导出导入、卸载。市场分区（浏览/安装）在
+   PluginsMarketSection，用 Segmented 与已安装列表切换——两边信息密度都
+   不低，纵向堆叠会把「已安装」挤到第二屏。这个 tab 只在 plugins.manage
+   能力可用时出现（SettingsPage 里判），「桥不可用」分支只是兜底。 */
 import { useRef, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { ConfirmModal } from '../../components/ui/ConfirmModal';
 import { EmptyState } from '../../components/ui/EmptyState';
 import { Icon } from '../../components/ui/Icon';
 import { Modal } from '../../components/ui/Modal';
+import { Segmented } from '../../components/ui/Segmented';
 import { Switch } from '../../components/ui/Switch';
 import { toast } from '../../components/ui/Toast';
 import { tr } from '../../lib/i18n';
@@ -19,12 +22,14 @@ import {
   hasHost,
   importPluginTree,
   listPlugins,
+  uninstallMarketPlugin,
   updatePluginConfig,
   validatePluginConfig,
   type PluginEntryInfo,
   type PluginTreeExport,
 } from '../../lib/host';
 import { saveBlob } from '../wiki/shared';
+import { PluginsMarketSection } from './PluginsMarketSection';
 import { parseConfigDraft, parseTreeFile, pluginBadge, validationErrorLines } from './pluginsView';
 
 function errMsg(e: unknown): string {
@@ -34,6 +39,7 @@ function errMsg(e: unknown): string {
 export function PluginsSettings() {
   const queryClient = useQueryClient();
   const bridged = hasHost();
+  const [view, setView] = useState<'installed' | 'market'>('installed');
   const { data, isLoading, isError, refetch } = useQuery({
     queryKey: ['plugins'],
     queryFn: () => listPlugins(),
@@ -118,6 +124,24 @@ export function PluginsSettings() {
     },
   });
 
+  const uninstallMutation = useMutation({
+    // 传条目 id 而不是 name：市场装的插件条目 name 是 file:// 入口 URL，
+    // 包名只有 kernel 的安装记录知道，那边按 id 双解析（resolveInstallName）
+    mutationFn: (p: PluginEntryInfo) => uninstallMarketPlugin(p.id),
+    onSuccess: (result) => {
+      if (!result) return;
+      if (result.ok) {
+        toast(tr('插件已卸载', 'Plugin uninstalled'), 'ok');
+        invalidate();
+      } else {
+        // 拒卸原因是数据不是异常：仍启用 / 不是市场装的，原话如实展示
+        toast(result.message, 'error');
+        invalidate();
+      }
+    },
+    onError: (e) => toast(`${tr('卸载失败', 'Uninstall failed')}：${errMsg(e)}`, 'error'),
+  });
+
   const openConfig = (p: PluginEntryInfo) => {
     setConfigFor(p);
     setDraft(JSON.stringify(p.config ?? {}, null, 2));
@@ -176,19 +200,31 @@ export function PluginsSettings() {
           <Icon name="layers" size={15} style={{ color: 'var(--accent)' }} />
           {tr('插件', 'Plugins')}
         </span>
-        <div className="row gap8">
-          <button className="btn btn-soft sm" disabled={!bridged || exporting} onClick={() => void doExport()}>
-            <Icon name="download" size={12} />
-            {exporting ? tr('导出中…', 'Exporting…') : tr('导出全部配置', 'Export all config')}
-          </button>
-          <button
-            className="btn btn-soft sm"
-            disabled={!bridged || importMutation.isPending}
-            onClick={() => fileInputRef.current?.click()}
-          >
-            <Icon name="file" size={12} />
-            {tr('从文件导入', 'Import from file')}
-          </button>
+        <div className="row gap8" style={{ flexWrap: 'wrap' }}>
+          <Segmented
+            options={[
+              { v: 'installed', label: tr('已安装', 'Installed') },
+              { v: 'market', label: tr('插件市场', 'Market') },
+            ]}
+            value={view}
+            onChange={setView}
+          />
+          {view === 'installed' && (
+            <>
+              <button className="btn btn-soft sm" disabled={!bridged || exporting} onClick={() => void doExport()}>
+                <Icon name="download" size={12} />
+                {exporting ? tr('导出中…', 'Exporting…') : tr('导出全部配置', 'Export all config')}
+              </button>
+              <button
+                className="btn btn-soft sm"
+                disabled={!bridged || importMutation.isPending}
+                onClick={() => fileInputRef.current?.click()}
+              >
+                <Icon name="file" size={12} />
+                {tr('从文件导入', 'Import from file')}
+              </button>
+            </>
+          )}
           <input
             ref={fileInputRef}
             type="file"
@@ -203,10 +239,15 @@ export function PluginsSettings() {
         </div>
       </div>
       <div style={{ fontSize: 11.5, color: 'var(--text-3)', marginBottom: 14, lineHeight: 1.5 }}>
-        {tr(
-          '管理这台电脑上装的插件：随时停用或启用，改配置立即生效。导出的配置文件可以拿到另一台电脑上导入。',
-          'Manage plugins installed on this machine: enable or disable them anytime; config changes apply immediately. Exported config files can be imported on another machine.',
-        )}
+        {view === 'market'
+          ? tr(
+              '从插件市场把插件装到这台电脑上。装好的插件默认不启用，确认没问题后再手动启用。',
+              'Install plugins from the market onto this machine. New installs stay off until you enable them.',
+            )
+          : tr(
+              '管理这台电脑上装的插件：随时停用或启用，改配置立即生效。导出的配置文件可以拿到另一台电脑上导入。',
+              'Manage plugins installed on this machine: enable or disable them anytime; config changes apply immediately. Exported config files can be imported on another machine.',
+            )}
       </div>
 
       {!bridged ? (
@@ -215,6 +256,8 @@ export function PluginsSettings() {
           title={tr('插件管理不可用', 'Plugin management unavailable')}
           desc={tr('这个功能只在桌面客户端里可用。', 'This feature is only available in the desktop app.')}
         />
+      ) : view === 'market' ? (
+        <PluginsMarketSection />
       ) : isLoading ? (
         <div className="empty" style={{ padding: 24 }}>{tr('加载中…', 'Loading…')}</div>
       ) : isError || data == null ? (
@@ -255,6 +298,19 @@ export function PluginsSettings() {
                   <button className="btn btn-soft sm" onClick={() => openConfig(p)}>
                     <Icon name="sliders" size={12} />
                     {tr('配置', 'Configure')}
+                  </button>
+                  {/* 卸载只对停用条目开放；启用中的条目按钮置灰、悬停说明原因，
+                      主进程侧同样拒卸（plugin-enabled），这里只是把话提前说 */}
+                  <button
+                    className="btn btn-ghost sm"
+                    disabled={p.disabled ? uninstallMutation.isPending : true}
+                    title={p.disabled ? undefined : tr('先停用再卸载', 'Disable it first, then uninstall')}
+                    onClick={() => {
+                      if (p.disabled) uninstallMutation.mutate(p);
+                    }}
+                  >
+                    <Icon name="trash" size={12} />
+                    {tr('卸载', 'Uninstall')}
                   </button>
                   <Switch
                     checked={!p.disabled}

--- a/src/frontend/src/features/settings/__tests__/marketView.test.ts
+++ b/src/frontend/src/features/settings/__tests__/marketView.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  installPhaseText,
+  marketEntryState,
+  marketKindLabel,
+  marketPermissionLabels,
+  marketTierBadge,
+  normalizePackageId,
+} from '../marketView';
+
+/* ============================================================
+   设置页插件市场分区的纯函数（#711）：
+   ① 安装态机——未装 → 安装中 → 已装未启 → 已启用，装/启分离的中间态
+      必须显式存在，且安装进行中优先于旧条目的「已装」；
+   ② 徽章/权限/阶段文案映射——未知值原样兜底，权限空声明也要说清。
+   ============================================================ */
+
+const plugins = (
+  ...rows: { id: string; name: string; disabled: boolean }[]
+): { id: string; name: string; disabled: boolean }[] => rows;
+
+// 市场安装登记的树条目真实形状：id=规范化包名，name=file:// 入口 URL
+const FILE_URL = 'file:///plugins/a/1.0.0/index.mjs';
+
+describe('marketEntryState 安装态机', () => {
+  it('列表里没有对应条目、也没在装 → 未安装', () => {
+    expect(marketEntryState('a', plugins(), {})).toEqual({ kind: 'not-installed' });
+    expect(marketEntryState('a', plugins({ id: 'b', name: FILE_URL, disabled: true }), {})).toEqual({
+      kind: 'not-installed',
+    });
+  });
+
+  it('有进行中的安装 → 安装中，且带进度；旧条目仍在列表时安装中优先', () => {
+    const progress = { phase: 'extract', done: 3, total: 4 };
+    expect(marketEntryState('a', plugins(), { a: progress })).toEqual({ kind: 'installing', progress });
+    // 升级/重装：列表里已有旧条目，此刻用户关心进度而不是旧条目开关
+    expect(marketEntryState('a', plugins({ id: 'a', name: FILE_URL, disabled: false }), { a: progress })).toEqual({
+      kind: 'installing',
+      progress,
+    });
+  });
+
+  it('装完（disabled 条目出现、安装记录清掉）→ 已装未启，带插件 id 供就地启用', () => {
+    expect(marketEntryState('a', plugins({ id: 'a', name: FILE_URL, disabled: true }), {})).toEqual({
+      kind: 'installed-disabled',
+      pluginId: 'a',
+    });
+  });
+
+  it('启用后 → 已启用；命中多条时只要有一个没停用就算已启用', () => {
+    expect(marketEntryState('a', plugins({ id: 'a', name: FILE_URL, disabled: false }), {})).toEqual({
+      kind: 'installed-enabled',
+      pluginId: 'a',
+    });
+    expect(
+      marketEntryState(
+        'a',
+        plugins({ id: 'a', name: FILE_URL, disabled: true }, { id: 'a', name: FILE_URL, disabled: false }),
+        {},
+      ),
+    ).toEqual({ kind: 'installed-enabled', pluginId: 'a' });
+  });
+
+  it('scoped 包按规范化 id 匹配：@scope/pkg → scope--pkg（与 kernel packageEntryId 同步）', () => {
+    expect(normalizePackageId('@scope/pkg')).toBe('scope--pkg');
+    expect(normalizePackageId('plain-pkg')).toBe('plain-pkg');
+    expect(
+      marketEntryState('@scope/pkg', plugins({ id: 'scope--pkg', name: FILE_URL, disabled: true }), {}),
+    ).toEqual({ kind: 'installed-disabled', pluginId: 'scope--pkg' });
+  });
+});
+
+describe('徽章与文案映射', () => {
+  it('种类/分级已知值有大白话文案，未知值原样兜底不空白', () => {
+    expect(marketKindLabel('datasource').zh).toBe('数据源');
+    expect(marketKindLabel('something-new')).toEqual({ zh: 'something-new', en: 'something-new' });
+    expect(marketTierBadge('platinum')).toMatchObject({ zh: '白金', bg: 'var(--accent-soft)' });
+    expect(marketTierBadge('mystery').zh).toBe('mystery');
+  });
+
+  it('权限如实映射：声明什么列什么，什么都没声明也要明说', () => {
+    expect(marketPermissionLabels({ network: true, filesystem: true }).map((p) => p.zh)).toEqual([
+      '声明需要联网',
+      '声明需要读写文件',
+    ]);
+    expect(marketPermissionLabels({}).map((p) => p.zh)).toEqual(['未声明任何权限']);
+  });
+
+  it('安装四阶段各有其文案，未知阶段原样展示', () => {
+    expect(['download', 'verify', 'extract', 'register'].map((p) => installPhaseText(p).zh)).toEqual([
+      '下载中',
+      '校验中',
+      '解压中',
+      '登记中',
+    ]);
+    expect(installPhaseText('warmup').zh).toBe('warmup');
+  });
+});

--- a/src/frontend/src/features/settings/marketView.ts
+++ b/src/frontend/src/features/settings/marketView.ts
@@ -1,0 +1,130 @@
+/* 设置页插件市场分区的纯展示逻辑（#711，插件市场计划 PR-7）。
+
+   与 pluginsView.ts 同理由抽出：徽章映射、权限文案、安装态机都不依赖
+   React，抽出来 vitest 直接测；文案一律返回 {zh, en}，渲染处再 tr
+   （模块顶层 tr 不会随语言切换更新，见 lib/i18n 注释）。 */
+
+import type { MarketIndexEntry, PluginEntryInfo } from '../../lib/host';
+
+export interface BiText {
+  zh: string;
+  en: string;
+}
+
+/** 插件种类 → 大白话徽章文案。未知种类原样展示（新种类先上索引也不至于空白）。 */
+export function marketKindLabel(kind: MarketIndexEntry['kind'] | string): BiText {
+  switch (kind) {
+    case 'datasource':
+      return { zh: '数据源', en: 'Data source' };
+    case 'record-kind':
+      return { zh: '记录类型', en: 'Record kind' };
+    case 'runner':
+      return { zh: '运行器', en: 'Runner' };
+    case 'agent-tool':
+      return { zh: 'AI 工具', en: 'Agent tool' };
+    case 'workflow':
+      return { zh: '工作流', en: 'Workflow' };
+    case 'discipline':
+      return { zh: '学科包', en: 'Discipline' };
+    case 'panel':
+      return { zh: '面板', en: 'Panel' };
+    default:
+      return { zh: kind, en: kind };
+  }
+}
+
+export interface TierBadge extends BiText {
+  /** 徽章底色 / 文字色（design token 变量名）。 */
+  bg: string;
+  tx: string;
+}
+
+/** 质量分级 → 徽章。明度上白金最亮眼（accent），铜最低调，与 tier 语义同向。 */
+export function marketTierBadge(tier: MarketIndexEntry['tier'] | string): TierBadge {
+  switch (tier) {
+    case 'platinum':
+      return { zh: '白金', en: 'Platinum', bg: 'var(--accent-soft)', tx: 'var(--accent-text)' };
+    case 'gold':
+      return { zh: '金牌', en: 'Gold', bg: 'var(--warn-bg)', tx: 'var(--warn-tx)' };
+    case 'silver':
+      return { zh: '银牌', en: 'Silver', bg: 'var(--surface-3)', tx: 'var(--text-2)' };
+    case 'bronze':
+      return { zh: '铜牌', en: 'Bronze', bg: 'var(--surface-3)', tx: 'var(--text-3)' };
+    default:
+      return { zh: tier, en: tier, bg: 'var(--surface-3)', tx: 'var(--text-3)' };
+  }
+}
+
+/** 权限声明 → 如实展示的标签列表。v1 只展示声明、不做强制限制（诚实原则），
+    这句话由组件在权限区固定附注，不在这里拼。 */
+export function marketPermissionLabels(permissions: MarketIndexEntry['permissions']): BiText[] {
+  const labels: BiText[] = [];
+  if (permissions.network) labels.push({ zh: '声明需要联网', en: 'Declares network access' });
+  if (permissions.filesystem) labels.push({ zh: '声明需要读写文件', en: 'Declares file access' });
+  if (labels.length === 0) labels.push({ zh: '未声明任何权限', en: 'No permissions declared' });
+  return labels;
+}
+
+/** 安装 job 的四阶段 → 进度文字。阶段名以 desktop 侧 PHASE_STEP 为准
+    （download/verify/extract/register，分母恒为 4）；未知阶段原样展示。 */
+export function installPhaseText(phase: string): BiText {
+  switch (phase) {
+    case 'download':
+      return { zh: '下载中', en: 'Downloading' };
+    case 'verify':
+      return { zh: '校验中', en: 'Verifying' };
+    case 'extract':
+      return { zh: '解压中', en: 'Extracting' };
+    case 'register':
+      return { zh: '登记中', en: 'Registering' };
+    default:
+      return { zh: phase, en: phase };
+  }
+}
+
+export interface InstallProgress {
+  phase: string;
+  done: number;
+  total: number;
+}
+
+/** npm 包名 → 配置树条目 id。必须与 kernel 的 packageEntryId 逐字符同步
+    （src/kernel/src/market/lifecycle.ts）：':' 是 loader 子树分隔符、'/' 读起来
+    像路径，都不能进 id，scoped 包剥 @、'/' 换 '--'。前端不能跨目录 import
+    kernel（镜像惯例，见 lib/host.ts 头注释），所以这里手工镜像一份。 */
+export function normalizePackageId(name: string): string {
+  return name.replace(/^@/, '').replace(/\//g, '--');
+}
+
+/** 市场条目在本机的状态。装/启是两步，中间态（已装未启）必须显式存在。 */
+export type MarketEntryState =
+  | { kind: 'not-installed' }
+  | { kind: 'installing'; progress: InstallProgress }
+  | { kind: 'installed-disabled'; pluginId: string }
+  | { kind: 'installed-enabled'; pluginId: string };
+
+/**
+ * 态机：市场条目名 + 已装插件列表 + 进行中的安装 → 当前状态。
+ *
+ * - 匹配按条目 id：市场安装登记的树条目 name 存的是 file:// 入口 URL，
+ *   id 才是规范化包名（kernel packageEntryId），按 name 匹配永远不中。
+ * - 安装进行中优先于「已装」：升级/重装时列表里可能已有同名旧条目，
+ *   此刻用户关心的是进度，不是旧条目的开关。
+ * - 命中多条时只要有一个没停用就算「已启用」——宁可少催一次「启用」，
+ *   也别在已经跑着的情况下再给启用按钮。
+ */
+export function marketEntryState(
+  entryName: string,
+  installedPlugins: Pick<PluginEntryInfo, 'id' | 'name' | 'disabled'>[],
+  installing: Record<string, InstallProgress | undefined>,
+): MarketEntryState {
+  const progress = installing[entryName];
+  if (progress) return { kind: 'installing', progress };
+  const entryId = normalizePackageId(entryName);
+  const matches = installedPlugins.filter((p) => p.id === entryId);
+  const enabled = matches.find((p) => !p.disabled);
+  if (enabled) return { kind: 'installed-enabled', pluginId: enabled.id };
+  const first = matches[0];
+  if (!first) return { kind: 'not-installed' };
+  return { kind: 'installed-disabled', pluginId: first.id };
+}

--- a/src/frontend/src/lib/host.ts
+++ b/src/frontend/src/lib/host.ts
@@ -316,7 +316,9 @@ export async function installMarketPlugin(
   return (await b.invoke('plugins.market.install', { name, version })) as { jobId: string };
 }
 
-/** 卸载插件；条目仍启用时返回 ok:false（先禁用再卸）。 */
+/** 卸载插件；条目仍启用时返回 ok:false（先禁用再卸）。
+    name 收 npm 包名或树条目 id 皆可（kernel 侧双解析）——前端列表里
+    可靠可得的只有条目 id，传 id 即可。 */
 export async function uninstallMarketPlugin(name: string): Promise<MarketUninstallResult | null> {
   const b = bridge();
   if (!b) return null;

--- a/src/kernel/src/market/lifecycle.ts
+++ b/src/kernel/src/market/lifecycle.ts
@@ -118,6 +118,7 @@ export async function installAndRegister(options: InstallAndRegisterOptions): Pr
 }
 
 export interface UninstallAndRemoveOptions {
+  /** npm 包名或树条目 id（packageEntryId 形态），二者皆可，见 resolveInstallName。 */
   name: string
   pluginsDir: string
   tree: SqliteTree
@@ -130,12 +131,32 @@ export type UninstallOutcome =
   | { ok: false; code: 'plugin-enabled' | 'not-installed'; message: string }
 
 /**
+ * 卸载入口的双解析：输入先当 npm 包名直查安装记录；未命中再扫全部
+ * 安装记录，找 packageEntryId(record.name) 等于输入的那条——即输入是
+ * 树条目 id 的情形。为什么要兼容 id：前端插件列表（plugins.list）里
+ * 可靠可得的只有条目 id（条目 name 存的是 file:// 入口 URL，市场包名
+ * 根本不在里面），而从 id 反推包名对含 '--' 的无 scope 包名有歧义，
+ * 只有持有安装记录的这一侧能无歧义地解析。都未命中时原样返回，
+ * 让后续统一走 not-installed。
+ */
+function resolveInstallName(metaStore: PluginMetaLike, input: string): string {
+  if (readRecord(metaStore, input)) return input
+  for (const key of metaStore.list()) {
+    if (!key.startsWith(INSTALL_RECORD_PREFIX)) continue
+    const record = readRecord(metaStore, key.slice(INSTALL_RECORD_PREFIX.length))
+    if (record && packageEntryId(record.name) === input) return record.name
+  }
+  return input
+}
+
+/**
  * 卸载并拆登记：树条目仍处于启用态时拒绝（用户先禁用、看清后果再卸，
  * 也避免「卸载顺手停掉正在运行的东西」这种隐式副作用）；disabled 或
  * 条目已被用户删掉时：移除树条目 → 删安装目录 → 删记录。
  */
 export async function uninstallAndRemove(options: UninstallAndRemoveOptions): Promise<UninstallOutcome> {
-  const { name, pluginsDir, tree, metaStore } = options
+  const { pluginsDir, tree, metaStore } = options
+  const name = resolveInstallName(metaStore, options.name)
   const entryId = packageEntryId(name)
   const entry = tree.store[entryId]
   const record = readRecord(metaStore, name)

--- a/src/kernel/tests/market-lifecycle.test.ts
+++ b/src/kernel/tests/market-lifecycle.test.ts
@@ -176,6 +176,46 @@ describe('uninstallAndRemove', () => {
     expect(await h.store.load()).toEqual([])
   })
 
+  it('uninstalls by tree entry id, including scoped packages (dual resolution)', async () => {
+    // 前端插件列表里可靠可得的只有条目 id；scoped 包的 id（scope--pkg）
+    // 无法无歧义反推包名，必须由持有安装记录的 kernel 侧解析。
+    // fixture registry 只发 polaris-plugin-hello，scoped 记录手工播种：
+    // uninstallPlugin 的 rm 是 force 的，目录不存在也照常收尾。
+    const h = await bootTree()
+    const pluginsDir = await freshPluginsDir()
+    const scoped = '@zju-real/polaris-plugin-x'
+    const entryId = packageEntryId(scoped) // 'zju-real--polaris-plugin-x'
+    h.metaStore.set(installRecordKey(scoped), {
+      name: scoped,
+      version: '1.0.0',
+      entry: 'index.js',
+      tarballSha512: 'sha512-x',
+      entrySha256: 'x',
+      installedAt: '2026-01-01T00:00:00.000Z',
+      dir: join(pluginsDir, '@zju-real', 'polaris-plugin-x', '1.0.0'),
+    } satisfies InstallRecord)
+    // 与 lifecycle 登记同形：ensureId 尊重传入的 id（create 形参剔除了 id，
+    // 经变量传入绕过字面量多余属性检查，正是 installAndRegister 的写法）
+    const entryOptions = { id: entryId, name: 'file:///nowhere/index.js', disabled: true }
+    await h.tree.create(entryOptions)
+
+    const outcome = await uninstallAndRemove({ name: entryId, pluginsDir, tree: h.tree, metaStore: h.metaStore })
+    expect(outcome).toEqual({ ok: true })
+    expect(h.tree.store[entryId]).toBeUndefined()
+    expect(h.metaStore.get(installRecordKey(scoped))).toBeUndefined()
+
+    // 无 scope 包按 id 卸载同样成立（id 与包名相等，走直查分支）
+    await installHello(h, pluginsDir)
+    const byId = await uninstallAndRemove({
+      name: packageEntryId(NAME),
+      pluginsDir,
+      tree: h.tree,
+      metaStore: h.metaStore,
+    })
+    expect(byId).toEqual({ ok: true })
+    expect(h.metaStore.get(KEY)).toBeUndefined()
+  })
+
   it('reports a plugin that was never installed as data', async () => {
     const h = await bootTree()
     const outcome = await uninstallAndRemove({


### PR DESCRIPTION
Closes #711. Part of #698 (marketplace M2, item PR-7). Frontend plus one cross-layer resolution fix.

- the Plugins tab gains a Segmented "installed / market" split (both views are dense; stacking would push the installed list below the fold); export/import stay on the installed view
- market cards (name/kind/tier/publisher) with a detail modal showing every field and the declared permissions honestly — labels plus an explicit "v1 displays declarations only, nothing is enforced yet" note; empty/offline/error states carry the endpoint and error code verbatim
- install drives the `plugins.market.install` job through the existing `invokeJob` helper (which already handles the events-before-jobId race), four-phase progress; completion lands in the **explicit installed-but-not-enabled intermediate state** with an inline enable action — install/enable separation made visible, not just mechanical
- installed rows gain uninstall (disabled entries only; enabled ones are greyed with a "disable first" hint mirroring the backend refusal); endpoint field with save/refresh and a restore-default that lets the main process own the default
- two same-root-cause resolution bugs found and fixed during review: market entries matched installed plugins by `name`, but market installs register the tree entry with a `file://` name and a normalized-package-name **id** — matching now normalizes (`normalizePackageId`, a documented manual mirror of the kernel's `packageEntryId`); and uninstall passed the `file://` name where the kernel expected a package name — `uninstallAndRemove` now resolves package names first and falls back to scanning install records by entry id (the frontend only has the id reliably; reversing `--` is ambiguous), with the frontend passing `p.id`
- state machine (`marketEntryState`) is a pure function with 8 vitest cases including scoped-package normalization

Kernel suite 96 (one new uninstall-by-entry-id case incl. scoped packages); frontend tsc/build/vitest 172 green; desktop/backend otherwise untouched.