### PR TITLE
fix: user data directory moves out of the app bundle

### DIFF
--- a/src/backend/app/core/config.py
+++ b/src/backend/app/core/config.py
@@ -2,6 +2,7 @@
 
 import logging
 from functools import lru_cache
+from pathlib import Path
 from typing import Literal
 
 from pydantic import AliasChoices, Field, field_validator, model_validator
@@ -261,6 +262,22 @@ class Settings(BaseSettings):
         if v and (v.startswith("#") or not v.isascii()):
             logger.warning("忽略非法配置值（疑似注释混入）：%r", v[:40])
             return ""
+        return v
+
+    @field_validator("data_dir", mode="after")
+    @classmethod
+    def _resolve_data_dir(cls, v: str) -> str:
+        """data_dir 一律钉成绝对路径（#718）：桌面引擎启动器会 chdir 到
+        App 安装包里的后端源码目录，相对默认 "./data" 会随之漂进安装目录
+        （应用更新即被整体替换，用户文件全丢）。这里在 settings 加载时基于
+        当时的 cwd resolve 一次，此后进程内任何 chdir 都不再影响落盘位置；
+        桌面正常路径由引导器注入绝对的 POLARIS_DATA_DIR，本兜底只在 env
+        缺失时生效。docker/server 部署显式设 /srv/data（绝对路径），不受影响。"""
+        path = Path(v)
+        if not path.is_absolute():
+            resolved = str(path.resolve())
+            logger.info("data_dir 是相对路径 %r，已按当前工作目录解析为 %s", v, resolved)
+            return resolved
         return v
 
     @model_validator(mode="after")

