### PR TITLE
feat: seed plugin, market e2e loop, and plugin docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ htmlcov/
 # 只匹配目录，会把软链漏进提交
 node_modules
 dist/
+# 种子插件的 dist 反向入库：安装引擎装的是 npm 包产物（单文件 bundle），
+# e2e fixture 直接拿它打 tarball，不入库则 e2e 凭空依赖一次本地构建
+!plugins/*/dist/
 *.tsbuildinfo
 .vite/
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -96,6 +96,7 @@ looks like; to do real work, [run your own instance](getting-started.md).
 | Configure environment variables and model routing | [Configuration](configuration.md) |
 | Deploy for your lab | [Deployment](deployment.md) |
 | Install the desktop client | [Desktop](desktop.md) |
+| Extend the desktop app with plugins | [Plugins](plugins.md) |
 
 > [!TIP]
 > New to Polaris? The shortest useful path is: [get it running](getting-started.md), create a

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,88 @@
+# Plugins (desktop)
+
+The desktop app has a plugin kernel (`@polaris/kernel`, a [cordis](https://github.com/cordiverse/cordis)
+runtime hosted in the Electron main process). Plugins extend the shell without forking it: a
+plugin is an npm package that the app downloads, verifies, and mounts into its config tree.
+This page documents the loading model, the marketplace, and how to write a plugin. The seed
+plugin [`plugins/polaris-plugin-hello`](https://github.com/ZJU-REAL/Polaris/tree/main/plugins/polaris-plugin-hello)
+is the living template — everything below is demonstrated there and exercised end-to-end in CI.
+
+## The loading model: the config tree is the source of truth
+
+The kernel does not load "whatever is on disk". A persistent **config tree** (stored in the
+app's local SQLite database) is the single source of truth for what runs: each entry names a
+plugin (a built-in `cordis:*` specifier or a `file://` bundle), carries its config, and has a
+`disabled` flag. On startup the loader mounts exactly this tree; enabling, disabling,
+configuring, and removing a plugin are all edits to the tree. The tree survives restarts, can
+be exported and imported whole, and a last-good snapshot guards imports.
+
+Consequences worth internalizing:
+
+- deleting files on disk does not "uninstall" a plugin — the tree entry is authoritative, and
+  a missing or altered file makes the entry fail verification (below) rather than vanish;
+- state you see in the plugins list is runtime fact (`active` / `disabled` / `error` /
+  `pending`), while the `disabled` flag is persistent user intent.
+
+## Install and enable are separate
+
+Installing a plugin **never runs its code**. The install pipeline downloads the exact listed
+version from the npm registry, verifies the tarball against its `sha512` integrity, extracts
+it, validates the `polaris` manifest, and registers a **disabled** entry in the config tree.
+Only when the user explicitly enables the entry is the bundle imported and applied. Upgrades
+follow the same rule: a newly installed version is forced back to disabled, so "update"
+can never mean "silently execute new code".
+
+Uninstalling is refused while the entry is enabled — disable first, then uninstall removes
+the tree entry, the installed files, and the install record.
+
+## Content-hash pinning
+
+Trust binds to content, not names. At install time the kernel records:
+
+- the tarball's `sha512` (the same SRI value npm publishes), and
+- the entry file's `sha256`.
+
+The entry hash is re-verified at two points: a **startup scan** before the tree mounts
+(a tampered plugin is forcibly disabled with a note, without disturbing other plugins), and
+an **enable-time guard** covering files modified mid-session. A hash mismatch means the
+plugin will not load until it is reinstalled. Patching an installed bundle in place is
+therefore never a supported workflow — publish a new version.
+
+## The market: index and endpoint
+
+What is *listed* lives in one JSON file — [`market/index.json`](https://github.com/ZJU-REAL/Polaris/blob/main/market/index.json)
+in the main repository, documented in [`market/README.md`](https://github.com/ZJU-REAL/Polaris/blob/main/market/README.md).
+The app fetches it from a configurable **endpoint** (default: the file's raw GitHub URL), so
+mirrors and self-hosted indexes are first-class; an empty value in settings resets to the
+official source. Distribution itself is plain npm: the index says *what* is listed, the npm
+registry serves the bytes, and the client verifies them independently.
+
+Each entry carries a kind, publisher, declared permissions, a quality tier
+(bronze/silver/gold/platinum), and governance badges such as `official`.
+
+## Writing a plugin from the template
+
+1. **Copy the template.** Start from
+   [`plugins/polaris-plugin-hello`](https://github.com/ZJU-REAL/Polaris/tree/main/plugins/polaris-plugin-hello);
+   its README documents every manifest field. The plugin itself is a cordis plugin: an object
+   with `name`, an optional schemastery `Config`, and `apply(ctx, config)` that registers
+   recyclable effects (`ctx.effect`) and services (`ctx.provide`).
+2. **Fill in the `polaris` manifest** in `package.json`: `kind` (one of the seven extension
+   points), `entry` (path to the bundle), honest `permissions`, and descriptions.
+3. **Bundle to a single file.** `entry` must point at one self-contained JS file; there is no
+   `npm install` at runtime, so bundle every dependency (the template uses esbuild →
+   `dist/index.js`). Installs with a multi-file entry are rejected.
+4. **Publish to npm and get listed.** Clients install the exact version named by the index
+   entry and verify integrity end-to-end.
+
+## v1 boundaries, stated plainly
+
+- **Permissions are display-only.** The `permissions` declaration is shown to users as-is and
+  linted, but not enforced by a sandbox yet. Treat it as an honesty contract.
+- **Official source only.** Until the contract freezes, `market/index.json` accepts entries
+  reviewed and published by the Polaris team; third-party listing PRs are closed.
+- **Single-file bundle is a hard rule.** The kernel resolves nothing at load time.
+- **In-process runtime only.** The manifest admits `python-edge` / `subprocess-mcp` /
+  `container` runtimes for forward compatibility, but v1 only loads `in-process` bundles.
+- **Descriptions are linted** against instruction-like text and invisible unicode (metadata
+  is agent-visible; prompt-injection via descriptions is a real attack class).

--- a/market/index.json
+++ b/market/index.json
@@ -1,4 +1,18 @@
 {
   "schemaVersion": 1,
-  "plugins": []
+  "plugins": [
+    {
+      "name": "polaris-plugin-hello",
+      "version": "0.1.0",
+      "kind": "panel",
+      "description": "A minimal hello panel plugin for Polaris, published as the official template for third-party plugins",
+      "publisher": "Polaris official",
+      "permissions": {
+        "network": false,
+        "filesystem": false
+      },
+      "tier": "bronze",
+      "badges": ["official"]
+    }
+  ]
 }

--- a/plugins/polaris-plugin-hello/README.md
+++ b/plugins/polaris-plugin-hello/README.md
@@ -1,0 +1,80 @@
+# polaris-plugin-hello
+
+The official Polaris seed plugin. It does one visible thing — expose a
+`hello-panel` service with a configurable greeting — and exists so that:
+
+- the marketplace always has at least one installable, end-to-end-tested entry;
+- third-party developers have a copyable template that already passes every
+  rule the install engine enforces.
+
+To write your own plugin, copy this directory and work through the sections
+below. The full loading model is documented in
+[`docs/plugins.md`](../../docs/plugins.md).
+
+## Anatomy
+
+```
+polaris-plugin-hello/
+├── package.json   # npm metadata + the `polaris` manifest (see table below)
+├── src/index.ts   # plugin source: Config schema + apply(ctx, config)
+└── dist/index.js  # single-file bundle — the ONLY thing the kernel loads
+```
+
+A plugin is a [cordis](https://github.com/cordiverse/cordis) plugin: an object
+with `name`, an optional schemastery `Config`, and `apply(ctx, config)`. Inside
+`apply` you have three basic moves, all demonstrated in `src/index.ts`:
+
+| move | call | what it is for |
+| --- | --- | --- |
+| validate config | `export const Config = Schema.object({...})` | the settings UI renders and validates config through this schema |
+| own a side effect | `ctx.effect(() => { ...; return cleanup })` | anything you start must be returned as a cleanup; disable/uninstall disposes it |
+| expose a service | `ctx.provide('hello-panel', service)` | other plugins consume it via `ctx.get(...)`; unmounted with your plugin |
+
+## The `polaris` manifest
+
+Lives in `package.json` under the `polaris` key. Validated on install; an
+invalid manifest fails the install and leaves nothing on disk.
+
+| field | required | meaning |
+| --- | --- | --- |
+| `kind` | yes | one of `datasource` \| `record-kind` \| `runner` \| `agent-tool` \| `workflow` \| `discipline` \| `panel` |
+| `entry` | yes | package-relative path to the **single-file bundle** (here `dist/index.js`) |
+| `description` | no | string, or `{ zh, en }` record; linted on install (no imperative/injection text, no invisible unicode) |
+| `permissions` | no | declared summary (`network` / `filesystem`); **shown to users as-is, not enforced in v1** — declare honestly |
+| `runtime` | no | `in-process` (the only runtime actually loaded in v1) \| `python-edge` \| `subprocess-mcp` \| `container` |
+| `locales` | no | locales your strings cover, e.g. `["zh", "en"]` |
+
+## Hard rules the install engine enforces
+
+1. **Single-file bundle.** `entry` must point at one self-contained JS file
+   (Obsidian model). The kernel imports it directly — there is no `npm install`
+   step and no `node_modules` at runtime, so bundle every runtime dependency
+   (this template bundles schemastery via esbuild; that is why all deps are
+   `devDependencies`). Build with:
+
+   ```sh
+   pnpm run build   # esbuild src/index.ts --bundle → dist/index.js (CJS)
+   ```
+
+2. **Install and enable are separate.** Installing writes files and registers a
+   *disabled* config-tree entry; not one line of your code runs until the user
+   enables it. Never rely on install-time side effects.
+
+3. **Trust is pinned to content hashes, not names.** At install time the engine
+   records the tarball's sha512 and the entry file's sha256. The entry hash is
+   re-verified before every load — if the file on disk changes, the plugin is
+   forcibly disabled with a warning. Ship a new version instead of patching
+   files in place.
+
+4. **Descriptions are linted.** `description` (both the npm one and the
+   manifest one) must not contain instruction-like text ("ignore previous…",
+   "you must…") or invisible unicode. This guards agent-facing metadata against
+   prompt injection; plain factual descriptions always pass.
+
+## Publishing
+
+npm handles distribution: `npm publish` the package, then get it listed in the
+official index (`market/index.json` in the main repo — see the policy in
+`market/README.md`; until the marketplace opens, listing is by Polaris team
+review only). Clients install the exact listed version from the npm registry
+and verify it against `dist.integrity`.

--- a/plugins/polaris-plugin-hello/dist/index.js
+++ b/plugins/polaris-plugin-hello/dist/index.js
@@ -1,0 +1,895 @@
+"use strict";
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from2, except, desc) => {
+  if (from2 && typeof from2 === "object" || typeof from2 === "function") {
+    for (let key of __getOwnPropNames(from2))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from2[key], enumerable: !(desc = __getOwnPropDesc(from2, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+// src/index.ts
+var index_exports = {};
+__export(index_exports, {
+  Config: () => Config,
+  default: () => index_default
+});
+module.exports = __toCommonJS(index_exports);
+
+// ../../vendor/deepseek-cordis/cosmokit/src/misc.ts
+function isNullable(value) {
+  return value === null || value === void 0;
+}
+function isPlainObject(data) {
+  return data && typeof data === "object" && !Array.isArray(data);
+}
+function filterKeys(object, filter) {
+  return Object.fromEntries(Object.entries(object).filter(([key, value]) => filter(key, value)));
+}
+function mapValues(object, transform) {
+  return Object.fromEntries(Object.entries(object).map(([key, value]) => [key, transform(value, key)]));
+}
+function pick(source, keys, forced) {
+  if (!keys) return { ...source };
+  const result = {};
+  for (const key of keys) {
+    if (forced || source[key] !== void 0) result[key] = source[key];
+  }
+  return result;
+}
+
+// ../../vendor/deepseek-cordis/cosmokit/src/types.ts
+function is(type, value) {
+  if (arguments.length === 1) return (value2) => is(type, value2);
+  return type in globalThis && value instanceof globalThis[type] || Object.prototype.toString.call(value).slice(8, -1) === type;
+}
+function isArrayBufferLike(value) {
+  return is("ArrayBuffer", value) || is("SharedArrayBuffer", value);
+}
+function isArrayBufferSource(value) {
+  return isArrayBufferLike(value) || ArrayBuffer.isView(value);
+}
+var Binary;
+((Binary2) => {
+  Binary2.is = isArrayBufferLike;
+  Binary2.isSource = isArrayBufferSource;
+  function fromSource(source) {
+    if (ArrayBuffer.isView(source)) {
+      return source.buffer.slice(source.byteOffset, source.byteOffset + source.byteLength);
+    } else {
+      return source;
+    }
+  }
+  Binary2.fromSource = fromSource;
+  function toBase64(source) {
+    source = fromSource(source);
+    if (typeof Buffer !== "undefined") {
+      return Buffer.from(source).toString("base64");
+    }
+    let binary = "";
+    const bytes = new Uint8Array(source);
+    for (let i = 0; i < bytes.byteLength; i++) {
+      binary += String.fromCharCode(bytes[i]);
+    }
+    return btoa(binary);
+  }
+  Binary2.toBase64 = toBase64;
+  function fromBase64(source) {
+    if (typeof Buffer !== "undefined") return fromSource(Buffer.from(source, "base64"));
+    return Uint8Array.from(atob(source), (c) => c.charCodeAt(0));
+  }
+  Binary2.fromBase64 = fromBase64;
+  function toHex(source) {
+    source = fromSource(source);
+    if (typeof Buffer !== "undefined") return Buffer.from(source).toString("hex");
+    return Array.from(new Uint8Array(source), (byte) => byte.toString(16).padStart(2, "0")).join("");
+  }
+  Binary2.toHex = toHex;
+  function fromHex(source) {
+    if (typeof Buffer !== "undefined") return fromSource(Buffer.from(source, "hex"));
+    const hex = source.length % 2 === 0 ? source : source.slice(0, source.length - 1);
+    const buffer = [];
+    for (let i = 0; i < hex.length; i += 2) {
+      buffer.push(parseInt(`${hex[i]}${hex[i + 1]}`, 16));
+    }
+    return Uint8Array.from(buffer).buffer;
+  }
+  Binary2.fromHex = fromHex;
+})(Binary || (Binary = {}));
+var base64ToArrayBuffer = Binary.fromBase64;
+var arrayBufferToBase64 = Binary.toBase64;
+var hexToArrayBuffer = Binary.fromHex;
+var arrayBufferToHex = Binary.toHex;
+function clone(source, refs = /* @__PURE__ */ new Map()) {
+  if (!source || typeof source !== "object") return source;
+  if (is("Date", source)) return new Date(source.valueOf());
+  if (is("RegExp", source)) return new RegExp(source.source, source.flags);
+  if (isArrayBufferLike(source)) return source.slice(0);
+  if (ArrayBuffer.isView(source)) return source.buffer.slice(source.byteOffset, source.byteOffset + source.byteLength);
+  const cached = refs.get(source);
+  if (cached) return cached;
+  if (Array.isArray(source)) {
+    const result2 = [];
+    refs.set(source, result2);
+    source.forEach((value, index) => {
+      result2[index] = Reflect.apply(clone, null, [value, refs]);
+    });
+    return result2;
+  }
+  const result = Object.create(Object.getPrototypeOf(source));
+  refs.set(source, result);
+  for (const key of Reflect.ownKeys(source)) {
+    const descriptor = { ...Reflect.getOwnPropertyDescriptor(source, key) };
+    if ("value" in descriptor) {
+      descriptor.value = Reflect.apply(clone, null, [descriptor.value, refs]);
+    }
+    Reflect.defineProperty(result, key, descriptor);
+  }
+  return result;
+}
+function deepEqual(a, b, strict) {
+  if (a === b) return true;
+  if (!strict && isNullable(a) && isNullable(b)) return true;
+  if (typeof a !== typeof b) return false;
+  if (typeof a !== "object") return false;
+  if (!a || !b) return false;
+  function check(test, then) {
+    return test(a) ? test(b) ? then(a, b) : false : test(b) ? false : void 0;
+  }
+  return check(Array.isArray, (a2, b2) => a2.length === b2.length && a2.every((item, index) => deepEqual(item, b2[index]))) ?? check(is("Date"), (a2, b2) => a2.valueOf() === b2.valueOf()) ?? check(is("RegExp"), (a2, b2) => a2.source === b2.source && a2.flags === b2.flags) ?? check(isArrayBufferLike, (a2, b2) => {
+    if (a2.byteLength !== b2.byteLength) return false;
+    const viewA = new Uint8Array(a2);
+    const viewB = new Uint8Array(b2);
+    for (let i = 0; i < viewA.length; i++) {
+      if (viewA[i] !== viewB[i]) return false;
+    }
+    return true;
+  }) ?? Object.keys({ ...a, ...b }).every((key) => deepEqual(a[key], b[key], strict));
+}
+
+// ../../vendor/deepseek-cordis/cosmokit/src/time.ts
+var Time;
+((Time2) => {
+  Time2.millisecond = 1;
+  Time2.second = 1e3;
+  Time2.minute = Time2.second * 60;
+  Time2.hour = Time2.minute * 60;
+  Time2.day = Time2.hour * 24;
+  Time2.week = Time2.day * 7;
+  let timezoneOffset = (/* @__PURE__ */ new Date()).getTimezoneOffset();
+  function setTimezoneOffset(offset) {
+    timezoneOffset = offset;
+  }
+  Time2.setTimezoneOffset = setTimezoneOffset;
+  function getTimezoneOffset() {
+    return timezoneOffset;
+  }
+  Time2.getTimezoneOffset = getTimezoneOffset;
+  function getDateNumber(date2 = /* @__PURE__ */ new Date(), offset) {
+    if (typeof date2 === "number") date2 = new Date(date2);
+    if (offset === void 0) offset = timezoneOffset;
+    return Math.floor((date2.valueOf() / Time2.minute - offset) / 1440);
+  }
+  Time2.getDateNumber = getDateNumber;
+  function fromDateNumber(value, offset) {
+    const date2 = new Date(value * Time2.day);
+    if (offset === void 0) offset = timezoneOffset;
+    return new Date(+date2 + offset * Time2.minute);
+  }
+  Time2.fromDateNumber = fromDateNumber;
+  const numeric = /\d+(?:\.\d+)?/.source;
+  const timeRegExp = new RegExp(`^${[
+    "w(?:eek(?:s)?)?",
+    "d(?:ay(?:s)?)?",
+    "h(?:our(?:s)?)?",
+    "m(?:in(?:ute)?(?:s)?)?",
+    "s(?:ec(?:ond)?(?:s)?)?"
+  ].map((unit) => `(${numeric}${unit})?`).join("")}$`);
+  function parseTime(source) {
+    const capture = timeRegExp.exec(source);
+    if (!capture) return 0;
+    return (parseFloat(capture[1]) * Time2.week || 0) + (parseFloat(capture[2]) * Time2.day || 0) + (parseFloat(capture[3]) * Time2.hour || 0) + (parseFloat(capture[4]) * Time2.minute || 0) + (parseFloat(capture[5]) * Time2.second || 0);
+  }
+  Time2.parseTime = parseTime;
+  function parseDate(date2) {
+    const parsed = parseTime(date2);
+    if (parsed) {
+      date2 = Date.now() + parsed;
+    } else if (/^\d{1,2}(:\d{1,2}){1,2}$/.test(date2)) {
+      date2 = `${(/* @__PURE__ */ new Date()).toLocaleDateString()}-${date2}`;
+    } else if (/^\d{1,2}-\d{1,2}-\d{1,2}(:\d{1,2}){1,2}$/.test(date2)) {
+      date2 = `${(/* @__PURE__ */ new Date()).getFullYear()}-${date2}`;
+    }
+    return date2 ? new Date(date2) : /* @__PURE__ */ new Date();
+  }
+  Time2.parseDate = parseDate;
+  function format(ms) {
+    const abs = Math.abs(ms);
+    if (abs >= Time2.day - Time2.hour / 2) {
+      return Math.round(ms / Time2.day) + "d";
+    } else if (abs >= Time2.hour - Time2.minute / 2) {
+      return Math.round(ms / Time2.hour) + "h";
+    } else if (abs >= Time2.minute - Time2.second / 2) {
+      return Math.round(ms / Time2.minute) + "m";
+    } else if (abs >= Time2.second) {
+      return Math.round(ms / Time2.second) + "s";
+    }
+    return ms + "ms";
+  }
+  Time2.format = format;
+  function toDigits(source, length = 2) {
+    return source.toString().padStart(length, "0");
+  }
+  Time2.toDigits = toDigits;
+  function template(template2, time = /* @__PURE__ */ new Date()) {
+    return template2.replace("yyyy", time.getFullYear().toString()).replace("yy", time.getFullYear().toString().slice(2)).replace("MM", toDigits(time.getMonth() + 1)).replace("dd", toDigits(time.getDate())).replace("hh", toDigits(time.getHours())).replace("mm", toDigits(time.getMinutes())).replace("ss", toDigits(time.getSeconds())).replace("SSS", toDigits(time.getMilliseconds(), 3));
+  }
+  Time2.template = template;
+})(Time || (Time = {}));
+
+// ../../vendor/deepseek-cordis/schemastery/src/index.ts
+var kSchema = Symbol.for("schemastery");
+var kValidationError = Symbol.for("ValidationError");
+globalThis.__schemastery_index__ ??= 0;
+globalThis.__schemastery_refs__ = void 0;
+var ValidationError = class extends TypeError {
+  constructor(message, options) {
+    let prefix = "$";
+    for (const segment of options.path || []) {
+      if (typeof segment === "string") {
+        prefix += "." + segment;
+      } else if (typeof segment === "number") {
+        prefix += "[" + segment + "]";
+      } else if (typeof segment === "symbol") {
+        prefix += `[Symbol(${segment.toString()})]`;
+      }
+    }
+    if (prefix.startsWith(".")) prefix = prefix.slice(1);
+    super((prefix === "$" ? "" : `${prefix} `) + message);
+    this.options = options;
+  }
+  name = "ValidationError";
+  static is(error) {
+    return !!error?.[kValidationError];
+  }
+};
+Object.defineProperty(ValidationError.prototype, kValidationError, {
+  value: true
+});
+var Schema = function(options) {
+  const schema = function(data, options2 = {}) {
+    return Schema.resolve(data, schema, options2)[0];
+  };
+  if (options.refs) {
+    const refs = mapValues(options.refs, (options2) => new Schema(options2));
+    const getRef = (uid) => refs[uid];
+    for (const key in refs) {
+      const options2 = refs[key];
+      options2.sKey = getRef(options2.sKey);
+      options2.inner = getRef(options2.inner);
+      options2.list = options2.list && options2.list.map(getRef);
+      options2.dict = options2.dict && mapValues(options2.dict, getRef);
+    }
+    return refs[options.uid];
+  }
+  Object.assign(schema, options);
+  if (typeof schema.callback === "string") {
+    try {
+      schema.callback = new Function("return " + schema.callback)();
+    } catch {
+    }
+  }
+  Object.defineProperty(schema, "uid", { value: globalThis.__schemastery_index__++ });
+  Object.setPrototypeOf(schema, Schema.prototype);
+  schema.meta ||= {};
+  schema.toString = schema.toString.bind(schema);
+  return schema;
+};
+Schema.prototype = Object.create(Function.prototype);
+Schema.prototype[kSchema] = true;
+Object.defineProperty(Schema.prototype, "~standard", {
+  get() {
+    return {
+      version: 1,
+      vendor: "schemastery",
+      validate: (value) => {
+        try {
+          return { value: Schema.resolve(value, this, {})[0] };
+        } catch (error) {
+          if (ValidationError.is(error)) {
+            return { issues: [{ message: error.message, path: error.options.path }] };
+          }
+          throw error;
+        }
+      }
+    };
+  }
+});
+Schema.ValidationError = ValidationError;
+Schema.prototype.toJSON = function toJSON() {
+  if (globalThis.__schemastery_refs__) {
+    globalThis.__schemastery_refs__[this.uid] ??= JSON.parse(JSON.stringify({ ...this }));
+    return this.uid;
+  }
+  globalThis.__schemastery_refs__ = { [this.uid]: { ...this } };
+  globalThis.__schemastery_refs__[this.uid] = JSON.parse(JSON.stringify({ ...this }));
+  const result = { uid: this.uid, refs: globalThis.__schemastery_refs__ };
+  globalThis.__schemastery_refs__ = void 0;
+  return result;
+};
+Schema.prototype.set = function set(key, value) {
+  this.dict[key] = value;
+  return this;
+};
+Schema.prototype.push = function push(value) {
+  this.list.push(value);
+  return this;
+};
+function mergeDesc(original, messages) {
+  const result = typeof original === "string" ? { "": original } : { ...original };
+  for (const locale in messages) {
+    const value = messages[locale];
+    if (value?.$description || value?.$desc) {
+      result[locale] = value.$description || value.$desc;
+    } else if (typeof value === "string") {
+      result[locale] = value;
+    }
+  }
+  return result;
+}
+function getInner(value) {
+  return value?.$value ?? value?.$inner;
+}
+function extractKeys(data) {
+  return filterKeys(data ?? {}, (key) => !key.startsWith("$"));
+}
+Schema.prototype.i18n = function i18n(messages) {
+  const schema = Schema(this);
+  const desc = mergeDesc(schema.meta.description, messages);
+  if (Object.keys(desc).length) schema.meta.description = desc;
+  if (schema.dict) {
+    schema.dict = mapValues(schema.dict, (inner, key) => {
+      return inner.i18n(mapValues(messages, (data) => getInner(data)?.[key] ?? data?.[key]));
+    });
+  }
+  if (schema.list) {
+    schema.list = schema.list.map((inner, index) => {
+      return inner.i18n(mapValues(messages, (data = {}) => {
+        if (Array.isArray(getInner(data))) return getInner(data)[index];
+        if (Array.isArray(data)) return data[index];
+        return extractKeys(data);
+      }));
+    });
+  }
+  if (schema.inner) {
+    schema.inner = schema.inner.i18n(mapValues(messages, (data) => {
+      if (getInner(data)) return getInner(data);
+      return extractKeys(data);
+    }));
+  }
+  if (schema.sKey) {
+    schema.sKey = schema.sKey.i18n(mapValues(messages, (data) => data?.$key));
+  }
+  return schema;
+};
+Schema.prototype.extra = function extra(key, value) {
+  const schema = Schema(this);
+  schema.meta = { ...schema.meta, [key]: value };
+  return schema;
+};
+for (const key of ["required", "disabled", "collapse", "hidden", "loose"]) {
+  Object.assign(Schema.prototype, {
+    [key](value = true) {
+      const schema = Schema(this);
+      schema.meta = { ...schema.meta, [key]: value };
+      return schema;
+    }
+  });
+}
+Schema.prototype.deprecated = function deprecated() {
+  const schema = Schema(this);
+  schema.meta.badges ||= [];
+  schema.meta.badges.push({ text: "deprecated", type: "danger" });
+  return schema;
+};
+Schema.prototype.experimental = function experimental() {
+  const schema = Schema(this);
+  schema.meta.badges ||= [];
+  schema.meta.badges.push({ text: "experimental", type: "warning" });
+  return schema;
+};
+Schema.prototype.pattern = function pattern(regexp) {
+  const schema = Schema(this);
+  const pattern2 = pick(regexp, ["source", "flags"]);
+  schema.meta = { ...schema.meta, pattern: pattern2 };
+  return schema;
+};
+Schema.prototype.simplify = function simplify(value) {
+  if (deepEqual(value, this.meta.default, this.type === "dict")) return null;
+  if (isNullable(value)) return value;
+  if (this.type === "object" || this.type === "dict") {
+    const result = {};
+    for (const key in value) {
+      const schema = this.type === "object" ? this.dict[key] : this.inner;
+      const item = schema?.simplify(value[key]);
+      if (this.type === "dict" || !isNullable(item)) result[key] = item;
+    }
+    if (deepEqual(result, this.meta.default, this.type === "dict")) return null;
+    return result;
+  } else if (this.type === "array" || this.type === "tuple") {
+    const result = [];
+    value.forEach((value2, index) => {
+      const schema = this.type === "array" ? this.inner : this.list[index];
+      const item = schema ? schema.simplify(value2) : value2;
+      result.push(item);
+    });
+    return result;
+  } else if (this.type === "intersect") {
+    const result = {};
+    for (const item of this.list) {
+      Object.assign(result, item.simplify(value));
+    }
+    return result;
+  } else if (this.type === "union") {
+    for (const schema of this.list) {
+      try {
+        Schema.resolve(value, schema, {});
+        return schema.simplify(value);
+      } catch {
+      }
+    }
+  }
+  return value;
+};
+Schema.prototype.toString = function toString(inline) {
+  return formatters[this.type]?.(this, inline) ?? `Schema<${this.type}>`;
+};
+Schema.prototype.role = function role(role, extra2) {
+  const schema = Schema(this);
+  schema.meta = { ...schema.meta, role, extra: extra2 };
+  return schema;
+};
+for (const key of ["default", "link", "comment", "description", "max", "min", "step"]) {
+  Object.assign(Schema.prototype, {
+    [key](value) {
+      const schema = Schema(this);
+      schema.meta = { ...schema.meta, [key]: value };
+      return schema;
+    }
+  });
+}
+var resolvers = {};
+Schema.extend = function extend(type, resolve2) {
+  resolvers[type] = resolve2;
+};
+Schema.resolve = function resolve(data, schema, options = {}, strict = false) {
+  if (!schema) return [data];
+  if (options.ignore?.(data, schema)) return [data];
+  if (isNullable(data) && schema.type !== "lazy") {
+    if (schema.meta.required) throw new ValidationError(`missing required value`, options);
+    let current = schema;
+    let fallback = schema.meta.default;
+    while (current?.type === "intersect" && isNullable(fallback)) {
+      current = current.list[0];
+      fallback = current?.meta.default;
+    }
+    if (isNullable(fallback)) return [data];
+    data = clone(fallback);
+  }
+  const callback = resolvers[schema.type];
+  if (!callback) throw new ValidationError(`unsupported type "${schema.type}"`, options);
+  try {
+    return callback(data, schema, options, strict);
+  } catch (error) {
+    if (!schema.meta.loose) throw error;
+    return [schema.meta.default];
+  }
+};
+Schema.from = function from(source) {
+  if (isNullable(source)) {
+    return Schema.any();
+  } else if (["string", "number", "boolean"].includes(typeof source)) {
+    return Schema.const(source).required();
+  } else if (source[kSchema]) {
+    return source;
+  } else if (typeof source === "function") {
+    switch (source) {
+      case String:
+        return Schema.string().required();
+      case Number:
+        return Schema.number().required();
+      case Boolean:
+        return Schema.boolean().required();
+      case Function:
+        return Schema.function().required();
+      default:
+        return Schema.is(source).required();
+    }
+  } else {
+    throw new TypeError(`cannot infer schema from ${source}`);
+  }
+};
+Schema.lazy = function lazy(builder) {
+  const toJSON2 = () => {
+    if (!schema.inner[kSchema]) {
+      schema.inner = schema.builder();
+      schema.inner.meta = { ...schema.meta, ...schema.inner.meta };
+    }
+    return schema.inner.toJSON();
+  };
+  const schema = new Schema({ type: "lazy", builder, inner: { toJSON: toJSON2 } });
+  return schema;
+};
+Schema.natural = function natural() {
+  return Schema.number().step(1).min(0);
+};
+Schema.percent = function percent() {
+  return Schema.number().step(0.01).min(0).max(1).role("slider");
+};
+Schema.date = function date() {
+  return Schema.union([
+    Schema.is(Date),
+    Schema.transform(Schema.string().role("datetime"), (value, options) => {
+      const date2 = new Date(value);
+      if (isNaN(+date2)) throw new ValidationError(`invalid date "${value}"`, options);
+      return date2;
+    }, true)
+  ]);
+};
+Schema.regExp = function regExp(flag = "") {
+  return Schema.union([
+    Schema.is(RegExp),
+    Schema.transform(Schema.string().role("regexp", { flag }), (value, options) => {
+      try {
+        return new RegExp(value, flag);
+      } catch (e) {
+        throw new ValidationError(e.message, options);
+      }
+    }, true)
+  ]);
+};
+Schema.arrayBuffer = function arrayBuffer(encoding) {
+  return Schema.union([
+    Schema.is(ArrayBuffer),
+    Schema.is(SharedArrayBuffer),
+    Schema.transform(Schema.any(), (value, options) => {
+      if (Binary.isSource(value)) return Binary.fromSource(value);
+      throw new ValidationError(`expected ArrayBufferSource but got ${value}`, options);
+    }, true),
+    ...encoding ? [Schema.transform(Schema.string(), (value, options) => {
+      try {
+        return encoding === "base64" ? Binary.fromBase64(value) : Binary.fromHex(value);
+      } catch (e) {
+        throw new ValidationError(e.message, options);
+      }
+    }, true)] : []
+  ]);
+};
+Schema.extend("lazy", (data, schema, options, strict) => {
+  if (!schema.inner[kSchema]) {
+    schema.inner = schema.builder();
+    schema.inner.meta = { ...schema.meta, ...schema.inner.meta };
+  }
+  return Schema.resolve(data, schema.inner, options, strict);
+});
+Schema.extend("any", (data) => {
+  return [data];
+});
+Schema.extend("never", (data, _, options) => {
+  throw new ValidationError(`expected nullable but got ${data}`, options);
+});
+Schema.extend("const", (data, { value }, options) => {
+  if (deepEqual(data, value)) return [value];
+  throw new ValidationError(`expected ${value} but got ${data}`, options);
+});
+function checkWithinRange(data, meta, description, options, skipMin = false) {
+  const { max = Infinity, min = -Infinity } = meta;
+  if (data > max) throw new ValidationError(`expected ${description} <= ${max} but got ${data}`, options);
+  if (data < min && !skipMin) throw new ValidationError(`expected ${description} >= ${min} but got ${data}`, options);
+}
+Schema.extend("string", (data, { meta }, options) => {
+  if (typeof data !== "string") throw new ValidationError(`expected string but got ${data}`, options);
+  if (meta.pattern) {
+    const regexp = new RegExp(meta.pattern.source, meta.pattern.flags);
+    if (!regexp.test(data)) throw new ValidationError(`expect string to match regexp ${regexp}`, options);
+  }
+  checkWithinRange(data.length, meta, "string length", options);
+  return [data];
+});
+function decimalShift(data, digits) {
+  const str = data.toString();
+  if (str.includes("e")) return data * Math.pow(10, digits);
+  const index = str.indexOf(".");
+  if (index === -1) return data * Math.pow(10, digits);
+  const frac = str.slice(index + 1);
+  const integer = str.slice(0, index);
+  if (frac.length <= digits) return +(integer + frac.padEnd(digits, "0"));
+  return +(integer + frac.slice(0, digits) + "." + frac.slice(digits));
+}
+function isMultipleOf(data, min, step) {
+  step = Math.abs(step);
+  if (!/^\d+\.\d+$/.test(step.toString())) {
+    return (data - min) % step === 0;
+  }
+  const index = step.toString().indexOf(".");
+  const digits = step.toString().slice(index + 1).length;
+  return Math.abs(decimalShift(data, digits) - decimalShift(min, digits)) % decimalShift(step, digits) === 0;
+}
+Schema.extend("number", (data, { meta }, options) => {
+  if (typeof data !== "number") throw new ValidationError(`expected number but got ${data}`, options);
+  checkWithinRange(data, meta, "number", options);
+  const { step } = meta;
+  if (step && !isMultipleOf(data, meta.min ?? 0, step)) {
+    throw new ValidationError(`expected number multiple of ${step} but got ${data}`, options);
+  }
+  return [data];
+});
+Schema.extend("boolean", (data, _, options) => {
+  if (typeof data === "boolean") return [data];
+  throw new ValidationError(`expected boolean but got ${data}`, options);
+});
+Schema.extend("bitset", (data, { bits, meta }, options) => {
+  let value = 0, keys = [];
+  if (typeof data === "number") {
+    value = data;
+    for (const key in bits) {
+      if (data & bits[key]) {
+        keys.push(key);
+      }
+    }
+  } else if (Array.isArray(data)) {
+    keys = data;
+    for (const key of keys) {
+      if (typeof key !== "string") throw new ValidationError(`expected string but got ${key}`, options);
+      if (key in bits) value |= bits[key];
+    }
+  } else {
+    throw new ValidationError(`expected number or array but got ${data}`, options);
+  }
+  if (value === meta.default) return [value];
+  return [value, keys];
+});
+Schema.extend("function", (data, _, options) => {
+  if (typeof data === "function") return [data];
+  throw new ValidationError(`expected function but got ${data}`, options);
+});
+Schema.extend("is", (data, { constructor }, options) => {
+  if (typeof constructor === "function") {
+    if (data instanceof constructor) return [data];
+    throw new ValidationError(`expected ${constructor.name} but got ${data}`, options);
+  } else {
+    if (isNullable(data)) {
+      throw new ValidationError(`expected ${constructor} but got ${data}`, options);
+    }
+    let prototype = Object.getPrototypeOf(data);
+    while (prototype) {
+      if (prototype.constructor?.name === constructor) return [data];
+      prototype = Object.getPrototypeOf(prototype);
+    }
+    throw new ValidationError(`expected ${constructor} but got ${data}`, options);
+  }
+});
+function property(data, key, schema, options) {
+  try {
+    const [value, adapted] = Schema.resolve(data[key], schema, {
+      ...options,
+      path: [...options.path || [], key]
+    });
+    if (adapted !== void 0) data[key] = adapted;
+    return value;
+  } catch (e) {
+    if (!options?.autofix) throw e;
+    delete data[key];
+    return schema.meta.default;
+  }
+}
+Schema.extend("array", (data, { inner, meta }, options) => {
+  if (!Array.isArray(data)) throw new ValidationError(`expected array but got ${data}`, options);
+  checkWithinRange(data.length, meta, "array length", options, !isNullable(inner.meta.default));
+  return [data.map((_, index) => property(data, index, inner, options))];
+});
+Schema.extend("dict", (data, { inner, sKey }, options, strict) => {
+  if (!isPlainObject(data)) throw new ValidationError(`expected object but got ${data}`, options);
+  const result = {};
+  for (const key in data) {
+    let rKey;
+    try {
+      rKey = Schema.resolve(key, sKey, options)[0];
+    } catch (error) {
+      if (strict) continue;
+      throw error;
+    }
+    result[rKey] = property(data, key, inner, options);
+    data[rKey] = data[key];
+    if (key !== rKey) delete data[key];
+  }
+  return [result];
+});
+Schema.extend("tuple", (data, { list }, options, strict) => {
+  if (!Array.isArray(data)) throw new ValidationError(`expected array but got ${data}`, options);
+  const result = list.map((inner, index) => property(data, index, inner, options));
+  if (strict) return [result];
+  result.push(...data.slice(list.length));
+  return [result];
+});
+function merge(result, data) {
+  for (const key in data) {
+    if (key in result) continue;
+    result[key] = data[key];
+  }
+}
+Schema.extend("object", (data, { dict }, options, strict) => {
+  if (!isPlainObject(data)) throw new ValidationError(`expected object but got ${data}`, options);
+  const result = {};
+  for (const key in dict) {
+    const value = property(data, key, dict[key], options);
+    if (!isNullable(value) || key in data) {
+      result[key] = value;
+    }
+  }
+  if (!strict) merge(result, data);
+  return [result];
+});
+Schema.extend("union", (data, { list, toString: toString2 }, options, strict) => {
+  const messages = [];
+  for (const inner of list) {
+    try {
+      return Schema.resolve(data, inner, options, strict);
+    } catch (error) {
+      messages.push(error);
+    }
+  }
+  throw new ValidationError(`expected ${toString2()} but got ${JSON.stringify(data)}`, options);
+});
+Schema.extend("intersect", (data, { list, toString: toString2 }, options, strict) => {
+  if (!list.length) return [data];
+  let result;
+  for (const inner of list) {
+    const value = Schema.resolve(data, inner, options, true)[0];
+    if (isNullable(value)) continue;
+    if (isNullable(result)) {
+      result = value;
+    } else if (typeof result !== typeof value) {
+      throw new ValidationError(`expected ${toString2()} but got ${JSON.stringify(data)}`, options);
+    } else if (typeof value === "object") {
+      merge(result ??= {}, value);
+    } else if (result !== value) {
+      throw new ValidationError(`expected ${toString2()} but got ${JSON.stringify(data)}`, options);
+    }
+  }
+  if (!strict && isPlainObject(data)) merge(result, data);
+  return [result];
+});
+Schema.extend("transform", (data, { inner, callback, preserve }, options) => {
+  const [result, adapted = data] = Schema.resolve(data, inner, options, true);
+  if (preserve) {
+    return [callback(result)];
+  } else {
+    return [callback(result), callback(adapted)];
+  }
+});
+var formatters = {};
+function defineMethod(name, keys, format) {
+  formatters[name] = format;
+  Object.assign(Schema, {
+    [name](...args) {
+      const schema = new Schema({ type: name });
+      keys.forEach((key, index) => {
+        switch (key) {
+          case "sKey":
+            schema.sKey = args[index] ?? Schema.string();
+            break;
+          case "inner":
+            schema.inner = Schema.from(args[index]);
+            break;
+          case "list":
+            schema.list = args[index].map(Schema.from);
+            break;
+          case "dict":
+            schema.dict = mapValues(args[index], Schema.from);
+            break;
+          case "bits": {
+            schema.bits = {};
+            for (const key2 in args[index]) {
+              if (typeof args[index][key2] !== "number") continue;
+              schema.bits[key2] = args[index][key2];
+            }
+            break;
+          }
+          case "callback": {
+            const callback = schema.callback = args[index];
+            callback["toJSON"] ||= () => callback.toString();
+            break;
+          }
+          case "constructor": {
+            const constructor = schema.constructor = args[index];
+            if (typeof constructor === "function") {
+              ;
+              constructor["toJSON"] ||= () => constructor["name"];
+            }
+            break;
+          }
+          default:
+            schema[key] = args[index];
+        }
+      });
+      if (name === "object" || name === "dict") {
+        schema.meta.default = {};
+      } else if (name === "array" || name === "tuple") {
+        schema.meta.default = [];
+      } else if (name === "bitset") {
+        schema.meta.default = 0;
+      }
+      return schema;
+    }
+  });
+}
+defineMethod("is", ["constructor"], ({ constructor }) => {
+  if (typeof constructor === "function") {
+    return constructor.name;
+  } else {
+    return constructor;
+  }
+});
+defineMethod("any", [], () => "any");
+defineMethod("never", [], () => "never");
+defineMethod("const", ["value"], ({ value }) => typeof value === "string" ? JSON.stringify(value) : value);
+defineMethod("string", [], () => "string");
+defineMethod("number", [], () => "number");
+defineMethod("boolean", [], () => "boolean");
+defineMethod("bitset", ["bits"], () => "bitset");
+defineMethod("function", [], () => "function");
+defineMethod("array", ["inner"], ({ inner }) => `${inner.toString(true)}[]`);
+defineMethod("dict", ["inner", "sKey"], ({ inner, sKey }) => `{ [key: ${sKey.toString()}]: ${inner.toString()} }`);
+defineMethod("tuple", ["list"], ({ list }) => `[${list.map((inner) => inner.toString()).join(", ")}]`);
+defineMethod("object", ["dict"], ({ dict }) => {
+  if (Object.keys(dict).length === 0) return "{}";
+  return `{ ${Object.entries(dict).map(([key, inner]) => {
+    return `${key}${inner.meta.required ? "" : "?"}: ${inner.toString()}`;
+  }).join(", ")} }`;
+});
+defineMethod("union", ["list"], ({ list }, inline) => {
+  const result = list.map(({ toString: format }) => format()).join(" | ");
+  return inline ? `(${result})` : result;
+});
+defineMethod("intersect", ["list"], ({ list }) => {
+  return `${list.map((inner) => inner.toString(true)).join(" & ")}`;
+});
+defineMethod("transform", ["inner", "callback", "preserve"], ({ inner }, isInner) => inner.toString(isInner));
+var src_default = Schema;
+
+// src/index.ts
+var Config = src_default.object({
+  greeting: src_default.string().description("\u95EE\u5019\u8BED\u524D\u7F00 / greeting prefix")
+});
+var hello = {
+  name: "polaris-plugin-hello",
+  Config,
+  apply(ctx, config) {
+    const greeting = config.greeting ?? "Hello";
+    ctx.effect(() => {
+      console.log(`[polaris-plugin-hello] panel ready (greeting=${greeting})`);
+      return () => {
+        console.log("[polaris-plugin-hello] panel disposed");
+      };
+    }, "hello panel lifecycle");
+    const service = {
+      message: () => `${greeting} from Polaris!`
+    };
+    ctx.provide("hello-panel", service);
+  }
+};
+var index_default = hello;
+// Annotate the CommonJS export names for ESM import in node:
+0 && (module.exports = {
+  Config
+});

