### PR TITLE
fix: wire Runner v2 dispatch, credentials, and leases into experiments

### DIFF
--- a/src/backend/app/agents/voyage/actions_experiment.py
+++ b/src/backend/app/agents/voyage/actions_experiment.py
@@ -50,10 +50,12 @@ from app.models.experiment import EXPERIMENT_TERMINAL_STATUSES, Experiment, Expe
 from app.models.idea import Idea
 from app.models.library_direction import LibraryPaper
 from app.models.paper import Paper, PaperWiki
+from app.models.resource import Resource, ResourceLease
 from app.models.ssh_credential import SSHCredential
 from app.models.voyage import VoyageRun, VoyageStep
 from app.services import experiment_settings as experiment_settings_service
 from app.services import experiments as experiments_service
+from app.services import resource_leases as resource_leases_service
 from app.services import ssh_exec
 from app.services import voyage_messages as messages_service
 from app.services.figure_annotate import prepare_image_for_llm
@@ -77,6 +79,8 @@ from app.services.managed_commands import (
     may_apply_recovery_automatically,
 )
 from app.services.managed_ssh import ManagedCommandHandle
+from app.services.runners import registry as runner_registry
+from app.services.runners.contract import RunnerPlugin
 
 RUN_POLL_SECONDS = 30.0  # 正式运行轮询间隔（测试 monkeypatch 为 0）
 MANAGED_COMMAND_POLL_SECONDS = 2.0
@@ -1240,26 +1244,58 @@ def _managed_command_waiting_result(
     }
 
 