--- a/src/desktop/src/bootstrap-smoke.ts
+++ b/src/desktop/src/bootstrap-smoke.ts
@@ -20,7 +20,7 @@
    ============================================================ */
 
 import { spawn, type ChildProcess } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -28,6 +28,7 @@ import { setTimeout as delay } from 'node:timers/promises';
 
 import {
   bootstrapEngine,
+  buildDataDirMigration,
   buildMigrationGuard,
   type BootstrapPhase,
   type EngineCommand,
@@ -123,9 +124,12 @@ async function runEngineOnce(config: EngineCommand): Promise<void> {
 }
 
 /** 跑一段 python -c，返回退出码；失败时把 stderr 打出来供排查。 */
-function runPython(python: string, code: string): Promise<number> {
+function runPython(python: string, code: string, env?: NodeJS.ProcessEnv): Promise<number> {
   return new Promise((resolveExit, rejectExit) => {
-    const child = spawn(python, ['-X', 'utf8', '-c', code], { stdio: ['ignore', 'ignore', 'pipe'] });
+    const child = spawn(python, ['-X', 'utf8', '-c', code], {
+      stdio: ['ignore', 'ignore', 'pipe'],
+      env: env ? { ...process.env, ...env } : process.env,
+    });
     let stderr = '';
     child.stderr!.on('data', (chunk: Buffer) => {
       stderr += chunk.toString();
@@ -136,6 +140,59 @@ function runPython(python: string, code: string): Promise<number> {
       resolveExit(exitCode ?? 1);
     });
   });
+}
+
+/**
+ * 数据目录搬迁语义（#718）：与守卫同一套路，用 venv Python 直接驱动
+ * buildDataDirMigration 生成的片段验证，不必为此再造一个「带旧数据的
+ * 安装包」跑整轮引擎。三个断言：旧非空 + 新缺失 → 整体搬走（含子结构）；
+ * 新已非空 → 绝不合并、源纹丝不动；片段自身对空环境幂等（旧位置不存在
+ * 时是空操作且要把新位置建出来）。
+ */
+async function assertDataDirMigration(python: string): Promise<void> {
+  const dir = mkdtempSync(join(tmpdir(), 'polaris-datadir-'));
+  try {
+    const oldDir = join(dir, 'backend', 'data');
+    const newDir = join(dir, 'userData', 'engine', 'data');
+    const code = buildDataDirMigration(oldDir.split('\\').join('/')).join('\n');
+    const env = { POLARIS_DATA_DIR: newDir.split('\\').join('/') };
+
+    // 场景 1：旧位置有数据、新位置不存在 → 搬走，旧位置消失
+    mkdirSync(join(oldDir, 'papers'), { recursive: true });
+    writeFileSync(join(oldDir, 'papers', 'a.pdf'), 'pdf-bytes');
+    if ((await runPython(python, code, env)) !== 0) {
+      throw new Error('datadir migration: 正常搬迁不该失败');
+    }
+    if (readFileSync(join(newDir, 'papers', 'a.pdf'), 'utf8') !== 'pdf-bytes') {
+      throw new Error('datadir migration: 旧数据没有搬到新位置');
+    }
+    if (existsSync(oldDir)) {
+      throw new Error('datadir migration: 搬迁后旧目录应当消失');
+    }
+
+    // 场景 2：新位置已非空 → 不合并；旧位置原样保留
+    mkdirSync(oldDir, { recursive: true });
+    writeFileSync(join(oldDir, 'stale.txt'), 'stale');
+    if ((await runPython(python, code, env)) !== 0) {
+      throw new Error('datadir migration: 新位置非空时应是无害空操作');
+    }
+    if (!existsSync(join(oldDir, 'stale.txt'))) {
+      throw new Error('datadir migration: 新位置非空时不得动旧目录');
+    }
+    if (existsSync(join(newDir, 'stale.txt')) || existsSync(join(newDir, 'data'))) {
+      throw new Error('datadir migration: 新位置非空时不得合并/嵌套旧数据');
+    }
+
+    // 场景 3：旧位置不存在 → 空操作，但要把新位置目录建出来
+    await rm(oldDir, { recursive: true, force: true });
+    await rm(newDir, { recursive: true, force: true });
+    if ((await runPython(python, code, env)) !== 0 || !existsSync(newDir)) {
+      throw new Error('datadir migration: 无旧数据时应只创建新目录');
+    }
+    console.log('datadir migration: 搬迁/不合并/幂等 OK');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 }
 
 /**
@@ -243,6 +300,20 @@ async function main(): Promise<void> {
       }
     }
     console.log(`snapshots after run 2: ${snaps.sort().join(', ')}`);
+
+    // #718：用户数据目录必须落在（临时）userData 下，安装目录（resources/
+    // backend）里绝不能长出 data/——那正是应用更新会整包清掉的地方
+    if (!existsSync(join(dataDir, 'engine', 'data'))) {
+      throw new Error('引擎启动后 <userData>/engine/data 应已创建');
+    }
+    if (existsSync(join(args.resources, 'backend', 'data'))) {
+      throw new Error('安装目录 resources/backend/data 不该被创建（#718）');
+    }
+    console.log(`data dir under userData: ${join(dataDir, 'engine', 'data')}`);
+
+    // 数据目录搬迁语义（#718，用引导出来的 venv Python 驱动）
+    console.log('\n== data dir migration semantics');
+    await assertDataDirMigration(config.command[0]!);
 
     // 守卫语义：失败还原 + 成功修剪（用引导出来的 venv Python 驱动）
     console.log('\n== migration guard semantics');

--- a/src/desktop/src/main/engine-bootstrap.ts
+++ b/src/desktop/src/main/engine-bootstrap.ts
@@ -182,15 +182,21 @@ export async function bootstrapEngine(opts: BootstrapOptions): Promise<EngineCom
 /**
  * 引擎启动 argv：与 legacy-engine docker 模式的 `sh -lc "alembic && uvicorn"`
  * 同构，但 command 模式没有 shell，所以用 python -c 的小启动器串联两步。
- * 启动器同时负责 cwd 与数据库地址：
+ * 启动器同时负责 cwd、数据库地址与用户数据目录：
  * - chdir 到后端源码目录——alembic.ini 的 script_location/prepend_sys_path
  *   都是相对 cwd 的相对路径；
  * - POLARIS_DATABASE_URL 指到 userData 的 SQLite 文件（legacy-engine 只注入
- *   POLARIS_PROFILE，数据库路径是引导方才知道的信息，所以写在启动器里）。
+ *   POLARIS_PROFILE，数据库路径是引导方才知道的信息，所以写在启动器里）；
+ * - POLARIS_DATA_DIR 指到 userData 的 engine/data/（#718）：后端 data_dir
+ *   默认相对 './data'，chdir 之后会落进 App 安装包的 resources/backend/，
+ *   应用更新整包替换时用户的 PDF/导出/实验日志就全没了。setdefault 而非
+ *   覆写：给高级用户留 env 改道的口子，与 PROFILE 同一语义。
  */
 function buildEngineCommand(venvPython: string, backendDir: string, engineDir: string): string[] {
   const dbPath = join(engineDir, 'polaris.db').split('\\').join('/');
   const snapshotRoot = join(engineDir, 'snapshots').split('\\').join('/');
+  const dataDir = join(engineDir, 'data').split('\\').join('/');
+  const legacyDataDir = join(backendDir, 'data').split('\\').join('/');
   // JSON.stringify 产出的字符串字面量对 Python 同样合法（转义子集兼容），
   // 借它安全嵌入含空格/反斜杠/非 ASCII 的路径
   const launcher = [
@@ -199,13 +205,52 @@ function buildEngineCommand(venvPython: string, backendDir: string, engineDir: s
     "os.environ.setdefault('PYTHONUTF8', '1')",
     "os.environ.setdefault('POLARIS_PROFILE', 'desktop')",
     `os.environ['POLARIS_DATABASE_URL'] = ${JSON.stringify(`sqlite+aiosqlite:///${dbPath}`)}`,
+    // 用户数据目录钉在 userData 下（#718，理由见本函数 docstring）
+    `os.environ.setdefault('POLARIS_DATA_DIR', ${JSON.stringify(dataDir)})`,
     `os.chdir(${JSON.stringify(backendDir)})`,
+    ...buildDataDirMigration(legacyDataDir),
     ...buildMigrationGuard(dbPath, snapshotRoot, "[sys.executable, '-m', 'alembic', 'upgrade', 'head']"),
     'import uvicorn',
     `uvicorn.run('app.main:app', host='127.0.0.1', port=${ENGINE_PORT})`,
   ].join('\n');
   // -X utf8：启动器自身的解释器也走 UTF-8 模式（env 对已启动的进程无效）
   return [venvPython, '-X', 'utf8', '-c', launcher];
+}
+
+/**
+ * 旧数据目录一次性搬迁的 Python 片段（#718）：修复前的桌面版把用户文件
+ * 写进了 <resources/backend>/data（chdir 后的相对 './data'）——那里随应用
+ * 更新整包替换。首个修复版启动时：旧位置非空且新位置（POLARIS_DATA_DIR，
+ * 读 env 以尊重用户覆写）还没有内容 → shutil.move 整体搬过去。
+ *
+ * 只搬一次：搬成功后旧位置消失，之后每次启动的判断都是空操作；新位置
+ * 已有内容时绝不合并（说明用户已在新位置积累了数据，盲目合并可能覆盖）。
+ * 失败只打日志不阻断启动——宁可这一轮继续用旧位置的文件（backend 兜底
+ * 已把相对 data_dir resolve 到 cwd，行为与修复前一致），也不能让引擎
+ * 起不来；且任何路径下都不主动删除源目录（shutil.move 失败时源保持原样）。
+ *
+ * 放在启动器里而不是 TS 侧：与 alembic 同理（见下），bootstrapEngine 有
+ * 哨兵会整段跳过，而搬迁必须每次 spawn 都检查；纯 stdlib，不加依赖。
+ * 片段自带 import，可独立喂给 python -c（bootstrap-smoke 单独驱动验证）。
+ */
+export function buildDataDirMigration(legacyDataDir: string): string[] {
+  return [
+    'import os, shutil',
+    `_old_data = ${JSON.stringify(legacyDataDir)}`,
+    "_new_data = os.environ['POLARIS_DATA_DIR']",
+    'try:',
+    '    if os.path.isdir(_old_data) and os.listdir(_old_data):',
+    '        if not os.path.isdir(_new_data) or not os.listdir(_new_data):',
+    // shutil.move 遇到已存在的目标目录会把源搬进目标里面（变成 data/data）；
+    // 空目录先 rmdir 掉，让 move 落在正确的一层。rmdir 只删空目录，安全。
+    '            if os.path.isdir(_new_data):',
+    '                os.rmdir(_new_data)',
+    "            print(f'engine-launcher: 迁移旧数据目录 {_old_data} -> {_new_data}', flush=True)",
+    '            shutil.move(_old_data, _new_data)',
+    '    os.makedirs(_new_data, exist_ok=True)',
+    'except Exception as _e:',
+    "    print(f'engine-launcher: 旧数据目录迁移失败（{_e}），保留 {_old_data}，继续启动', flush=True)",
+  ];
 }
 
 /**


### PR DESCRIPTION
Closes #718. Part of #715 (audit item 3 — PDFs/exports/artifacts were landing inside the install directory and being wiped on every update).

- the engine launcher injects `POLARIS_DATA_DIR=<userData>/engine/data` via `setdefault` (an explicit env override still wins, same semantics as the profile variable)
- backend hardening: a settings validator resolves a relative `data_dir` to an absolute path once at load time, so no later chdir can ever redirect user files again; docker/server deployments (absolute paths) and the test env are unaffected
- one-time migration in the launcher (every spawn, before the migration guard — deliberately not behind the bootstrap sentinel): a non-empty legacy `<backendDir>/data` moves wholesale to the new location when it's absent/empty; a non-empty target is never merged into; failures log and never delete the source
- bootstrap-smoke asserts the data dir lands under userData and the install dir stays clean, and drives the migration fragment through all three scenarios (move with substructure / refuse-merge / idempotent create) using the bootstrapped venv's own Python

Verification: branch and clean-baseline suites have the identical 3-failure set (zero new); packaged bootstrap-smoke PASS on the real staged resources; desktop build/smoke, kernel 97, golden spike all green; rebased onto #723 with no conflicts.