--- a/plugins/polaris-plugin-hello/package.json
+++ b/plugins/polaris-plugin-hello/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "polaris-plugin-hello",
+  "version": "0.1.0",
+  "description": "A minimal hello panel plugin for Polaris, published as the official template for third-party plugins",
+  "license": "MIT",
+  "homepage": "https://github.com/ZJU-REAL/Polaris",
+  "main": "dist/index.js",
+  "files": [
+    "dist"
+  ],
+  "polaris": {
+    "kind": "panel",
+    "entry": "dist/index.js",
+    "description": {
+      "zh": "示例面板插件：提供一个可配置问候语的 hello 服务",
+      "en": "An example panel plugin exposing a hello service with a configurable greeting"
+    },
+    "permissions": {
+      "network": false,
+      "filesystem": false
+    },
+    "runtime": "in-process",
+    "locales": [
+      "zh",
+      "en"
+    ]
+  },
+  "scripts": {
+    "build": "esbuild src/index.ts --bundle --platform=node --target=node22 --format=cjs --outfile=dist/index.js",
+    "lint": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@deepseek-ai/cordis": "workspace:*",
+    "@deepseek-ai/schemastery": "workspace:*",
+    "@types/node": "^22.0.0",
+    "esbuild": "^0.24.0",
+    "typescript": "^5.5.4"
+  }
+}