-async def _open_executor(
+async def _resolve_runner_plugin(
     session: AsyncSession, ctx: ActionContext, experiment: Experiment
-) -> Runner:
-    """为实验打开执行后端（Runner）。执行细节走 Runner 抽象，实验逻辑不直接依赖 SSH。
+) -> tuple[RunnerPlugin, Runner | None]:
+    """Runner v2 分派点（#716）：backend 从 checkpoint.params 读（#676 创建时已存），
+    经注册表拿插件。这是动作层「获得执行器/子基座」的唯一入口。
 
-    kind 从 plan 里取（预留分派点：以后训练类→ContainerRunner 等），目前所有 kind 都用
-    RemoteHostRunner，行为与之前一致。"""
+    - python-ml（含缺省）：插件绑定的底座就是原 open_runner 的返回物——v2 适配器的
+      生命周期方法委托同一套 v1 原语，动作层继续直连原语（launch_setup/run_smoke/
+      probe_gpu 等未进 v2 生命周期的观测与修复面），语义与直接 open_runner 等价，
+      python-ml 路径行为逐字节不变；
+    - 非 SSH 底座后端（credential_kinds 不含 "ssh"，如 ngspice/openfoam/fmu）：
+      返回未绑底座的插件与 None——分派正确性在此保证；动作层按 v2 生命周期
+      驱动这些后端是后续阶段（R4 余下部分）的事。
+    """
+    raw = str(_params(ctx).get("backend") or "").strip()
+    backend = raw or runner_registry.DEFAULT_BACKEND
+    # 未注册后端在此抛 UnknownBackendError：经 _guarded 留痕后交引擎失败分派（可诊断）
+    manifest = runner_registry.manifest_for(backend)
+    if "ssh" not in manifest.credential_kinds:
+        return runner_registry.get(backend)(), None
     if experiment.credential_id is None:
         raise ValueError("实验缺少 SSH 凭据（credential_id 为空）")
     credential = await session.get(SSHCredential, experiment.credential_id)
     if credential is None:
         raise ValueError("SSH 凭据已删除，无法连接实验服务器")
     plan = experiment.plan if isinstance(experiment.plan, dict) else {}
-    return await open_runner(
+    runner = await open_runner(
         credential=credential,
         exp_id=str(experiment.id),
         project_id=experiment.project_id,
         kind=plan.get("kind"),
         container=plan.get("container"),
     )
+    return runner_registry.get(backend)(runner=runner), runner
+
+
+async def _open_executor(
+    session: AsyncSession, ctx: ActionContext, experiment: Experiment
+) -> Runner:
+    """为实验打开执行后端（Runner）。分派收窄到 _resolve_runner_plugin 一处（#716）。
+
+    本动作层的既有流程（setup/smoke/run/figures 及其修复循环）建立在 19 原语之上，
+    只对 SSH 底座后端成立；非 SSH 后端在这里明确报错（可诊断、进失败分派），
+    绝不拿错底座乱跑。
+    """
+    plugin, runner = await _resolve_runner_plugin(session, ctx, experiment)
+    if runner is None:
+        raise ValueError(
+            f"后端 {plugin.manifest.backend} 不使用 SSH 执行底座，"
+            "实验动作流程尚未接入该后端的执行生命周期"
+        )
+    return runner
 
 
 # ---- 计划 schema 校验 ----
@@ -1940,12 +1976,67 @@ async def _probe_resources(executor: Runner, plan: dict[str, Any]) -> tuple[list
     return resources, warnings
 
 
+# 排队等待 runner 主机席位的上限（秒）：给在跑实验一点收尾腾位的余地，又不让
+# setup 无限悬挂——超时转为可诊断失败，由引擎失败分派决定重试/换方案/问人。
+RESOURCE_LEASE_WAIT_SECONDS = 600.0
+
+
+async def _acquire_resource_lease(ctx: ActionContext) -> None:
+    """备环境前获取 runner 主机租约（#716 接线 #677/#685）。
+
+    checkpoint.params.resource_id 非空 = 用户创建实验时指定了注册的 runner 主机；
+    在 prepare 语义（experiment_setup 连接主机之前）排队拿席位，独占主机上两个
+    实验不再同时开跑。释放不在这里管：voyage run 的四个终态写入点都挂了
+    release_for_run 兜底（engine._set_status / cancel_voyage / gates.fail_voyage /
+    api.voyages 删除路径），不管实验怎么死都不占着资源。
+
+    用独立 session：wait_and_acquire 内部会 commit/rollback，混用调用方 session
+    会把人家已加载的 ORM 对象状态搅乱。
+    """
+    raw = _params(ctx).get("resource_id")
+    if not raw:
+        return
+    async with get_sessionmaker()() as session:
+        resource = await session.get(Resource, uuid.UUID(str(raw)))
+        if resource is None:
+            # 资源被删——转可诊断失败（引擎分派），不是崩溃
+            raise ValueError(f"指定的 runner 主机资源已不存在：{raw}")
+        # 幂等：setup 失败重试/断点续跑会重入本函数，run 已持有该资源的活租约就不叠加
+        held = await session.execute(
+            select(ResourceLease.id).where(
+                ResourceLease.resource_id == resource.id,
+                ResourceLease.run_id == ctx.run.id,
+                ResourceLease.released_at.is_(None),
+            )
+        )
+        if held.first() is not None:
+            return
+        try:
+            await resource_leases_service.wait_and_acquire(
+                session,
+                resource,
+                ctx.run,
+                timeout=RESOURCE_LEASE_WAIT_SECONDS,
+                note="experiment.setup",
+            )
+        except resource_leases_service.ResourceBusyError as e:
+            raise ValueError(
+                f"runner 主机忙：等待 {RESOURCE_LEASE_WAIT_SECONDS:.0f} 秒仍没有空闲席位（{e}）。"
+                "可稍后重试，或换一台注册主机。"
+            ) from e
+    await ctx.log("已获得 runner 主机资源席位")
+
+
 @register("experiment.setup")
 @_guarded
 async def experiment_setup(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
     async with get_sessionmaker()() as session:
         experiment = await _get_experiment(session, ctx)
         await _set_status(ctx, session, experiment, "setup")
+
+        # 资源租约（#716）：指定了 runner 主机资源时，备环境前先排队拿席位；
+        # 拿不到转为可诊断失败（引擎失败分派处理），终态释放由 release_for_run 兜底
+        await _acquire_resource_lease(ctx)
 
         # 实验的全局环境设置（管理端「实验设置」里配）：模型/数据集位置、pip 镜像、
         # HF 端点、代理。既写进 env.sh，也**作为事实写进 codegen 提示词**——模型不知道

--- a/src/backend/app/schemas/experiment.py
+++ b/src/backend/app/schemas/experiment.py
@@ -97,7 +97,16 @@ class ExperimentCreate(BaseModel):
 
     @model_validator(mode="after")
     def _one_of_credential_or_resource(self) -> "ExperimentCreate":
-        if self.credential_id is None and self.resource_id is None:
+        if self.credential_id is not None or self.resource_id is not None:
+            return self
+        # 凭据放宽（#716）：只有自述需要 ssh 凭据的后端（credential_kinds 含 "ssh"，
+        # 今天即 python-ml）才强制二选一；本机底座后端（ngspice/openfoam/fmu）没有
+        # 连接凭据概念，两者都可不给。backend 字段校验先于本校验跑，这里 manifest
+        # 必然可取。
+        backend = self.params.backend if self.params else "python-ml"
+        from app.services.runners.registry import manifest_for  # 延迟导入：同 backend 校验
+
+        if "ssh" in manifest_for(backend).credential_kinds:
             raise ValueError("either credential_id or resource_id is required")
         return self
 

--- a/src/backend/app/services/experiments.py
+++ b/src/backend/app/services/experiments.py
@@ -171,10 +171,25 @@ async def create_experiment(
         if (resource.config or {}).get("unavailable") or resource.credential_id is None:
             raise RunnerHostUnavailableError(str(data.resource_id))
         credential_id = resource.credential_id
-    credential = await session.get(SSHCredential, credential_id)
-    # kind 校验（#677 凭据多态化后）：实验直跑只吃 ssh 凭据，别的 kind 私钥列为空，
-    # 放进来会在 ssh_exec 解密时炸得不知所云——这里当不存在处理
-    if credential is None or credential.user_id != user_id or credential.kind != "ssh":
+    # 凭据放宽（#716）：是否强制 SSH 凭据由后端 manifest 自述（credential_kinds）。
+    # python-ml 声明 "ssh" → 维持原状（必须给凭据，检查逐字节同前）；本机底座后端
+    # （ngspice/openfoam/fmu，credential_kinds 为空）不吃连接凭据 → credential_id
+    # 可空。给了就照旧校验归属/kind——错的凭据不因后端用不上而放行。
+    # 延迟导入：runners 注册表反向经 python-ml 适配器牵到 voyage 动作层，顶层互 import
+    # 会让 fmu_worker 这类以 runners 为入口的进程死在环上（实测炸过 fmu 子进程测试）
+    from app.services.runners.registry import manifest_for
+
+    backend = data.params.backend if data.params else "python-ml"
+    needs_ssh = "ssh" in manifest_for(backend).credential_kinds
+    credential = None
+    if credential_id is not None:
+        credential = await session.get(SSHCredential, credential_id)
+        # kind 校验（#677 凭据多态化后）：实验直跑只吃 ssh 凭据，别的 kind 私钥列为空，
+        # 放进来会在 ssh_exec 解密时炸得不知所云——这里当不存在处理
+        if credential is None or credential.user_id != user_id or credential.kind != "ssh":
+            raise CredentialNotFoundError(str(credential_id))
+    elif needs_ssh:
+        # schema 的条件校验已挡住这条路；服务层兜底（不走 schema 的直接调用方）
         raise CredentialNotFoundError(str(credential_id))
 
     params = data.params
@@ -185,10 +200,10 @@ async def create_experiment(
     experiment = Experiment(
         project_id=project.id,
         idea_id=idea.id,
-        credential_id=credential.id,
+        credential_id=credential.id if credential is not None else None,
         status="planning",
         budget=budget,
-        server_host=credential.host,
+        server_host=credential.host if credential is not None else None,
     )
     session.add(experiment)
     await session.flush()
@@ -214,13 +229,13 @@ async def create_experiment(
                     if params and params.intake
                     else None
                 ),
-                # 执行后端（Runner v2，#675）：现阶段无读者（动作层仍走旧路），
-                # R4 起 navigator 把它写进 plan.backend 供 resolve_backend 分派
+                # 执行后端（Runner v2，#675/#716）：动作层分派点
+                # （actions_experiment._resolve_runner_plugin）从这里读，经注册表拿插件
                 "backend": params.backend if params else "python-ml",
                 # 流程包（#678）：非空时 navigator 按包生成计划；None = 原路径
                 "process_pack": params.process_pack if params else None,
-                # runner 主机资源（#685）：非空 = 用户指定跑在哪台注册机器上；
-                # 现阶段只作记录（租约获取由 R2 的 prepare 阶段接管时消费）
+                # runner 主机资源（#685/#716）：非空 = 用户指定跑在哪台注册机器上；
+                # experiment_setup 备环境前据此排队获取租约（resource_leases）
                 "resource_id": str(data.resource_id) if data.resource_id else None,
             }
         },

--- a/src/backend/app/services/runners/__init__.py
+++ b/src/backend/app/services/runners/__init__.py
@@ -24,6 +24,7 @@ from app.services.runners.registry import (
     DEFAULT_BACKEND,
     UnknownBackendError,
     known_backends,
+    manifest_for,
     resolve_backend,
 )
 
@@ -43,5 +44,6 @@ __all__ = [
     "RunnerPlugin",
     "UnknownBackendError",
     "known_backends",
+    "manifest_for",
     "resolve_backend",
 ]

--- a/src/backend/app/services/runners/container_substrate.py
+++ b/src/backend/app/services/runners/container_substrate.py
@@ -260,10 +260,11 @@ class ContainerBackendBase:
     async def prepare(self, ctx) -> None:
         """备环境 = 建工作目录 + 物料落盘（纯数据通道）。
 
-        TODO(#680 接线)：manifest.resources 已声明 cpu/mem 需求，这里应在落盘前
-        对 docker host 对应的 Resource 走 resource_leases.acquire（wait=True 排队），
-        cleanup 里 release——等动作层切到 v2 分派（R4 后半）连同 run_id 一起接入；
-        本 PR 先把需求声明进 manifest，租约获取暂缺不影响单机语义。
+        资源租约（#680 → #716 已接线）：租约获取不在本底座内做，而在动作层
+        experiment_setup 的备环境之前（resource_leases.wait_and_acquire，按
+        checkpoint.params.resource_id 排队），释放挂在 voyage run 的终态写入点
+        （release_for_run 兜底）——租约的主体是 run，底座不知道 run，放这里
+        只会拿不到 run_id。manifest.resources 的 cpu/mem 需求供调度/预检消费。
         """
         substrate = self._require_substrate()
         if ctx.files:

--- a/src/backend/app/services/runners/registry.py
+++ b/src/backend/app/services/runners/registry.py
@@ -4,10 +4,11 @@
 默认 `python-ml` 保全兼容——今天所有存量实验不写 backend，走 python-ml，行为不变。
 实验 kind（eval/training/…）退役为科学语义标签，不再暗示执行后端。
 
-分派现状与迁移计划：本阶段（R1）注册表与 python-ml 适配器就位，`resolve_backend`
-可拿到并驱动插件，但 **actions_experiment 仍走旧路**（直接调 open_runner + 19 原语）——
-切换动作层到 v2 分派是 R4 接入第一个非 ML 后端（openfoam/ngspice）时的事：届时
-动作层按 resolve_backend 拿插件，python-ml 的行为因适配器全部委托存量原语而保持逐字节一致。
+分派现状（#716 已翻转）：动作层的执行器获取点（actions_experiment._open_executor）
+经本注册表分派——backend 从 voyage checkpoint.params 读（#676 创建时已存）。
+python-ml（含缺省）的插件绑定的底座就是原 open_runner 的返回物，动作层继续直连
+存量原语，行为逐字节一致；非 SSH 底座后端在分派点拿到各自插件（动作层驱动其
+完整生命周期是后续阶段的事）。
 """
 
 from __future__ import annotations
@@ -15,7 +16,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
-from app.services.runners.contract import RunnerPlugin
+from app.services.runners.contract import RunnerManifest, RunnerPlugin
 from app.services.runners.fmu import FMU_BACKEND, FMURunner
 from app.services.runners.ngspice import NGSPICE_BACKEND, NgspiceRunner
 from app.services.runners.openfoam import OPENFOAM_BACKEND, OpenFOAMRunner
@@ -54,6 +55,17 @@ def get(backend: str) -> Callable[..., RunnerPlugin]:
     if factory is None:
         raise UnknownBackendError(backend, known_backends())
     return factory
+
+
+def manifest_for(backend: str) -> RunnerManifest:
+    """按 id 取后端自述（不绑底座）。
+
+    约定：所有插件工厂都接受无参调用返回「未绑底座」的探针实例（python-ml 的
+    runner=None、容器后端的 substrate=None、fmu 的 workdir=None），manifest 是
+    实例属性可直接读——凭据放宽（experiments.create_experiment 按
+    credential_kinds 决定是否强制 SSH 凭据）与动作层分派都靠它，无副作用。
+    """
+    return get(backend)().manifest
 
 
 def known_backends() -> list[str]:

--- a/src/backend/tests/test_runner_v2_wiring.py
+++ b/src/backend/tests/test_runner_v2_wiring.py
@@ -1,0 +1,388 @@
+"""Runner v2 接线（#716）：分派翻转 / 凭据放宽 / 资源租约接入实验链路。
+
+三条线各取最小可信断言面：
+- 分派：动作层「获得执行器」唯一入口（_resolve_runner_plugin）按
+  checkpoint.params.backend 从注册表拿插件——fake 后端拿到 fake 插件，
+  python-ml 拿到绑定 v1 底座（open_runner 返回物）的适配器；
+- 凭据：ngspice（credential_kinds 为空）无凭据创建成功且 credential_id 落空；
+  python-ml 无凭据仍被 schema 拒绝（422，行为不变）；
+- 租约：experiment_setup 备环境前按 resource_id 排队获取（幂等、忙则可诊断
+  失败），voyage 终态由 release_for_run 兜底释放（整管线集成验证）。
+"""
+
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from app.agents.voyage import VoyageEngine
+from app.agents.voyage import actions_experiment as ax
+from app.agents.voyage.actions import ActionContext
+from app.core.db import get_sessionmaker
+from app.core.llm.router import LLMRouter
+from app.models.experiment import Experiment
+from app.models.idea import Idea
+from app.models.resource import ResourceLease
+from app.models.voyage import VoyageRun
+from app.services import resource_leases, ssh_exec
+from app.services.runners import registry as runner_registry
+from app.services.runners.contract import RunnerManifest, RunStatus
+from app.services.runners.python_ml import PythonMLRunner
+from tests.conftest import RecordingBus, register_and_login
+from tests.fake_ssh import FakeSSHConnector, FakeSSHServer
+from tests.test_ssh_credentials import PAYLOAD as CRED_PAYLOAD
+
+RUN_LOG = (
+    'POLARIS_METRIC {"name": "accuracy", "step": 1, "value": 0.7}\n'
+    "done (fake experiment)\n"
+)
+FAKE_PNG = b"\x89PNG\r\n\x1a\n(fake png bytes)"
+
+
+@pytest_asyncio.fixture
+async def fake_ssh(app):
+    server = FakeSSHServer(
+        run_log=RUN_LOG,
+        plot_outputs={
+            "figures/primary_metric.png": FAKE_PNG,
+            "figures/primary_metric.pdf": b"%PDF-1.4 (fake pdf)",
+        },
+    )
+    ssh_exec.set_connector_factory(lambda: FakeSSHConnector(server))
+    yield server
+    ssh_exec.set_connector_factory(None)
+
+
+@pytest_asyncio.fixture(autouse=True)
+def fast_poll(monkeypatch):
+    monkeypatch.setattr(ax, "RUN_POLL_SECONDS", 0)
+
+
+async def _setup_project(client, email="alice@example.com"):
+    token = await register_and_login(client, email)
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = await client.post("/api/projects", json={"name": "wiring-proj"}, headers=headers)
+    assert resp.status_code == 201
+    return resp.json()["id"], headers
+
+
+async def _seed_idea(project_id: str) -> str:
+    async with get_sessionmaker()() as session:
+        idea = Idea(
+            project_id=uuid.UUID(project_id),
+            title="runner v2 wiring idea",
+            summary="s",
+            status="promoted",
+        )
+        session.add(idea)
+        await session.commit()
+        return str(idea.id)
+
+
+async def _create_credential(client, headers) -> str:
+    resp = await client.post("/api/ssh-credentials", json=CRED_PAYLOAD, headers=headers)
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+def _ctx_for(voyage: VoyageRun) -> ActionContext:
+    return ActionContext(run=voyage, llm=LLMRouter(), checkpoint=dict(voyage.checkpoint or {}))
+
+
+async def _load_exp_and_voyage(exp_id: str) -> tuple[Experiment, VoyageRun]:
+    async with get_sessionmaker()() as session:
+        experiment = await session.get(Experiment, uuid.UUID(exp_id))
+        voyage = await session.get(VoyageRun, experiment.voyage_id)
+        return experiment, voyage
+
+
+# ---- 分派翻转 ----
+
+
+class FakeEchoPlugin:
+    """注册进注册表的假后端：只用于验证分派点拿到正确插件（无凭据、无底座）。"""
+
+    manifest = RunnerManifest(
+        backend="fake-echo",
+        interaction="batch",
+        side_effects="none",
+        credential_kinds=(),
+    )
+
+    @classmethod
+    def create(cls, **_):
+        return cls()
+
+    async def validate(self, plan):
+        return []
+
+    async def prepare(self, ctx):
+        return None
+
+    async def launch(self, ctx):
+        return "fake-handle"
+
+    async def poll(self, handle):
+        return RunStatus(state="succeeded", exit_code=0)
+
+    async def collect(self, ctx):
+        raise NotImplementedError
+
+    async def cancel(self, handle):
+        return None
+
+    async def cleanup(self, ctx):
+        return None
+
+    async def dry_run(self, ctx):
+        raise NotImplementedError
+
+
+async def test_dispatch_hands_out_registered_fake_plugin(client, queue_stub, monkeypatch):
+    """backend=fake 的实验：创建无需凭据，动作层分派点拿到 fake 插件本尊。"""
+    monkeypatch.setitem(runner_registry._FACTORIES, "fake-echo", FakeEchoPlugin.create)
+    project_id, headers = await _setup_project(client)
+    idea_id = await _seed_idea(project_id)
+
+    resp = await client.post(
+        f"/api/projects/{project_id}/experiments",
+        json={"idea_id": idea_id, "params": {"backend": "fake-echo"}},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    exp = resp.json()
+    assert exp["server_host"] is None
+
+    experiment, voyage = await _load_exp_and_voyage(exp["id"])
+    assert experiment.credential_id is None
+    assert voyage.checkpoint["params"]["backend"] == "fake-echo"
+
+    ctx = _ctx_for(voyage)
+    async with get_sessionmaker()() as session:
+        plugin, runner = await ax._resolve_runner_plugin(session, ctx, experiment)
+        assert isinstance(plugin, FakeEchoPlugin)
+        assert runner is None
+        # 既有 19 原语流程只对 SSH 底座后端成立：非 SSH 后端明确报错（可诊断）
+        with pytest.raises(ValueError, match="fake-echo"):
+            await ax._open_executor(session, ctx, experiment)
+
+
+async def test_dispatch_python_ml_binds_v1_substrate(client, queue_stub, fake_ssh):
+    """缺省后端（python-ml）：插件绑定的底座就是 open_runner 的返回物（等价性）。"""
+    project_id, headers = await _setup_project(client)
+    idea_id = await _seed_idea(project_id)
+    cred_id = await _create_credential(client, headers)
+    resp = await client.post(
+        f"/api/projects/{project_id}/experiments",
+        json={"idea_id": idea_id, "credential_id": cred_id},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    experiment, voyage = await _load_exp_and_voyage(resp.json()["id"])
+    assert voyage.checkpoint["params"]["backend"] == "python-ml"
+
+    ctx = _ctx_for(voyage)
+    async with get_sessionmaker()() as session:
+        plugin, runner = await ax._resolve_runner_plugin(session, ctx, experiment)
+        try:
+            assert isinstance(plugin, PythonMLRunner)
+            assert isinstance(runner, ssh_exec.SSHExecutor)  # v1 底座（裸机形态）
+            assert plugin._runner is runner  # 适配器委托的正是同一底座
+        finally:
+            if runner is not None:
+                await runner.close()
+
+
+async def test_dispatch_unknown_backend_is_diagnosable(client, queue_stub):
+    """checkpoint 里的 backend 事后失效（插件卸载）：UnknownBackendError，不静默回退。"""
+    voyage = VoyageRun(
+        kind="experiment",
+        goal="g",
+        status="executing",
+        checkpoint={"params": {"backend": "gone-backend"}},
+    )
+    ctx = _ctx_for(voyage)
+    with pytest.raises(runner_registry.UnknownBackendError):
+        await ax._resolve_runner_plugin(None, ctx, None)
+
+
+# ---- 凭据放宽 ----
+
+
+async def test_ngspice_creates_without_credential(client, queue_stub):
+    project_id, headers = await _setup_project(client)
+    idea_id = await _seed_idea(project_id)
+    resp = await client.post(
+        f"/api/projects/{project_id}/experiments",
+        json={"idea_id": idea_id, "params": {"backend": "ngspice"}},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    experiment, voyage = await _load_exp_and_voyage(resp.json()["id"])
+    assert experiment.credential_id is None
+    assert experiment.server_host is None
+    assert voyage.checkpoint["params"]["backend"] == "ngspice"
+
+
+async def test_python_ml_still_requires_credential(client, queue_stub):
+    """存量行为不变：python-ml（显式或缺省）没有凭据/资源 → 422。"""
+    project_id, headers = await _setup_project(client)
+    idea_id = await _seed_idea(project_id)
+    for payload in (
+        {"idea_id": idea_id},
+        {"idea_id": idea_id, "params": {"backend": "python-ml"}},
+    ):
+        resp = await client.post(
+            f"/api/projects/{project_id}/experiments", json=payload, headers=headers
+        )
+        assert resp.status_code == 422, resp.text
+
+
+async def test_non_ssh_backend_still_validates_given_credential(client, queue_stub):
+    """后端用不上凭据 ≠ 错凭据放行：给了 credential_id 就照旧校验归属。"""
+    project_id, headers = await _setup_project(client)
+    idea_id = await _seed_idea(project_id)
+    resp = await client.post(
+        f"/api/projects/{project_id}/experiments",
+        json={
+            "idea_id": idea_id,
+            "credential_id": str(uuid.uuid4()),
+            "params": {"backend": "ngspice"},
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 404, resp.text
+
+
+# ---- 资源租约 ----
+
+
+async def _register_host(client, headers, name="lease-box") -> str:
+    cred_id = await _create_credential(client, headers)
+    resp = await client.post(
+        "/api/resources/runner-hosts",
+        json={"name": name, "credential_id": cred_id},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+async def _active_leases(resource_id: str) -> list[ResourceLease]:
+    async with get_sessionmaker()() as session:
+        rows = await session.execute(
+            select(ResourceLease).where(
+                ResourceLease.resource_id == uuid.UUID(resource_id),
+                ResourceLease.released_at.is_(None),
+            )
+        )
+        return list(rows.scalars().all())
+
+
+async def test_setup_lease_acquire_idempotent_and_busy_diagnosable(
+    client, queue_stub, monkeypatch
+):
+    headers = {
+        "Authorization": f"Bearer {await register_and_login(client, 'lease@example.com')}"
+    }
+    resource_id = await _register_host(client, headers)
+
+    async with get_sessionmaker()() as session:
+        run1 = VoyageRun(
+            kind="experiment",
+            goal="r1",
+            status="executing",
+            checkpoint={"params": {"resource_id": resource_id}},
+        )
+        run2 = VoyageRun(
+            kind="experiment",
+            goal="r2",
+            status="executing",
+            checkpoint={"params": {"resource_id": resource_id}},
+        )
+        session.add_all([run1, run2])
+        await session.commit()
+        await session.refresh(run1)
+        await session.refresh(run2)
+
+    # 没写 resource_id 的实验：不进租约体系（缺省路径零变化）
+    plain = VoyageRun(kind="experiment", goal="p", status="executing", checkpoint={"params": {}})
+    await ax._acquire_resource_lease(_ctx_for(plain))
+    assert await _active_leases(resource_id) == []
+
+    # run1 获租；重入（setup 修复循环/断点续跑）不叠加
+    await ax._acquire_resource_lease(_ctx_for(run1))
+    assert len(await _active_leases(resource_id)) == 1
+    await ax._acquire_resource_lease(_ctx_for(run1))
+    leases = await _active_leases(resource_id)
+    assert len(leases) == 1
+    assert leases[0].run_id == run1.id
+
+    # run2 排队直到超时：可诊断失败（ValueError），不是崩溃
+    monkeypatch.setattr(ax, "RESOURCE_LEASE_WAIT_SECONDS", 0.05)
+    with pytest.raises(ValueError, match="runner 主机忙"):
+        await ax._acquire_resource_lease(_ctx_for(run2))
+
+    # run1 终态释放（四个终态点都挂了 release_for_run）后 run2 立即可得
+    async with get_sessionmaker()() as session:
+        released = await resource_leases.release_for_run(session, run1.id)
+        assert released == 1
+    await ax._acquire_resource_lease(_ctx_for(run2))
+    leases = await _active_leases(resource_id)
+    assert len(leases) == 1
+    assert leases[0].run_id == run2.id
+
+    # 资源被删后：可诊断失败
+    async with get_sessionmaker()() as session:
+        gone = VoyageRun(
+            kind="experiment",
+            goal="g",
+            status="executing",
+            checkpoint={"params": {"resource_id": str(uuid.uuid4())}},
+        )
+        session.add(gone)
+        await session.commit()
+        await session.refresh(gone)
+    with pytest.raises(ValueError, match="已不存在"):
+        await ax._acquire_resource_lease(_ctx_for(gone))
+
+
+async def test_pipeline_with_resource_id_acquires_then_releases_lease(
+    client, queue_stub, fake_ssh, bus_recorder
+):
+    """整管线：resource_id 实验 setup 前获租、voyage 终态兜底释放（#680 模式复用）。"""
+    project_id, headers = await _setup_project(client)
+    idea_id = await _seed_idea(project_id)
+    resource_id = await _register_host(client, headers, name="pipeline-box")
+
+    resp = await client.post(
+        f"/api/projects/{project_id}/experiments",
+        json={"idea_id": idea_id, "resource_id": resource_id},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    exp = resp.json()
+    voyage_id = uuid.UUID(exp["voyage_id"])
+
+    async def leases_for_run():
+        async with get_sessionmaker()() as session:
+            rows = await session.execute(
+                select(ResourceLease).where(ResourceLease.run_id == voyage_id)
+            )
+            return list(rows.scalars().all())
+
+    assert await leases_for_run() == []  # 创建只记录 resource_id，不提前占席位
+
+    engine = VoyageEngine(event_bus=RecordingBus(), llm_router=LLMRouter())
+    await engine.run(voyage_id)
+
+    resp = await client.get(f"/api/voyages/{voyage_id}", headers=headers)
+    assert resp.json()["status"] == "done", resp.json()
+    resp = await client.get(f"/api/experiments/{exp['id']}", headers=headers)
+    assert resp.json()["status"] == "done"
+
+    leases = await leases_for_run()
+    assert len(leases) == 1  # setup 获租恰一次（幂等），终态已释放
+    assert leases[0].released_at is not None
+    assert leases[0].note == "experiment.setup"


### PR DESCRIPTION
Closes #716. Part of #715 (audit item 1 — the merged v2 backends were unreachable in production and leases were release-only).

- **dispatch flips at exactly one point**: the action layer's executor-acquisition funnels through a new resolver reading `checkpoint.params.backend` and dispatching via the registry; an unregistered backend fails diagnosably through the engine's failure path instead of silently falling back. For python-ml (and the default) the opened substrate is the byte-identical `open_runner` return — the plugin wraps the very same object, proven by the untouched experiment suites and an identity assertion. The 3,444-line action layer was deliberately not rewritten: primitives outside the v2 lifecycle stay direct
- **credentials follow the manifest**: the ssh requirement now applies only to backends whose `credential_kinds` include ssh; ngspice/openfoam/fmu experiments create without a credential (a wrong credential is still rejected, not ignored); schema and service validate in both layers; the frontend needed nothing — `credential_id` was already optional in the type
- **leases finally get acquired**: `experiment_setup` calls `wait_and_acquire` (600s queue, idempotent per run, its own session so internal commits can't pollute the caller) before touching the host; busy-timeout and vanished-resource become diagnosable failures the engine can reroute; release stays on the four existing terminal hooks; the #680 TODO at the container substrate is updated to the wired reality
- one latent bug fixed en route: a top-level registry import created a cycle that killed `fmu_worker` subprocess entry — moved to a deferred import with the reasoning documented

Verification: clean baseline 1697 passed / 3 pre-existing failures; branch 1706 passed with the **identical** failure set (diffed line-by-line) — zero new; 8 new tests (dispatch identity, both credential directions, unknown backend, lease acquire/queue/timeout/release/full-pipeline); goldens byte-identical; existing experiment/runner/resource suites pass without a single modification; rebased onto #723 with zero conflicts.