### PR TITLE
fix: local-engine correctness for links, setup, notifications, and first run

### DIFF
--- a/docs/task-system.md
+++ b/docs/task-system.md
@@ -539,9 +539,10 @@ So the rule is: the terminal you see live is SSE; the terminal you see after a r
 increments are deliberately not persisted — they would be the bulk of the volume and add nothing once
 the full output is stored.
 
-Run status changes are additionally published to the topic notification channel
-(`notify:project:{project_id}`) as `voyage.status`, and gate creation as `gate.created`. Runs with no
-topic skip this silently — there is no channel to publish to.
+Run status changes are additionally published to the owner's notification channel
+(`notify:user:{user_id}`) as `voyage.status`, and gate creation as `gate.created`. Channels are
+per-user (#721), so library-scoped runs with no originating topic are delivered too; only runs
+without an owner (e.g. cron-initiated) skip this silently.
 
 The task detail endpoint also exposes two derived views built from the checkpoint: `skills` (which
 skill versions this run snapshotted) and `plan_history` (every plan change, in plain language). By

--- a/src/backend/app/agents/voyage/actions.py
+++ b/src/backend/app/agents/voyage/actions.py
@@ -30,10 +30,11 @@ class ActionContext:
     step_id: Any | None = None  # 当前节点 id（动作查自己的闸门等；engine 注入）
 
     async def notify(self, message: dict[str, Any]) -> None:
-        """向项目通知频道发布事件（bus 未注入 / 无起源课题时为 no-op）。"""
-        # P9a：独立库任务无 project_id，无项目通知频道，静默跳过。
-        if self.bus is not None and self.run.project_id is not None:
-            await self.bus.publish_notify(self.run.project_id, message)
+        """向发起人的通知频道发布事件（bus 未注入 / 无发起人时为 no-op）。"""
+        # #721：频道改按用户组织，独立库任务（无 project_id）的通知不再丢失；
+        # created_by 为空只剩 cron 等无人值守场景——没人在听，跳过即可。
+        if self.bus is not None and self.run.created_by is not None:
+            await self.bus.publish_notify(self.run.created_by, message)
 
     async def log(self, message: str, *, level: str = "info") -> None:
         """向本任务日志频道发一条进度日志（任务详情页 terminal 消费）。

--- a/src/backend/app/agents/voyage/engine.py
+++ b/src/backend/app/agents/voyage/engine.py
@@ -218,16 +218,17 @@ class VoyageEngine:
             await self._bus.publish_voyage_event(run_id, event, data)
 
     async def _emit_notify(
-        self, project_id: uuid.UUID | None, message: dict[str, Any]
+        self, user_id: uuid.UUID | None, message: dict[str, Any]
     ) -> None:
-        # P9a：库化任务可能无起源课题（project_id 为空）——无项目通知频道，静默跳过。
-        if project_id is not None and self._bus is not None:
-            await self._bus.publish_notify(project_id, message)
+        # #721：通知频道按用户组织（notify:user:{id}），库化任务（无起源课题）
+        # 一样能送达发起人；user_id 为空只剩 cron 等无人值守场景，静默跳过。
+        if user_id is not None and self._bus is not None:
+            await self._bus.publish_notify(user_id, message)
 
     async def _emit_status(self, run: VoyageRun) -> None:
         await self._emit_voyage(run.id, "status", {"status": run.status, "cursor": run.cursor})
         await self._emit_notify(
-            run.project_id,
+            run.created_by,
             {"type": "voyage.status", "voyage_id": str(run.id), "status": run.status},
         )
 
@@ -346,7 +347,7 @@ class VoyageEngine:
                     {"message": messages_service.serialize_message(message)},
                 )
                 await self._emit_notify(
-                    run.project_id,
+                    run.created_by,
                     {
                         "type": "voyage.ask",
                         "voyage_id": str(run.id),
@@ -363,7 +364,7 @@ class VoyageEngine:
             experiment = await experiments_service.mark_waiting_by_voyage(session, run.id)
             if experiment is not None:
                 await self._emit_notify(
-                    experiment.project_id,
+                    run.created_by,
                     {
                         "type": "experiment.status",
                         "experiment_id": str(experiment.id),
@@ -591,7 +592,7 @@ class VoyageEngine:
             if experiment is not None:
                 # WS 状态联动：原先由报告动作的 _set_status 发，现在终态在这里落定
                 await self._emit_notify(
-                    run.project_id,
+                    run.created_by,
                     {
                         "type": "experiment.status",
                         "experiment_id": str(experiment.id),
@@ -910,7 +911,7 @@ class VoyageEngine:
             run, f"步骤 {node_index} 需要 {gate.kind} 人工审批，任务暂停", level="gate"
         )
         await self._emit_notify(
-            run.project_id,
+            run.created_by,
             {
                 "type": "gate.created",
                 "gate": {

--- a/src/backend/app/api/experiments.py
+++ b/src/backend/app/api/experiments.py
@@ -557,7 +557,7 @@ async def cancel_experiment(
     except experiments_service.ExperimentAlreadyFinishedError as e:
         raise HTTPException(status.HTTP_409_CONFLICT, detail="EXPERIMENT_ALREADY_FINISHED") from e
     await bus.publish_notify(
-        experiment.project_id,
+        user.id,
         {
             "type": "experiment.status",
             "experiment_id": str(experiment.id),
@@ -566,7 +566,7 @@ async def cancel_experiment(
     )
     if experiment.voyage_id is not None:
         await bus.publish_notify(
-            experiment.project_id,
+            user.id,
             {
                 "type": "voyage.status",
                 "voyage_id": str(experiment.voyage_id),

--- a/src/backend/app/api/gates.py
+++ b/src/backend/app/api/gates.py
@@ -6,7 +6,7 @@
   paper_submission 闸门批准前置稿件 review_passed（M5-C），管理员可传
   override=true 跳过；
 - reject：关联航程置 failed；
-- 决策后向 ``notify:project:{project_id}`` 发布 gate.decided。
+- 决策后向 ``notify:user:{user_id}`` 发布 gate.decided（#721 频道按用户组织）。
 """
 
 import uuid
@@ -124,7 +124,7 @@ async def _decide(
                     voyage_id, "status", {"status": run.status, "cursor": run.cursor}
                 )
                 await bus.publish_notify(
-                    run.project_id,
+                    user.id,
                     {
                         "type": "voyage.status",
                         "voyage_id": str(voyage_id),
@@ -135,7 +135,7 @@ async def _decide(
             experiment = await experiments_service.fail_by_voyage(session, voyage_id)
             if experiment is not None:
                 await bus.publish_notify(
-                    experiment.project_id,
+                    user.id,
                     {
                         "type": "experiment.status",
                         "experiment_id": str(experiment.id),
@@ -148,7 +148,7 @@ async def _decide(
         idea = await ideas_service.promote_from_gate(session, gate)
         if idea is not None:
             await bus.publish_notify(
-                gate.project_id,
+                user.id,
                 {"type": "idea.status", "idea_id": str(idea.id), "status": idea.status},
             )
 
@@ -158,7 +158,7 @@ async def _decide(
     )
     if manuscript is not None:
         await bus.publish_notify(
-            manuscript.project_id,
+            user.id,
             {
                 "type": "manuscript.status",
                 "manuscript_id": str(manuscript.id),
@@ -167,7 +167,7 @@ async def _decide(
         )
 
     await bus.publish_notify(
-        gate.project_id,
+        user.id,
         {"type": "gate.decided", "gate": gate_read.model_dump(mode="json")},
     )
     return gate_read

--- a/src/backend/app/api/ideas.py
+++ b/src/backend/app/api/ideas.py
@@ -271,7 +271,7 @@ async def update_idea(
     idea = await _member_idea(session, idea_id, user)
     idea = await ideas_service.set_idea_status(session, idea, data.status)
     await bus.publish_notify(
-        idea.project_id,
+        user.id,
         {"type": "idea.status", "idea_id": str(idea.id), "status": idea.status},
     )
     return IdeaRead.model_validate(idea)
@@ -297,7 +297,7 @@ async def promote_idea(
     gate = await ideas_service.create_promotion_gate(session, idea, user)
     gate_read = GateRead.model_validate(gate)
     await bus.publish_notify(
-        idea.project_id, {"type": "gate.created", "gate": gate_read.model_dump(mode="json")}
+        user.id, {"type": "gate.created", "gate": gate_read.model_dump(mode="json")}
     )
     return gate_read
 
@@ -430,14 +430,15 @@ async def post_session_message(
     project_id = await review_service.session_project_id(session, review_session)
     message = await review_service.add_human_message(session, review_session, user, data.content)
     message_read = ReviewMessageRead.model_validate(message)
-    if project_id is not None:
-        await bus.publish_notify(
-            project_id,
-            {
-                "type": "review.message",
-                "session_id": str(review_session.id),
-                "project_id": str(project_id),
-                "message": message_read.model_dump(mode="json"),
-            },
-        )
+    # #721：频道按用户组织，库级评审会话（无起源课题）的消息也照发；
+    # project_id 保留在载荷里给前端按课题过滤，可能为 None。
+    await bus.publish_notify(
+        user.id,
+        {
+            "type": "review.message",
+            "session_id": str(review_session.id),
+            "project_id": str(project_id) if project_id is not None else None,
+            "message": message_read.model_dump(mode="json"),
+        },
+    )
     return message_read

--- a/src/backend/app/api/manuscripts.py
+++ b/src/backend/app/api/manuscripts.py
@@ -1130,11 +1130,11 @@ async def submit_manuscript(
         raise HTTPException(status.HTTP_409_CONFLICT, detail="REVIEW_REQUIRED") from e
     gate_read = GateRead.model_validate(gate)
     await bus.publish_notify(
-        manuscript.project_id,
+        user.id,
         {"type": "gate.created", "gate": gate_read.model_dump(mode="json")},
     )
     await bus.publish_notify(
-        manuscript.project_id,
+        user.id,
         {
             "type": "manuscript.status",
             "manuscript_id": str(manuscript.id),

--- a/src/backend/app/api/voyages.py
+++ b/src/backend/app/api/voyages.py
@@ -328,15 +328,16 @@ async def answer_voyage_ask(
         await bus.publish_voyage_event(
             run.id, "status", {"status": run.status, "cursor": run.cursor}
         )
-        if run.project_id is not None:
-            await bus.publish_notify(
-                run.project_id,
-                {"type": "voyage.status", "voyage_id": str(run.id), "status": run.status},
-            )
+        # #721：频道按用户组织，库级 run（无起源课题）也照发；收件人是当前
+        # 操作者——个人化定位下 run 的归属人就是他。
+        await bus.publish_notify(
+            user.id,
+            {"type": "voyage.status", "voyage_id": str(run.id), "status": run.status},
+        )
         experiment = await experiments_service.fail_by_voyage(session, run.id)
         if experiment is not None:
             await bus.publish_notify(
-                experiment.project_id,
+                user.id,
                 {
                     "type": "experiment.status",
                     "experiment_id": str(experiment.id),
@@ -372,7 +373,7 @@ async def answer_voyage_ask(
     experiment = await experiments_service.resume_from_waiting_by_voyage(session, run.id)
     if experiment is not None:
         await bus.publish_notify(
-            experiment.project_id,
+            user.id,
             {
                 "type": "experiment.status",
                 "experiment_id": str(experiment.id),

--- a/src/backend/app/api/ws.py
+++ b/src/backend/app/api/ws.py
@@ -1,9 +1,9 @@
 """WebSocket 端点。
 
 - ``WS /ws/notifications?token=<jwt>``（docs/api-m1.md §5）：手动校验 JWT（复用
-  fastapi-users JWTStrategy.read_token），订阅用户所在全部项目的
-  ``notify:project:{id}`` 频道并转发（gate.created / gate.decided / voyage.status /
-  manuscript.status）；
+  fastapi-users JWTStrategy.read_token），订阅当前用户自己的
+  ``notify:user:{id}`` 频道并转发（gate.created / gate.decided / voyage.status /
+  manuscript.status）；库级任务（无起源课题）的通知也走这条频道（#721）；
 - ``WS /ws/manuscripts/{file_id}?token=<jwt>``（docs/api-m5-b.md §6）：pycrdt CRDT
   协同房间（y-websocket 二进制协议，房间名 = file id）。on_connect 校验
   JWT + 课题归属 + 文件存在且非 readonly，失败分别以 4401 / 4404 / 4403 关闭。
@@ -19,13 +19,11 @@ import uuid
 from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
 from fastapi_users_db_sqlalchemy import SQLAlchemyUserDatabase
 from redis.asyncio import Redis
-from sqlalchemy import select
 
 from app.api.auth import UserManager, get_jwt_strategy
 from app.core.db import get_sessionmaker
 from app.core.events import notify_channel
 from app.core.redis import get_redis
-from app.models.project import Project
 from app.models.user import User
 from app.services import manuscripts as manuscripts_service
 from app.services import runner_ws as runner_ws_service
@@ -48,12 +46,6 @@ async def authenticate_ws_token(token: str | None) -> User | None:
     return user
 
 
-async def _user_project_ids(user_id: uuid.UUID) -> list[uuid.UUID]:
-    async with get_sessionmaker()() as session:
-        stmt = select(Project.id).where(Project.owner_id == user_id)
-        return [pid for (pid,) in (await session.execute(stmt)).all()]
-
-
 @router.websocket("/ws/notifications")
 async def notifications_ws(
     websocket: WebSocket,
@@ -66,18 +58,14 @@ async def notifications_ws(
         return
     await websocket.accept()
 
-    project_ids = await _user_project_ids(user.id)
+    # 频道按用户组织（#721）：每人恒有且只有一条自己的频道，连课题都没有的
+    # 用户也能收到库级任务的通知，不再需要查课题清单。
     redis: Redis = get_redis()
     pubsub = redis.pubsub()
-    channels = [notify_channel(pid) for pid in project_ids]
-    if channels:
-        await pubsub.subscribe(*channels)
+    channel = notify_channel(user.id)
+    await pubsub.subscribe(channel)
 
     async def forward() -> None:
-        if not channels:
-            # 用户暂无项目：没有频道可订阅（未 subscribe 时 get_message 会抛
-            # RuntimeError），挂起等 watch_disconnect 感知断开即可
-            await asyncio.Event().wait()
         while True:
             message = await pubsub.get_message(ignore_subscribe_messages=True, timeout=5.0)
             if message is None:
@@ -106,8 +94,7 @@ async def notifications_ws(
     finally:
         for task in tasks:
             task.cancel()
-        if channels:
-            await pubsub.unsubscribe(*channels)
+        await pubsub.unsubscribe(channel)
         await pubsub.aclose()
 
 

--- a/src/backend/app/core/events.py
+++ b/src/backend/app/core/events.py
@@ -1,7 +1,7 @@
 """实时事件总线：向 Redis 频道发布 JSON 事件（频道约定见 docs/api-m1.md §6）。
 
 - ``voyage:{id}:events``：voyage 引擎发布，SSE 端点订阅转发
-- ``notify:project:{project_id}``：gate/voyage 状态变化，WS 端点订阅转发
+- ``notify:user:{user_id}``：gate/voyage 状态变化，WS 端点订阅转发
 - ``crdt:stream``：worker（AI 起草）发布分节流式增量，API 进程订阅后代写活跃
   CRDT 房间（跨进程直播 AI 撰写；worker 与 API 是独立容器，房间只在 API 进程）
 """
@@ -20,8 +20,14 @@ def voyage_channel(voyage_id: uuid.UUID | str) -> str:
     return f"voyage:{voyage_id}:events"
 
 
-def notify_channel(project_id: uuid.UUID | str) -> str:
-    return f"notify:project:{project_id}"
+def notify_channel(user_id: uuid.UUID | str) -> str:
+    """按用户组织的通知频道（#721）。
+
+    以前按课题（notify:project:{id}）组织：库级任务没有起源课题，通知只能
+    静默丢掉；个人化定位后课题恒归属单人，按用户组织既覆盖库级任务，又让
+    WS 端只需订阅自己一条频道。pub/sub 无持久化，旧频道没有留存问题。
+    """
+    return f"notify:user:{user_id}"
 
 
 def paper_task_channel(task_id: str) -> str:
@@ -82,9 +88,9 @@ class EventBus:
                 level=data.get("level"),
             )
 
-    async def publish_notify(self, project_id: uuid.UUID | str, message: dict[str, Any]) -> None:
+    async def publish_notify(self, user_id: uuid.UUID | str, message: dict[str, Any]) -> None:
         payload = json.dumps(message, ensure_ascii=False, default=str)
-        await self._redis.publish(notify_channel(project_id), payload)
+        await self._redis.publish(notify_channel(user_id), payload)
 
     async def publish_crdt_stream(self, command: dict[str, Any]) -> None:
         """AI 起草分节流式命令（op=open|delta|replace，含 file_id/section/text）。"""

--- a/src/backend/app/services/managed_command_watchdog.py
+++ b/src/backend/app/services/managed_command_watchdog.py
@@ -36,7 +36,8 @@ RECHECK_MINUTES = 30
 @dataclass(slots=True, frozen=True)
 class WatchdogEvent:
     voyage_id: uuid.UUID
-    project_id: uuid.UUID | None
+    # #721：通知频道按用户组织，这里带的是 run 归属人（created_by）
+    user_id: uuid.UUID | None
     message: dict[str, Any]
     action: str
     used_memory_mib: int = 0
@@ -267,7 +268,7 @@ async def check_unanswered_managed_commands(
             events.append(
                 WatchdogEvent(
                     voyage_id=run.id,
-                    project_id=run.project_id,
+                    user_id=run.created_by,
                     message=messages_service.serialize_message(ask),
                     action=action,
                     used_memory_mib=usage.used_memory_mib if usage is not None else 0,

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -70,8 +70,8 @@ class RecordingBus:
     async def publish_voyage_event(self, voyage_id, event: str, data: dict) -> None:
         self.voyage_events.append((str(voyage_id), event, data))
 
-    async def publish_notify(self, project_id, message: dict) -> None:
-        self.notify.append((str(project_id), message))
+    async def publish_notify(self, user_id, message: dict) -> None:
+        self.notify.append((str(user_id), message))
 
     async def publish_crdt_stream(self, command: dict) -> None:
         self.crdt_stream.append(command)

--- a/src/backend/tests/test_voyage_ask.py
+++ b/src/backend/tests/test_voyage_ask.py
@@ -126,6 +126,34 @@ async def test_fatal_step_attended_asks(client, queue_stub):
     assert resp.json()["open_ask"]["id"] == str(ask.id)
 
 
+async def test_fatal_step_library_run_notifies_owner(client, queue_stub):
+    """#721：库级 run（无起源课题）的通知不再静默丢——频道按用户组织。"""
+    await register_and_login(client)
+    async with get_sessionmaker()() as session:
+        owner_id = (
+            await session.execute(select(User.id).order_by(User.created_at))
+        ).scalars().first()
+        run = VoyageRun(
+            kind="custom",
+            goal="库级 ask 通知",
+            status="planning",
+            cursor=0,
+            plan=FATAL_PLAN,
+            project_id=None,
+            created_by=owner_id,
+        )
+        session.add(run)
+        await session.commit()
+        run_id = run.id
+
+    engine, bus = _engine()
+    await engine.run(run_id)
+
+    # 提问事件送达发起人自己的频道（notify:user:{id}），而不是被 project_id 判空吞掉
+    assert any(m.get("type") == "voyage.ask" for _u, m in bus.notify)
+    assert bus.notify and all(u == str(owner_id) for u, _m in bus.notify)
+
+
 async def test_fatal_step_unattended_degrades_to_paused_error(client, queue_stub):
     project_id, _headers = await _make_project(client)
     run_id = await _run(project_id, plan=FATAL_PLAN, attended=False)

--- a/src/backend/tests/test_voyage_engine.py
+++ b/src/backend/tests/test_voyage_engine.py
@@ -58,7 +58,7 @@ async def test_demo_voyage_full_loop(client, queue_stub, bus_recorder):
     assert {"status", "step", "log"} <= kinds
     statuses = [e[2]["status"] for e in bus.voyage_events if e[1] == "status"]
     assert "paused_gate" in statuses
-    # gate.created 广播到项目通知频道
+    # gate.created 广播到发起人的通知频道（#721 起按用户组织）
     assert any(m["type"] == "gate.created" for _, m in bus.notify)
 
     # 闸门落库且 payload 关联 voyage

--- a/src/backend/worker/tasks.py
+++ b/src/backend/worker/tasks.py
@@ -183,9 +183,9 @@ async def watch_unanswered_managed_commands(ctx: dict[str, Any]) -> int:
             "ask.updated",
             {"message": event.message, "action": event.action},
         )
-        if event.project_id is not None:
+        if event.user_id is not None:
             await bus.publish_notify(
-                event.project_id,
+                event.user_id,
                 {
                     "type": "voyage.ask.updated",
                     "voyage_id": str(event.voyage_id),

--- a/src/desktop/e2e/e2e.ts
+++ b/src/desktop/e2e/e2e.ts
@@ -96,8 +96,8 @@ async function launch(env: Record<string, string>): Promise<{ app: ElectronAppli
     env,
     timeout: 60_000,
   });
-  // 窗口在 startKernel 之后才创建：docker 引擎首启要跑全部迁移（最长 120s），
-  // 等窗口的超时必须盖过它。
+  // #721 起窗口先于内核创建，几秒内必现；超时保留裕量以防慢 CI。
+  // 引擎启动的等待挪到了页面内（首启等待页），由各组的选择器超时盖住。
   const page = app.windows()[0] ?? ((await app.waitForEvent('window', { timeout: 240_000 })) as Page);
   await page.waitForLoadState('domcontentloaded');
   return { app, page };
@@ -173,7 +173,9 @@ async function groupEngine(): Promise<void> {
     // 免登录（#601）：desktop 档后端 local_session=true，RequireAuth 应静默
     // 换会话直接进工作台。等 AppShell 的侧栏出现即视为「进了应用」；
     // 全新数据库没有课题，会被 RequireTopic 送到 /start。
-    await page.waitForSelector('.sidebar', { timeout: 60_000 });
+    // #721 起窗口先起：docker 引擎首启的迁移（最长 120s）发生在首启等待页
+    // 期间，等待页就绪后整页 reload 再进应用，这条超时必须盖过全程。
+    await page.waitForSelector('.sidebar', { timeout: 240_000 });
     await page.waitForSelector('text=/选择或创建课题|Pick or create a topic/', { timeout: 30_000 });
     check('免登录直达工作台（侧栏 + /start 落地页）', true);
 
@@ -350,6 +352,13 @@ async function groupMarket(): Promise<void> {
     app = r.app;
     const { page } = r;
     await page.waitForFunction('typeof window.polaris?.invoke === "function"', undefined, { timeout: 30_000 });
+    // #721 起内核在窗口之后后台启动：plugins.* 依赖配置树就绪，先等内核
+    // 真正 started 再开始驱动，否则会撞上 ERR_CAPABILITY_UNAVAILABLE。
+    await page.waitForFunction(
+      `window.polaris.invoke('kernel.status').then((s) => s.started === true).catch(() => false)`,
+      undefined,
+      { timeout: 60_000 },
+    );
 
     // 安装引擎固定打 https://registry.npmjs.org：在主进程的全局 fetch 外
     // 包一层，把该域名重定向到本地替身。只改本次 e2e 会话的运行时全局，

--- a/src/desktop/src/main/index.ts
+++ b/src/desktop/src/main/index.ts
@@ -39,15 +39,19 @@ if (!app.requestSingleInstanceLock()) {
     // 一期不处理跳转目标，只保证协议已注册、不会把 URL 当文件打开
   });
 
-  void app.whenReady().then(async () => {
-    // 内核先于 IPC：installIpc 一装好 renderer 就可能打 kernel.status，
-    // 不能让它读到「还没启动」的假象。start 本身不做 IO，不拖慢首窗。
-    await startKernel();
+  void app.whenReady().then(() => {
     app.setAsDefaultProtocolClient(DEEP_LINK_SCHEME);
     handleAppProtocol(() => readConfig().serverUrl);
     installIpc();
     installMenu();
+    // 窗口先起、内核后台启动（#721）：打包态首启的内嵌引擎引导要下载
+    // Python 工具链、装依赖，可能长达数分钟——以前 await startKernel 在
+    // createWindow 之前，用户这几分钟连窗口都看不到，像没装上一样。
+    // 现在渲染层经 kernel.engineBootstrapStatus 轮询进度并显示首启等待页；
+    // 期间 kernel.status/localBackend 读到「还没启动」是真实状态而不是假象，
+    // 等待页正是为消化这个窗口期而存在。
     createWindow();
+    void startKernel().catch((err) => console.error('[kernel] start failed:', err));
 
     app.on('activate', () => {
       if (!getWindow()) createWindow();

--- a/src/desktop/src/main/kernel.ts
+++ b/src/desktop/src/main/kernel.ts
@@ -61,11 +61,16 @@ export function marketPluginsDir(): string {
 }
 
 /**
- * 内嵌引擎引导进度，kernel.engineBootstrapStatus 直接读它。
- * idle = 没走内嵌路径（开发态 / 显式 env）；failed = 引导失败已回落远端。
- * 渲染层的进度条二期再接，这里先把契约与状态源立起来。
+ * 内嵌引擎引导进度，kernel.engineBootstrapStatus 直接读它（#721 起窗口先于
+ * 内核创建，渲染层的首启等待页轮询这个状态）。
+ * - starting：内核启动中，还不知道走不走内嵌路径（初始态）
+ * - check/python/venv/install：内嵌引导各阶段（见 engine-bootstrap.ts）
+ * - engine：环境已装好，引擎进程启动中（首启迁移可能要一会儿）
+ * - ready + done：引擎已健康，本地地址可用
+ * - idle + done：没走内嵌路径（开发态 / 显式 env / 无引擎），按远端流程走
+ * - failed + done：内嵌引导或引擎启动失败，已回落远端流程
  */
-let bootstrapStatus: EngineBootstrapStatus = { phase: 'idle', done: false };
+let bootstrapStatus: EngineBootstrapStatus = { phase: 'starting', done: false };
 
 /**
  * 首启种子树。只在 store 完全为空时写入：树是用户状态的真相，任何非空
@@ -124,11 +129,14 @@ async function bootstrapPackagedEngine(): Promise<LegacyEngineConfig | null> {
       dataDir: app.getPath('userData'),
       onProgress: ({ phase, line }) => {
         bootstrapStatus = { phase, done: false };
-        // 首启会下载 Python 工具链，日志是唯一的可观测面（进度条二期接）
+        // 首启会下载 Python 工具链，日志与首启等待页是仅有的可观测面
         if (line) console.log(`[engine-bootstrap] ${line}`);
       },
     });
-    bootstrapStatus = { phase: 'ready', done: true };
+    // 环境装好 ≠ 可用：引擎进程还要跑迁移并通过健康检查（下方 entry.update
+    // 才等它），done 必须等引擎真的健康——否则首启等待页会提前放行，
+    // 前端探测拿到 null 又回落远端，等待整段白等。
+    bootstrapStatus = { phase: 'engine', done: false };
     return config;
   } catch (err) {
     bootstrapStatus = { phase: 'failed', done: true };
@@ -137,9 +145,22 @@ async function bootstrapPackagedEngine(): Promise<LegacyEngineConfig | null> {
   }
 }
 
-/** 幂等启动：重复调用返回同一实例（app ready 与 smoke 都可能触发）。 */
+let startingKernel: Promise<Kernel> | null = null;
+
+/** 幂等启动：重复调用返回同一实例（app ready 与 smoke 都可能触发）。
+    #721 起启动在窗口之后台进行，启动中的并发调用共享同一个 Promise。 */
 export async function startKernel(): Promise<Kernel> {
   if (kernel) return kernel;
+  startingKernel ??= doStartKernel().finally(() => {
+    startingKernel = null;
+  });
+  return startingKernel;
+}
+
+async function doStartKernel(): Promise<Kernel> {
+  // smoke 等场景会 stop 后再次 start：进度回到初始态，别让上一轮的
+  // ready/failed 冒充本轮结论
+  bootstrapStatus = { phase: 'starting', done: false };
   const instance = createKernel({ name: 'polaris-desktop' });
 
   // 持久层先于 loader 直挂：配置树就存在这里。失败不阻断启动——树退化
@@ -230,8 +251,8 @@ export async function startKernel(): Promise<Kernel> {
     // 改内存态并同步拉起 fiber，磁盘上始终是 disabled 占位——树保存用户
     // 意图（要不要这个插件），引擎参数每次启动现算注入。
     // entry.update 内部 init → fiber.await()：resolve 返回时引擎已健康或
-    // 已抛错。窗口在 startKernel 之后才创建，所以 kernel.localBackend 与
-    // CSP 在首个页面请求时就已是最终答案（与旧直挂语义一致）。
+    // 已抛错。#721 起窗口先于内核创建：首个文档的 CSP 可能没放行本地引擎，
+    // 前端首启等待页在 bootstrapStatus done 后 reload 拿到最终 CSP 与地址。
     const entry = configTree.store['legacy-engine'];
     if (entry) {
       try {
@@ -251,6 +272,17 @@ export async function startKernel(): Promise<Kernel> {
 
   await instance.start();
   kernel = instance;
+  // 引导进度收尾：走了内嵌路径的（engine 阶段）以引擎服务是否真挂出为准；
+  // 没走内嵌路径的（starting 一路没变过：开发态 / 显式 env / 无引擎）标成
+  // idle——env 引擎的健康等待已在上方 entry.update 完成，前端拿 done 后
+  // 探测 localBackend 即得最终答案。failed（引导抛错）保持原样不覆盖。
+  if (bootstrapStatus.phase === 'engine') {
+    bootstrapStatus = localBackend().baseUrl
+      ? { phase: 'ready', done: true }
+      : { phase: 'failed', done: true };
+  } else if (bootstrapStatus.phase === 'starting') {
+    bootstrapStatus = { phase: 'idle', done: true };
+  }
   return instance;
 }
 
@@ -261,6 +293,9 @@ export async function startKernel(): Promise<Kernel> {
  * 关库排在其后，不需要在这里显式 flush。
  */
 export async function stopKernel(): Promise<void> {
+  // 启动进行中（窗口先起后用户立刻退出）：等启动收尾再停，否则 kernel
+  // 还没赋值、stop 变 no-op，引导中拉起的引擎子进程/容器就漏掉了。
+  if (startingKernel) await startingKernel.catch(() => undefined);
   const instance = kernel;
   kernel = null;
   if (instance) await instance.stop();

--- a/src/desktop/src/shared/contract.ts
+++ b/src/desktop/src/shared/contract.ts
@@ -103,9 +103,12 @@ export interface LocalBackendInfo {
 
 /**
  * 内嵌引擎（打包态自带的 Python 后端）的引导进度。首启要下载 Python
- * 工具链并安装依赖，可能长达数分钟——前端进度条二期接这个方法轮询。
- * phase：idle（没走内嵌路径）/ check / python / venv / install / ready /
- * failed（引导失败，已回落远端流程）。done 在 ready 或 failed 时为 true。
+ * 工具链并安装依赖，可能长达数分钟——窗口先于内核创建（#721），前端的
+ * 首启等待页轮询这个方法。
+ * phase：starting（内核启动中，路径未定）/ check / python / venv / install /
+ * engine（环境已装好，引擎进程启动中）/ ready / idle（没走内嵌路径，按
+ * 远端或显式 env 流程）/ failed（引导或引擎启动失败，已回落远端流程）。
+ * done 在 ready / idle / failed 时为 true。
  */
 export interface EngineBootstrapStatus {
   phase: string;
@@ -220,7 +223,7 @@ export interface Methods {
   'kernel.status': { params: void; result: KernelStatus };
   /** 本地引擎地址；前端启动时问一次，非空则 REST/WS 全走本地。 */
   'kernel.localBackend': { params: void; result: LocalBackendInfo };
-  /** 内嵌引擎引导进度；首启 bootstrap 期间轮询可得阶段信息。 */
+  /** 内嵌引擎引导进度；首启等待页轮询它决定何时放行进应用。 */
   'kernel.engineBootstrapStatus': { params: void; result: EngineBootstrapStatus };
 
   /* ---- plugins.*：配置树管理（#705）。能力位 plugins.manage 不可用

--- a/src/desktop/src/smoke.ts
+++ b/src/desktop/src/smoke.ts
@@ -66,7 +66,9 @@ function check(label: string, ok: boolean, detail = ''): void {
 void app.whenReady().then(async () => {
   handleAppProtocol(() => SERVER_URL);
   installIpc(); // preload 的 sendSync 依赖它，不装就测不到真实注入链路
-  const kernelInstance = await startKernel(); // 与 main/index.ts 同序：内核先于窗口，kernel.status 才是真的
+  // 白盒断言需要内核已就绪：这里显式 await（生产 main/index.ts 自 #721 起
+  // 窗口先起、内核后台启动，渲染层靠首启等待页消化启动窗口期）
+  const kernelInstance = await startKernel();
 
   console.log('CSP');
   const csp = buildCsp(SERVER_URL);

--- a/src/frontend/src/features/desktop/EngineBootstrapPage.tsx
+++ b/src/frontend/src/features/desktop/EngineBootstrapPage.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useRef, useState } from 'react';
+import { Icon } from '../../components/ui/Icon';
+import { LangToggle } from '../../components/ui/LangToggle';
+import { PolarisMark, PolarisWordmark } from '../../components/ui/PolarisLogo';
+import {
+  engineBootstrapStatus,
+  kernelLocalBackend,
+  type EngineBootstrapStatus,
+} from '../../lib/host';
+import { tr, useLang } from '../../lib/i18n';
+import { BOOTSTRAP_STEPS, bootstrapGate, bootstrapStepIndex } from './engineBootstrap';
+
+/**
+ * 桌面端首启等待页（#721）：窗口先起、内核在后台准备本机引擎，这里轮询
+ * kernel.engineBootstrapStatus 给用户看得见的进度，而不是几分钟的白屏。
+ *
+ * 就绪后的放行分两条路：
+ * - 探测到本地引擎地址 → 整页 reload。当前文档是引擎起来**之前**加载的，
+ *   CSP 里没放行 127.0.0.1，不重载的话对本地引擎的一切请求都会被拦；
+ *   重载后 main.tsx 的启动探测直接命中就绪状态，不会再回到这页。
+ * - 没有本地引擎（idle / failed 后用户选择远程）→ onProceed() 进应用，
+ *   App 按既有逻辑落到服务器配置页或远端流程。
+ */
+export function EngineBootstrapPage({
+  initialStatus,
+  onProceed,
+}: {
+  initialStatus: EngineBootstrapStatus;
+  onProceed: () => void;
+}) {
+  useLang();
+  const [status, setStatus] = useState(initialStatus);
+  const [leaving, setLeaving] = useState(false);
+  const proceededRef = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const id = window.setInterval(() => {
+      void engineBootstrapStatus().then((next) => {
+        if (!cancelled && next) setStatus(next);
+      });
+    }, 1000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, []);
+
+  const gate = bootstrapGate(status);
+
+  useEffect(() => {
+    if (gate !== 'proceed' || proceededRef.current) return;
+    proceededRef.current = true;
+    setLeaving(true);
+    void kernelLocalBackend().then((info) => {
+      if (info?.baseUrl) {
+        window.location.reload();
+      } else {
+        onProceed();
+      }
+    });
+  }, [gate, onProceed]);
+
+  const active = bootstrapStepIndex(status.phase);
+
+  return (
+    <div className="auth-page">
+      <div className="auth-brand">
+        <PolarisMark size={56} />
+        <PolarisWordmark height={32} />
+      </div>
+
+      <div className="auth-lang">
+        <LangToggle />
+      </div>
+
+      <div className="auth-card fadeup">
+        {gate === 'failed' ? (
+          <>
+            <div className="auth-card-title">{tr('本机环境没有准备好', 'Local setup did not finish')}</div>
+            <div className="auth-card-sub">
+              {tr(
+                '准备本机运行环境时出了问题。你可以改用远程服务器继续使用；重启应用会再试一次本机环境。',
+                'Something went wrong while preparing the local environment. You can continue with a remote server; restarting the app will retry the local setup.',
+              )}
+            </div>
+            <button
+              type="button"
+              className="btn btn-primary"
+              style={{ width: '100%', justifyContent: 'center', height: 38 }}
+              onClick={() => {
+                if (!proceededRef.current) {
+                  proceededRef.current = true;
+                  onProceed();
+                }
+              }}
+            >
+              <Icon name="arrow" size={14} />
+              {tr('使用远程服务器', 'Use a remote server')}
+            </button>
+          </>
+        ) : (
+          <>
+            <div className="auth-card-title">
+              {leaving ? tr('马上就好…', 'Almost there…') : tr('正在准备本地环境', 'Preparing the local environment')}
+            </div>
+            <div className="auth-card-sub">
+              {tr('首次启动需要几分钟，之后会快很多。', 'The first launch takes a few minutes; later launches are much faster.')}
+            </div>
+            <div style={{ display: 'grid', gap: 10, marginTop: 4 }}>
+              {BOOTSTRAP_STEPS.map((step, i) => {
+                const stepDone = active > i || leaving;
+                const stepActive = active === i && !leaving;
+                return (
+                  <div
+                    key={step.en}
+                    className="row"
+                    style={{
+                      gap: 8,
+                      fontSize: 13,
+                      color: stepActive ? 'var(--text-1)' : stepDone ? 'var(--ok-tx)' : 'var(--text-4)',
+                      fontWeight: stepActive ? 600 : 400,
+                    }}
+                  >
+                    {stepActive ? (
+                      <Icon name="refresh" size={13} style={{ animation: 'spin 1s linear infinite' }} />
+                    ) : (
+                      <Icon name={stepDone ? 'check' : 'dot'} size={13} />
+                    )}
+                    {tr(step.zh, step.en)}
+                  </div>
+                );
+              })}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/features/desktop/ServerSetupPage.tsx
+++ b/src/frontend/src/features/desktop/ServerSetupPage.tsx
@@ -3,7 +3,7 @@ import { Icon } from '../../components/ui/Icon';
 import { LangToggle } from '../../components/ui/LangToggle';
 import { PolarisMark, PolarisWordmark } from '../../components/ui/PolarisLogo';
 import { setToken } from '../../lib/api';
-import { serverOrigin } from '../../lib/endpoint';
+import { localOrigin, remoteServerOrigin } from '../../lib/endpoint';
 import { setServerUrl, testServer, type ServerProbe } from '../../lib/host';
 import { tr, useLang } from '../../lib/i18n';
 
@@ -17,7 +17,12 @@ import { tr, useLang } from '../../lib/i18n';
 export function ServerSetupPage({ onCancel }: { onCancel?: () => void }) {
   // 同登录页：就地重渲染，别把用户正在填的服务器地址和刚探测出的结果冲掉。
   useLang();
-  const [url, setUrl] = useState(serverOrigin());
+  // 回填的是**配置过的远端地址**而不是 serverOrigin()：本地引擎活跃时后者
+  // 是 127.0.0.1，会被误当成「已配置的服务器」填进输入框。
+  const [url, setUrl] = useState(remoteServerOrigin());
+  // 本地引擎活跃：数据在本机、请求走本机，这页填什么当下都不生效——
+  // 如实告诉用户，而不是让「保存后没变化」显得像坏了。
+  const localEngineActive = localOrigin() != null;
   const [probe, setProbe] = useState<ServerProbe | null>(null);
   const [testing, setTesting] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -75,12 +80,21 @@ export function ServerSetupPage({ onCancel }: { onCancel?: () => void }) {
 
       <div className="auth-card fadeup">
         <div className="auth-card-title">{tr('连接到服务器', 'Connect to a server')}</div>
-        <div className="auth-card-sub">
-          {tr(
-            '桌面端本身不存数据，请填写你所在实验室的 Polaris 服务器地址',
-            'The desktop app stores no data of its own — enter your lab’s Polaris server address',
-          )}
-        </div>
+        {localEngineActive ? (
+          <div className="auth-card-sub">
+            {tr(
+              '当前使用本机引擎，数据保存在这台电脑上。服务器地址是可选设置，仅在本机引擎不可用时生效。',
+              'You are using the local engine — your data stays on this computer. A server address is optional and only takes effect when the local engine is unavailable.',
+            )}
+          </div>
+        ) : (
+          <div className="auth-card-sub">
+            {tr(
+              '填写要连接的 Polaris 服务器地址；连接后数据保存在服务器上。',
+              'Enter the address of the Polaris server to connect to; your data will then live on that server.',
+            )}
+          </div>
+        )}
 
         <form onSubmit={(e) => void onSubmit(e)}>
           <div className="auth-field">

--- a/src/frontend/src/features/desktop/engineBootstrap.test.ts
+++ b/src/frontend/src/features/desktop/engineBootstrap.test.ts
@@ -1,0 +1,59 @@
+/* 首启等待页状态机（#721）：纯函数直测。
+
+   契约要点：
+   - null（web / 旧宿主异常）与 idle（没走内嵌路径）都放行——尤其旧宿主的
+     初始值是 idle+done:false，不放行会把旧宿主上的用户永远卡在等待页；
+   - failed 走失败分支（给「使用远程服务器」出路），不算放行也不算等待；
+   - 引导中的所有具名阶段都映射到四步进度里，未知阶段稳妥地不高亮。 */
+
+import { describe, expect, it } from 'vitest';
+import { BOOTSTRAP_STEPS, bootstrapGate, bootstrapStepIndex } from './engineBootstrap';
+
+describe('bootstrapGate', () => {
+  it('web 端 / 桥失败（null）放行', () => {
+    expect(bootstrapGate(null)).toBe('proceed');
+  });
+
+  it('idle 放行——不论 done（旧宿主初始值是 idle+done:false）', () => {
+    expect(bootstrapGate({ phase: 'idle', done: true })).toBe('proceed');
+    expect(bootstrapGate({ phase: 'idle', done: false })).toBe('proceed');
+  });
+
+  it('failed 走失败分支，即使 done=true 也不放行', () => {
+    expect(bootstrapGate({ phase: 'failed', done: true })).toBe('failed');
+  });
+
+  it('引导中的各阶段都等待', () => {
+    for (const phase of ['starting', 'check', 'python', 'venv', 'install', 'engine', 'ready']) {
+      expect(bootstrapGate({ phase, done: false })).toBe('wait');
+    }
+  });
+
+  it('done 后放行（ready 收尾）', () => {
+    expect(bootstrapGate({ phase: 'ready', done: true })).toBe('proceed');
+  });
+});
+
+describe('bootstrapStepIndex', () => {
+  it('具名阶段映射到四步进度', () => {
+    expect(bootstrapStepIndex('python')).toBe(0);
+    expect(bootstrapStepIndex('venv')).toBe(1);
+    expect(bootstrapStepIndex('install')).toBe(2);
+    expect(bootstrapStepIndex('engine')).toBe(3);
+    expect(bootstrapStepIndex('ready')).toBe(3);
+  });
+
+  it('starting/check 与未知阶段不高亮任何一步', () => {
+    expect(bootstrapStepIndex('starting')).toBe(-1);
+    expect(bootstrapStepIndex('check')).toBe(-1);
+    expect(bootstrapStepIndex('whatever-new-phase')).toBe(-1);
+  });
+
+  it('步骤序号都落在展示列表范围内', () => {
+    for (const phase of ['python', 'venv', 'install', 'engine', 'ready']) {
+      const i = bootstrapStepIndex(phase);
+      expect(i).toBeGreaterThanOrEqual(0);
+      expect(i).toBeLessThan(BOOTSTRAP_STEPS.length);
+    }
+  });
+});

--- a/src/frontend/src/features/desktop/engineBootstrap.ts
+++ b/src/frontend/src/features/desktop/engineBootstrap.ts
@@ -1,0 +1,55 @@
+/* ============================================================
+   首启等待页的状态机（纯函数，vitest 直测）。
+
+   桌面端窗口先于内核创建（#721）：打包态首启要在后台下载 Python、装依赖、
+   起引擎，短则秒级长则数分钟。挂载前 main.tsx 问一次引导状态，未就绪就先
+   进等待页轮询；这里只做「状态 → 决策」的纯映射，轮询与副作用在组件里。
+   ============================================================ */
+
+import type { EngineBootstrapStatus } from '../../lib/host';
+
+export type BootstrapGate = 'proceed' | 'wait' | 'failed';
+
+/**
+ * 由引导状态决定挂载去向：
+ * - null（web 端 / 旧宿主 / 桥故障）→ 放行，按既有远端流程走；
+ * - idle = 没走内嵌路径（开发态 / 显式 env）→ 放行。旧宿主的 idle 可能
+ *   done=false（当年初始值如此），也一并放行——旧宿主在窗口前就启动完了；
+ * - failed → 失败页（给「使用远程服务器」出路）；
+ * - 其余按 done 判断：没完就等。
+ */
+export function bootstrapGate(status: EngineBootstrapStatus | null): BootstrapGate {
+  if (status == null) return 'proceed';
+  if (status.phase === 'failed') return 'failed';
+  if (status.phase === 'idle') return 'proceed';
+  return status.done ? 'proceed' : 'wait';
+}
+
+/** 等待页展示的四个阶段（大白话，不用内部术语）。 */
+export const BOOTSTRAP_STEPS = [
+  { zh: '下载 Python', en: 'Downloading Python' },
+  { zh: '创建运行环境', en: 'Creating the environment' },
+  { zh: '安装组件', en: 'Installing components' },
+  { zh: '启动引擎', en: 'Starting the engine' },
+] as const;
+
+/**
+ * phase → 高亮的阶段序号；-1 = 还没进入具名阶段（starting/check：内核
+ * 启动中或复用旧环境的快速检查，几秒内就会有结论）。
+ * ready 归入「启动引擎」：done 之前它只是引导脚本的收尾态。
+ */
+export function bootstrapStepIndex(phase: string): number {
+  switch (phase) {
+    case 'python':
+      return 0;
+    case 'venv':
+      return 1;
+    case 'install':
+      return 2;
+    case 'engine':
+    case 'ready':
+      return 3;
+    default:
+      return -1;
+  }
+}

--- a/src/frontend/src/features/mcp/McpToolsPage.tsx
+++ b/src/frontend/src/features/mcp/McpToolsPage.tsx
@@ -5,7 +5,7 @@ import { Segmented } from '../../components/ui/Segmented';
 import { EmptyState } from '../../components/ui/EmptyState';
 import { toast } from '../../components/ui/Toast';
 import { tr } from '../../lib/i18n';
-import { portalUrl } from '../../lib/endpoint';
+import { localOrigin, portalUrl } from '../../lib/endpoint';
 import { copyText } from '../../lib/clipboard';
 import { useProject } from '../../app/project';
 import { api, getToken, type McpToolCheck, type McpToolInfo } from '../../lib/api';
@@ -203,7 +203,12 @@ export function McpToolsContent() {
   const projectId = pickedProjectId ?? currentProjectId;
   const [includeNetwork, setIncludeNetwork] = useState(false);
 
-  const origin = portalUrl();
+  // 本地模式（桌面端未配置服务器）没有门户地址：端点给出本机引擎的真实
+  // 地址（外部 MCP 客户端与桌面端同机，127.0.0.1 恰好就是对的），并附一行
+  // 「仅本机可访问」说明；以前回落 app://polaris 产出的端点谁都连不上。
+  const portal = portalUrl();
+  const isLocalEndpoint = portal == null && localOrigin() != null;
+  const origin = portal ?? localOrigin() ?? '';
   const httpUrl = `${origin}${data?.endpoint ?? '/mcp'}`;
   const token = getToken() ?? '';
 
@@ -271,6 +276,14 @@ export function McpToolsContent() {
           )}
         </div>
         <CopyRow label={tr('HTTP 端点（Streamable HTTP）', 'HTTP endpoint (Streamable HTTP)')} value={httpUrl} />
+        {isLocalEndpoint && (
+          <div style={{ fontSize: 12, color: 'var(--text-3)', marginTop: -8 }}>
+            {tr(
+              '这是本机引擎的地址，仅这台电脑上的程序可以访问。',
+              'This is your local engine address — only apps on this computer can reach it.',
+            )}
+          </div>
+        )}
         <CopyRow label={tr('访问令牌（你的登录 Bearer token）', 'Access token (your bearer token)')} value={token} secret />
         <div style={{ minWidth: 0 }}>
           <div className="h-eyebrow">{tr('客户端配置（Cursor / 支持 HTTP 的客户端）', 'Client config (Cursor / HTTP clients)')}</div>

--- a/src/frontend/src/features/reading/ChatPanel.tsx
+++ b/src/frontend/src/features/reading/ChatPanel.tsx
@@ -134,6 +134,8 @@ export function ChatPanel({ paperId, pid }: { paperId: string; pid: string }) {
     [paperId],
   );
 
+  // 本地模式（桌面端未配置服务器）没有别人打得开的门户地址：readLink 为
+  // null 时 ChatSurface 分享照常走、只是不附阅读链接（推荐语也不再提链接）。
   const readLink = portalUrl(`/papers/${paperId}/read`);
 
   return (

--- a/src/frontend/src/features/settings/ExtensionApiKeySettings.tsx
+++ b/src/frontend/src/features/settings/ExtensionApiKeySettings.tsx
@@ -6,14 +6,18 @@ import { Modal } from '../../components/ui/Modal';
 import { toast } from '../../components/ui/Toast';
 import { api } from '../../lib/api';
 import { copyText } from '../../lib/clipboard';
-import { portalUrl } from '../../lib/endpoint';
+import { localOrigin, portalUrl } from '../../lib/endpoint';
 import { tr } from '../../lib/i18n';
 
 export function ExtensionApiKeySettings() {
   const [apiKey, setApiKey] = useState<string | null>(null);
   const [keyPrefix, setKeyPrefix] = useState<string | null>(null);
   const [revokeOpen, setRevokeOpen] = useState(false);
-  const baseUrl = portalUrl();
+  // 浏览器扩展跑在同一台电脑上：本地模式（无门户地址）给本机引擎地址
+  // 一样能用，只是别的机器访问不到——附一行说明（#721）。
+  const portal = portalUrl();
+  const isLocalBase = portal == null && localOrigin() != null;
+  const baseUrl = portal ?? localOrigin() ?? '';
 
   const rotateMutation = useMutation({
     mutationFn: () => api.rotateDownloadApiKey(),
@@ -116,6 +120,14 @@ export function ExtensionApiKeySettings() {
               </button>
             </div>
           </FormField>
+          {isLocalBase && (
+            <div style={{ fontSize: 12, color: 'var(--text-3)', marginTop: 6 }}>
+              {tr(
+                '这是本机引擎的地址，仅这台电脑上的浏览器扩展可以使用。',
+                'This is your local engine address — only browser extensions on this computer can use it.',
+              )}
+            </div>
+          )}
         </div>
 
         {apiKey ? (

--- a/src/frontend/src/features/wiki/PaperReader.tsx
+++ b/src/frontend/src/features/wiki/PaperReader.tsx
@@ -74,6 +74,8 @@ export function PaperReader({
   }, [onClose]);
 
   const venueYear = [paper.venue, paper.year].filter(Boolean).join(' · ');
+  // 本地模式下没有门户地址（null）：不渲染「平台阅读链接」——
+  // app:// 链接发给别人只会打不开。
   const readLink = portalUrl(`/papers/${paper.id}/read`);
   const sourceUrl = paper.arxiv_id ? `https://arxiv.org/abs/${paper.arxiv_id}` : paper.url ?? null;
   const sourceLabel = paper.arxiv_id ? `arXiv:${paper.arxiv_id}` : tr('论文源链接', 'Source');
@@ -126,10 +128,12 @@ export function PaperReader({
               </div>
             )}
             <div className="paper-reader-links">
-              <a href={readLink} target="_blank" rel="noreferrer noopener">
-                <Icon name="book" size={12} />
-                {tr('平台阅读链接', 'Read on platform')}
-              </a>
+              {readLink && (
+                <a href={readLink} target="_blank" rel="noreferrer noopener">
+                  <Icon name="book" size={12} />
+                  {tr('平台阅读链接', 'Read on platform')}
+                </a>
+              )}
               {sourceUrl && (
                 <a href={sourceUrl} target="_blank" rel="noreferrer noopener">
                   <Icon name="link" size={12} />

--- a/src/frontend/src/lib/endpoint.ts
+++ b/src/frontend/src/lib/endpoint.ts
@@ -66,6 +66,20 @@ function remoteOrigin(): string {
 }
 
 /**
+ * 用户配置的远端服务器地址（桌面端；web 端与未配置时为 ''）。
+ * 服务器配置页用它回填输入框——serverOrigin() 在本地引擎活跃时返回
+ * 127.0.0.1，拿去回填会把本地引擎地址当成「已配置的服务器」展示。
+ */
+export function remoteServerOrigin(): string {
+  return remoteOrigin();
+}
+
+/** 本地引擎 origin（如 http://127.0.0.1:18080）；未探测到时为 null。 */
+export function localOrigin(): string | null {
+  return localBase;
+}
+
+/**
  * 服务器 origin：web 端为 ''（同源，走相对路径），桌面端为配置的地址（已去尾斜杠）；
  * 探测到本地引擎时本地优先。
  * 故意做成函数而非模块级常量：避免依赖「注入早于本模块求值」这一隐式时序。
@@ -91,12 +105,19 @@ export function wsUrl(path: string): string {
 }
 
 /**
- * 面向「别人也能打开」的链接：邀请/分享链接、给外部 MCP 客户端的服务端点。
- * 收件人多数用浏览器打开，所以桌面端要指向服务器上的 web 门户，而不是 app:// 本地页面。
+ * 面向「别人也能打开」的链接：分享链接、给外部客户端的服务端点。
+ * 收件人多数用浏览器打开，所以桌面端要指向服务器上的 web 门户，而不是
+ * app:// 本地页面。桌面端未配置远端服务器时返回 null（#721）：以前回落
+ * window.location.origin 会产出 app://polaris/... 这种别人根本打不开的
+ * 链接，各消费点必须自己决定「隐藏入口」还是「换成本机地址 + 说明」。
  */
-export function portalUrl(path = ''): string {
-  // 刻意用 remoteOrigin 而不是 serverOrigin：分享/邀请链接给别人打开，
+export function portalUrl(path = ''): string | null {
+  // 刻意用 remoteOrigin 而不是 serverOrigin：分享链接给别人打开，
   // 指向本机 127.0.0.1 的本地引擎对收件人毫无意义。
-  const origin = remoteOrigin() || (typeof window === 'undefined' ? '' : window.location.origin);
-  return `${origin}${path}`;
+  if (isDesktop()) {
+    const origin = remoteOrigin();
+    return origin ? `${origin}${path}` : null;
+  }
+  // web 端保持原行为：同源相对场景下 location.origin 就是真实门户地址
+  return `${typeof window === 'undefined' ? '' : window.location.origin}${path}`;
 }

--- a/src/frontend/src/lib/host.ts
+++ b/src/frontend/src/lib/host.ts
@@ -101,12 +101,33 @@ export interface LocalBackendInfo {
 
 /**
  * 问主进程要本地引擎地址；web 端返回 null（无桥，零请求）。
- * 只被 endpoint.ts 的启动探测调用，业务代码不要直接用。
+ * 只被 endpoint.ts 的启动探测与首启等待页调用，业务代码不要直接用。
  */
 export async function kernelLocalBackend(): Promise<LocalBackendInfo | null> {
   const b = bridge();
   if (!b) return null;
   return (await b.invoke('kernel.localBackend')) as LocalBackendInfo;
+}
+
+/** 内嵌引擎引导进度（contract.ts 的 EngineBootstrapStatus 镜像）。 */
+export interface EngineBootstrapStatus {
+  phase: string;
+  done: boolean;
+}
+
+/**
+ * 内嵌引擎引导进度；web 端返回 null。窗口先于内核创建（#721），首启
+ * 等待页靠轮询它决定何时放行进应用。invoke 失败（旧宿主/桥故障）也折叠
+ * 成 null——按「无引导流程」处理，宁可回落远端也不卡死首屏。
+ */
+export async function engineBootstrapStatus(): Promise<EngineBootstrapStatus | null> {
+  const b = bridge();
+  if (!b) return null;
+  try {
+    return (await b.invoke('kernel.engineBootstrapStatus')) as EngineBootstrapStatus;
+  } catch {
+    return null;
+  }
 }
 
 /* —— 能力清单 ——

--- a/src/frontend/src/main.tsx
+++ b/src/frontend/src/main.tsx
@@ -1,8 +1,10 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App';
+import { EngineBootstrapPage } from './features/desktop/EngineBootstrapPage';
+import { bootstrapGate } from './features/desktop/engineBootstrap';
 import { probeLocalBackend } from './lib/endpoint';
-import { hasHost, hostPlatform } from './lib/host';
+import { engineBootstrapStatus, hasHost, hostPlatform } from './lib/host';
 import './styles/global.css';
 
 // 桌面端把平台标在 <html> 上：macOS 的 hiddenInset 标题栏需要页面自己给
@@ -22,18 +24,36 @@ if (!container) {
   throw new Error('#root element not found');
 }
 
-const render = () =>
-  createRoot(container).render(
+const root = createRoot(container);
+const renderApp = () =>
+  root.render(
     <StrictMode>
       <App />
     </StrictMode>,
   );
 
-// 桌面端先问一次本地引擎地址再挂载（一次 IPC 往返，毫秒级）：让首屏请求
-// 就走对地址，而不是发出去之后才发现该走 127.0.0.1。web 端没有宿主桥，
+// 桌面端挂载前的两步探测（各一次 IPC 往返，毫秒级）；web 端没有宿主桥，
 // 保持原来的同步挂载路径，行为一字不变。
+// 1. 内核引导状态（#721）：窗口现在先于内核创建，打包态首启内核还在后台
+//    装环境——此刻探测本地引擎只会得到 null 然后误落远端流程。未就绪就
+//    先进等待页，就绪/失败后由等待页负责重探或给出远程出路。
+// 2. 本地引擎地址：让首屏请求就走对地址，而不是发出去之后才发现该走
+//    127.0.0.1。
 if (hasHost()) {
-  void probeLocalBackend().finally(render);
+  void engineBootstrapStatus().then((status) => {
+    if (status == null || bootstrapGate(status) === 'proceed') {
+      void probeLocalBackend().finally(renderApp);
+      return;
+    }
+    root.render(
+      <StrictMode>
+        <EngineBootstrapPage
+          initialStatus={status}
+          onProceed={() => void probeLocalBackend().finally(renderApp)}
+        />
+      </StrictMode>,
+    );
+  });
 } else {
-  render();
+  renderApp();
 }


### PR DESCRIPTION
Closes #721. Part of #715 (audit items 7, 8, 10) — four local-engine correctness fixes in one desktop/frontend/backend pass.

**Share links** — `portalUrl()` returns null with no remote origin instead of emitting `app://polaris/...`: chat share degrades gracefully (no dead link attached), the reader hides its portal anchor, and the MCP/extension endpoint pages show the real `http://127.0.0.1` address with a plain note that it works exactly because those clients run on the same machine; a related backfill bug (the setup page pre-filling 127.0.0.1 as "your server") fixed via a new `remoteServerOrigin()`.

**Server page honesty** — the false "stores no data" and lab-era copy are gone; with a local engine active the page states that data lives on this machine and the remote address is an optional fallback.

**Notifications reach library runs** — channels move from `notify:project:{id}` to `notify:user:{id}`; the engine publishes to `run.created_by` (only unattended cron runs skip), the API sites publish to the acting user, and the ws layer subscribes to one channel; library-scoped runs (wiki ingest, daily sync, discovery) finally notify, pinned by a new test.

**First run shows a window** — the window now opens before the kernel starts; the bootstrap status machine gains an `engine` phase (an installed environment is not a usable one — done waits for engine health) and a full-screen plain-language progress page with a remote-server escape hatch on failure. The CSP timing trap is handled by a one-shot reload once the local origin is known (no reload loop; old-host compatibility preserved), and shutdown during bootstrap awaits the in-flight start so engine children never leak.

Verification: branch vs clean-baseline full suites reconciled (1706 = 1705 + the new notification test; identical 3 pre-existing failures, the two extra ones each green standalone — known clock flakes); frontend vitest 188 incl. 8 new state-machine cases; desktop smoke with the real engine group and e2e groups A (real docker engine — the wait-page→reload→CSP chain verified for real) /B/C all green.