--- a/plugins/polaris-plugin-hello/src/index.ts
+++ b/plugins/polaris-plugin-hello/src/index.ts
@@ -1,0 +1,60 @@
+/* ============================================================
+   polaris-plugin-hello（#712）：官方种子插件，兼第三方开发者模板。
+
+   刻意保持「最小但完整」：一个 schemastery Config、一次 ctx.effect、
+   一次 ctx.provide——这三样分别示范配置校验、可回收副作用、服务挂出，
+   是 Polaris 插件的三种基本动作。没有任何网络/文件系统访问，与
+   manifest 里 permissions 全 false 的声明一致。
+
+   为什么依赖全是 devDependencies：入口必须是单文件 bundle（安装引擎
+   的硬规则，kernel 零依赖解析、装完即可 import），schemastery 会被
+   esbuild 打进 dist/index.js，运行时不存在 node_modules。
+   ============================================================ */
+
+import type { Context } from '@deepseek-ai/cordis'
+import Schema from '@deepseek-ai/schemastery'
+
+export interface HelloConfig {
+  /** 问候语前缀，默认 Hello。 */
+  greeting?: string
+}
+
+/** schemastery Config：设置页的配置表单与 plugins.updateConfig 的
+    校验都读它。字段全部可选——模板插件必须能零配置启用。 */
+export const Config: Schema<HelloConfig> = Schema.object({
+  greeting: Schema.string().description('问候语前缀 / greeting prefix'),
+})
+
+/** hello-panel 服务的形状：panel kind 在 v1 只有语义（清单/市场里的
+    归类），实际可观测面就是这个服务与 registry 里的插件名额。 */
+export interface HelloPanelService {
+  message(): string
+}
+
+const hello = {
+  name: 'polaris-plugin-hello',
+
+  Config,
+
+  apply(ctx: Context, config: HelloConfig): void {
+    const greeting = config.greeting ?? 'Hello'
+
+    // effect：副作用要可回收。禁用/卸载时 fiber dispose 会执行返回的
+    // 清理函数——日志本身没有句柄要收，这里示范的是形状
+    ctx.effect(() => {
+      console.log(`[polaris-plugin-hello] panel ready (greeting=${greeting})`)
+      return () => {
+        console.log('[polaris-plugin-hello] panel disposed')
+      }
+    }, 'hello panel lifecycle')
+
+    // 服务挂出：其他插件可 ctx.get('hello-panel') 消费；随 fiber 生命
+    // 周期自动挂上/摘下
+    const service: HelloPanelService = {
+      message: () => `${greeting} from Polaris!`,
+    }
+    ctx.provide('hello-panel', service)
+  },
+}
+
+export default hello

--- a/plugins/polaris-plugin-hello/tsconfig.json
+++ b/plugins/polaris-plugin-hello/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "noEmit": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,24 @@ importers:
         specifier: ^5.5.4
         version: 5.9.3
 
+  plugins/polaris-plugin-hello:
+    devDependencies:
+      '@deepseek-ai/cordis':
+        specifier: workspace:*
+        version: link:../../vendor/deepseek-cordis/cordis
+      '@deepseek-ai/schemastery':
+        specifier: workspace:*
+        version: link:../../vendor/deepseek-cordis/schemastery
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.1
+      esbuild:
+        specifier: ^0.24.0
+        version: 0.24.2
+      typescript:
+        specifier: ^5.5.4
+        version: 5.9.3
+
   spikes/p0/1-legacy-chain:
     dependencies:
       '@polaris/kernel':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - src/frontend
   - src/desktop
   - src/kernel
+  - plugins/*
   - vendor/deepseek-cordis/*
   - vendor/contract-smoke
   - spikes/p0/*

--- a/src/desktop/e2e/e2e.ts
+++ b/src/desktop/e2e/e2e.ts
@@ -4,12 +4,16 @@
    运行时才暴露的链路整条走一遍。与 smoke.ts 互补：smoke 在 Electron
    进程内做白盒断言，这里从进程外像用户一样操作 UI。
 
-   两个断言组：
+   三个断言组：
    - A「壳与免登录」：需要 docker 与 polaris-api-test:local 镜像，
      门控照抄冒烟——设 POLARIS_E2E_ENGINE=1 且镜像存在才跑，否则
      打明确日志后 skip（CI 无镜像时仍然全绿）。
    - B「无引擎回落」：不依赖 docker，任何机器必跑。不设引擎 env 起壳，
      应停在服务器配置页而不是崩溃。
+   - C「插件市场闭环」（#712）：不依赖 docker，任何机器必跑。本进程起
+     一个 127.0.0.1 的 http 替身充当索引源与 npm registry，经渲染进程的
+     window.polaris（生产 IPC 路径）驱动种子插件走完「换源 → 拉索引 →
+     安装 → 启用 → 拒卸 → 禁用 → 卸载」全链路。
 
    并行安全：容器名与端口都随机化（经 POLARIS_DESKTOP_ENGINE_CONTAINER /
    _PORT 覆盖默认值），同机的其他 docker 套件或手动实例互不干扰；
@@ -20,11 +24,19 @@
    ============================================================ */
 
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 import { _electron, type ElectronApplication, type Page } from 'playwright-core';
+
+// tar/tgz 生成逻辑复用 kernel 测试的共用 fixture（#710 抽出）：类型仅
+// import type，esbuild 打包 e2e 时只会带上纯函数的打包器本体
+// eslint-disable-next-line import/no-relative-packages
+import { makeTgz } from '../../kernel/tests/helpers/market-fixture';
 
 // Node 里 require('electron') 拿到的是可执行文件路径（字符串），类型声明
 // 描述的是渲染/主进程 API，所以这里显式断言。
@@ -35,6 +47,18 @@ const MAIN = join(__dirname, 'main.cjs');
 // __dirname = src/desktop/dist → 仓库的 src/backend（与 smoke.ts 同一推导）
 const BACKEND_DIR = join(__dirname, '..', '..', 'backend');
 const ENGINE_IMAGE = 'polaris-api-test:local';
+// 仓库根与种子插件目录（组 C 的 fixture 源头：真实包产物 + 真实索引文件）
+const REPO_ROOT = join(__dirname, '..', '..', '..');
+const HELLO_DIR = join(REPO_ROOT, 'plugins', 'polaris-plugin-hello');
+
+/** 渲染进程里 preload 暴露的桥的最小形状（类型只在 e2e 侧擦除前有效）。 */
+interface PolarisBridge {
+  polaris: {
+    invoke: (method: string, params?: unknown) => Promise<unknown>;
+    subscribe: (handler: (event: unknown) => void) => number;
+    unsubscribe: (id: number) => void;
+  };
+}
 
 const problems: string[] = [];
 
@@ -241,9 +265,223 @@ async function groupNoEngine(): Promise<void> {
   }
 }
 
+
+/* ---------------- 组 C：插件市场闭环（必跑） ---------------- */
+
+async function groupMarket(): Promise<void> {
+  console.log('\n插件市场闭环');
+
+  // fixture 全部取自「将来真上架的那份东西」：种子插件的真实 dist（已
+  // 入库）打成 npm 规范形状的 tarball，索引就是仓内 market/index.json
+  // 原文——断言对象是真实产物链，而不是另一套测试专用副本。
+  const pkgRaw = readFileSync(join(HELLO_DIR, 'package.json'), 'utf8');
+  const pkg = JSON.parse(pkgRaw) as { name: string; version: string };
+  const entryJs = readFileSync(join(HELLO_DIR, 'dist', 'index.js'), 'utf8');
+  const readme = readFileSync(join(HELLO_DIR, 'README.md'), 'utf8');
+  const indexRaw = readFileSync(join(REPO_ROOT, 'market', 'index.json'), 'utf8');
+
+  const tgz = makeTgz([
+    { name: 'package/package.json', data: pkgRaw },
+    { name: 'package/dist/index.js', data: entryJs },
+    { name: 'package/README.md', data: readme },
+  ]);
+  const integrity = `sha512-${createHash('sha512').update(tgz).digest('base64')}`;
+
+  // 本地 http 替身，一个进程同演索引源与 npm registry。为什么不走 #710
+  // 的 setMarketFetchForTesting：那是主进程 bundle 内的模块级变量，从
+  // e2e 进程够不到。索引源经生产路径换源（setEndpoint 指到 127.0.0.1）；
+  // registry 域名是安装引擎里写死的，靠下面 app.evaluate 在主进程包一层
+  // fetch 重定向。
+  let port = 0;
+  const server = createServer((req, res) => {
+    const url = req.url ?? '';
+    if (url === '/index.json') {
+      res.setHeader('content-type', 'application/json');
+      res.end(indexRaw);
+      return;
+    }
+    if (url === `/registry/${pkg.name}`) {
+      res.setHeader('content-type', 'application/json');
+      res.end(
+        JSON.stringify({
+          name: pkg.name,
+          versions: {
+            [pkg.version]: {
+              dist: {
+                tarball: `http://127.0.0.1:${port}/registry/${pkg.name}/-/${pkg.name}-${pkg.version}.tgz`,
+                integrity,
+              },
+            },
+          },
+        }),
+      );
+      return;
+    }
+    if (url === `/registry/${pkg.name}/-/${pkg.name}-${pkg.version}.tgz`) {
+      res.end(tgz);
+      return;
+    }
+    res.statusCode = 404;
+    res.end('not found');
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  port = (server.address() as AddressInfo).port;
+
+  const userData = mkdtempSync(join(tmpdir(), 'polaris-e2e-c-'));
+  let app: ElectronApplication | null = null;
+
+  try {
+    const indexEntry = (JSON.parse(indexRaw) as { plugins: { name: string; version: string }[] }).plugins.find(
+      (entry) => entry.name === pkg.name,
+    );
+    check(
+      'market/index.json 收录 hello 且版本与仓内包一致',
+      indexEntry != null && indexEntry.version === pkg.version,
+      `index=${JSON.stringify(indexEntry)} pkg=${pkg.version}`,
+    );
+
+    const r = await launch(launchEnv({ POLARIS_USER_DATA_DIR: userData }));
+    app = r.app;
+    const { page } = r;
+    await page.waitForFunction('typeof window.polaris?.invoke === "function"', undefined, { timeout: 30_000 });
+
+    // 安装引擎固定打 https://registry.npmjs.org：在主进程的全局 fetch 外
+    // 包一层，把该域名重定向到本地替身。只改本次 e2e 会话的运行时全局，
+    // 生产代码零改动；索引拉取等其余 URL 原样放行。
+    await app.evaluate((_electron, arg) => {
+      const original = globalThis.fetch;
+      const prefix = 'https://registry.npmjs.org/';
+      globalThis.fetch = ((input: unknown, init?: unknown) => {
+        const url = typeof input === 'string' ? input : String((input as { url?: unknown }).url ?? input);
+        if (url.startsWith(prefix)) {
+          return original(`http://127.0.0.1:${arg.port}/registry/${url.slice(prefix.length)}`, init as RequestInit);
+        }
+        return original(input as RequestInfo, init as RequestInit);
+      }) as typeof fetch;
+    }, { port });
+
+    const endpoint = `http://127.0.0.1:${port}/index.json`;
+    const ep = (await page.evaluate(
+      (u) => (window as unknown as PolarisBridge).polaris.invoke('plugins.market.setEndpoint', { endpoint: u }),
+      endpoint,
+    )) as { endpoint: string; isDefault: boolean };
+    check('setEndpoint 指向本地索引源', ep.endpoint === endpoint && !ep.isDefault, JSON.stringify(ep));
+
+    const entries = (await page.evaluate(() =>
+      (window as unknown as PolarisBridge).polaris.invoke('plugins.market.fetchIndex'),
+    )) as { name: string; version: string; tier: string; badges: string[] }[];
+    const listed = Array.isArray(entries) ? entries.find((entry) => entry.name === pkg.name) : undefined;
+    check(
+      'fetchIndex 经校验路径见到 hello（bronze/official）',
+      listed != null && listed.version === pkg.version && listed.tier === 'bronze' && listed.badges.includes('official'),
+      JSON.stringify(entries).slice(0, 300),
+    );
+
+    // 安装是长任务：先订阅事件再 invoke（进度可能赶在 invoke 返回之前），
+    // 等到本 job 的 job.done / job.error 或 60s 超时
+    const install = (await page.evaluate(async (arg) => {
+      const w = window as unknown as PolarisBridge;
+      const events: { type: string; jobId?: string; phase?: string; result?: unknown; code?: string; message?: string }[] = [];
+      const sub = w.polaris.subscribe((event) => {
+        const e = event as { type?: unknown };
+        if (typeof e.type === 'string' && e.type.startsWith('job.')) events.push(event as (typeof events)[number]);
+      });
+      try {
+        const { jobId } = (await w.polaris.invoke('plugins.market.install', arg)) as { jobId: string };
+        const deadline = Date.now() + 60_000;
+        for (;;) {
+          const finished = events.find((e) => e.jobId === jobId && (e.type === 'job.done' || e.type === 'job.error'));
+          if (finished || Date.now() > deadline) {
+            return {
+              finished: finished ?? null,
+              phases: events.filter((e) => e.jobId === jobId && e.type === 'job.progress').map((e) => e.phase),
+            };
+          }
+          await new Promise((resolve) => setTimeout(resolve, 100));
+        }
+      } finally {
+        w.polaris.unsubscribe(sub);
+      }
+    }, { name: pkg.name, version: pkg.version })) as {
+      finished: { type: string; result?: { entryId?: string }; code?: string; message?: string } | null;
+      phases: (string | undefined)[];
+    };
+    check('install job 以 job.done 收尾', install.finished?.type === 'job.done', JSON.stringify(install.finished));
+    check('job.done 带回条目 id', install.finished?.result?.entryId === pkg.name, JSON.stringify(install.finished?.result));
+    check(
+      '四个安装阶段全部上报进度',
+      ['download', 'verify', 'extract', 'register'].every((phase) => install.phases.includes(phase)),
+      `phases=${install.phases.join(',')}`,
+    );
+    check(
+      '安装物落盘 userData/plugins/<name>/<version>/',
+      existsSync(join(userData, 'plugins', pkg.name, pkg.version, 'dist', 'index.js')),
+    );
+
+    const listPlugins = async (): Promise<{ id: string; name: string; state: string }[]> =>
+      (await page.evaluate(() =>
+        (window as unknown as PolarisBridge).polaris.invoke('plugins.list'),
+      )) as { id: string; name: string; state: string }[];
+    const installedInfo = (await listPlugins()).find((info) => info.id === pkg.name);
+    check(
+      'plugins.list 出现 disabled 条目（装/启分离）',
+      installedInfo != null && installedInfo.state === 'disabled' && installedInfo.name.startsWith('file://'),
+      JSON.stringify(installedInfo),
+    );
+
+    const pluginCount = async (): Promise<number> =>
+      (((await page.evaluate(() =>
+        (window as unknown as PolarisBridge).polaris.invoke('kernel.status'),
+      )) as { plugins?: number }).plugins ?? 0);
+    const countBefore = await pluginCount();
+
+    const enabled = (await page.evaluate(
+      (id) => (window as unknown as PolarisBridge).polaris.invoke('plugins.enable', { id }),
+      pkg.name,
+    )) as { state: string };
+    check('enable 后条目 active（file:// 动态 import 真实走通）', enabled.state === 'active', JSON.stringify(enabled));
+    const countAfter = await pluginCount();
+    check('hello 占据 registry 名额（kernel.status 可观测）', countAfter > countBefore, `plugins ${countBefore} -> ${countAfter}`);
+
+    const refused = (await page.evaluate(
+      (name) => (window as unknown as PolarisBridge).polaris.invoke('plugins.market.uninstall', { name }),
+      pkg.name,
+    )) as { ok: boolean; code?: string };
+    check('enabled 状态拒卸（错误作为数据返回）', refused.ok === false && refused.code === 'plugin-enabled', JSON.stringify(refused));
+
+    const disabledInfo = (await page.evaluate(
+      (id) => (window as unknown as PolarisBridge).polaris.invoke('plugins.disable', { id }),
+      pkg.name,
+    )) as { state: string };
+    check('disable 停回 disabled', disabledInfo.state === 'disabled', JSON.stringify(disabledInfo));
+
+    const removed = (await page.evaluate(
+      (name) => (window as unknown as PolarisBridge).polaris.invoke('plugins.market.uninstall', { name }),
+      pkg.name,
+    )) as { ok: boolean };
+    check('禁用后卸载成功', removed.ok === true, JSON.stringify(removed));
+    check('卸载后树条目消失', !(await listPlugins()).some((info) => info.id === pkg.name));
+    check('卸载后盘面清空', !existsSync(join(userData, 'plugins', pkg.name)));
+    // 再卸一次报 not-installed：该分支要求树条目与安装记录**都**不在，
+    // 顺带证明 PluginMetaStore 里的记录也拆干净了
+    const again = (await page.evaluate(
+      (name) => (window as unknown as PolarisBridge).polaris.invoke('plugins.market.uninstall', { name }),
+      pkg.name,
+    )) as { ok: boolean; code?: string };
+    check('重复卸载报 not-installed（安装记录已清）', again.ok === false && again.code === 'not-installed', JSON.stringify(again));
+  } catch (err) {
+    check('插件市场组执行完成', false, String(err).slice(0, 400));
+  } finally {
+    await shutdown(app);
+    server.close();
+    rmSync(userData, { recursive: true, force: true });
+  }
+}
+
 void (async () => {
   await groupEngine();
   await groupNoEngine();
+  await groupMarket();
   console.log(problems.length ? `\n${problems.length} 项失败` : '\n全部通过');
   process.exit(problems.length ? 1 : 0);
 })();

--- a/src/kernel/tests/market.test.ts
+++ b/src/kernel/tests/market.test.ts
@@ -61,7 +61,19 @@ async function installHello(pluginsDir: string, fetchImpl: FetchImpl) {
 describe('market index', () => {
   it('the committed official index validates against the contract', async () => {
     const raw = JSON.parse(await readFile(join(import.meta.dirname, '../../../market/index.json'), 'utf8'))
-    expect(validateMarketIndex(raw)).toEqual({ schemaVersion: 1, plugins: [] })
+    const index = validateMarketIndex(raw)
+    expect(index.schemaVersion).toBe(1)
+    // 种子插件（#712）必须在官方索引上，且上架版本与仓内包一字不差——
+    // 索引说装哪个版本，安装引擎就装哪个版本，两处漂移会让 e2e 装错包
+    const pkg = JSON.parse(
+      await readFile(join(import.meta.dirname, '../../../plugins/polaris-plugin-hello/package.json'), 'utf8'),
+    ) as { name: string; version: string }
+    const hello = index.plugins.find((entry) => entry.name === pkg.name)
+    expect(hello).toBeDefined()
+    expect(hello!.version).toBe(pkg.version)
+    expect(hello!.kind).toBe('panel')
+    expect(hello!.tier).toBe('bronze')
+    expect(hello!.badges).toContain('official')
   })
 
   it('fetchIndex returns validated entries', async () => {

--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -66,6 +66,7 @@ export default withMermaid(
                   { text: 'Deployment', link: '/docs/deployment' },
                   { text: 'Development', link: '/docs/development' },
                   { text: 'Desktop app', link: '/docs/desktop' },
+                  { text: 'Plugins', link: '/docs/plugins' },
                 ],
               },
               {


### PR DESCRIPTION
Closes #712. Part of #698 (marketplace M2, final item). Proves the whole chain with a real installable package.

- `plugins/polaris-plugin-hello/` (new workspace member): a minimal panel-kind cordis plugin demonstrating the three fundamentals (schemastery Config, disposable `ctx.effect`, `ctx.provide`), esbuild single-file bundle with the dist committed (the market installs npm artifacts, and the e2e fixture packs the real thing); the README doubles as the third-party developer template — directory anatomy, the `polaris` manifest field table, and the four hard rules (single-file bundle with deps compiled in, install/enable separation, hash pinning means publish-don't-edit, description lint). One pitfall fixed en route: `"type": "module"` makes Node load a CJS bundle as an empty ESM object
- `market/index.json` gains the hello entry (bronze / Polaris official); the kernel index test now pins that the entry exists **and its version matches the package** — drift between the two would make e2e install the wrong version
- e2e group C (no gating, always runs, 16 assertions): a local `node:http` server serves the real index via `setEndpoint`, and a main-process fetch shim redirects the hardcoded npm registry host to it — production code untouched; the loop covers install-job phases, the disabled-entry intermediate state, enable with kernel-observable effects, refuse-uninstall-while-enabled, full cleanup, and not-installed on repeat uninstall (proving records were removed too)
- `docs/plugins.md`: the loading model (config tree as the source of truth), install/enable separation, hash pinning, market endpoint, authoring from the template, and the v1 boundaries stated honestly (permissions display-only, official source only, single-file rule, in-process only); linked from the docs nav

Rebased onto #713 with zero conflicts; kernel 96 tests, plugin dist rebuild zero-diff, frontend build, desktop lint/build/smoke, e2e group C all green. No backend changes.