### PR TITLE
fix: unify literature sources behind one registry

### DIFF
--- a/docs/literature.md
+++ b/docs/literature.md
@@ -83,7 +83,8 @@ direction:
 ### The daily feed
 
 **Daily Papers** is the deployment-wide feed of each day's new arXiv announcements (`new` and `cross`
-listings) in the categories an admin subscribes (default `cs.AI`, `cs.CL`, `cs.CV`). A worker probes
+listings) in the categories an admin subscribes. There is no default subscription — until categories
+are added in Settings the feed stays empty and the page says so. A worker probes
 arXiv from a configurable time each day (default 01:30 UTC) until the day's batch actually appears;
 weekends show as quiet because arXiv does not publish. Feed papers enter the content pool as
 lightweight rows — metadata and abstract, no PDF, no LLM cost — and get embeddings so semantic
@@ -267,7 +268,7 @@ Admin settings (Settings → Daily papers):
 
 | Setting | Default | What it does |
 | --- | --- | --- |
-| Subscribed categories | `cs.AI`, `cs.CL`, `cs.CV` | Which arXiv categories the daily feed fetches |
+| Subscribed categories | (empty — add your own) | Which arXiv categories the daily feed fetches |
 | Retention days | 14 (1–90) | How long feed entries live; also the window library syncs can see |
 | Sync time | 01:30 UTC | When the daily probe starts looking for arXiv's batch |
 | Library sync scan scope | Since last sync | What slice of the pool incremental syncs consider (today only / whole pool) |

--- a/src/backend/app/agents/voyage/actions_daily.py
+++ b/src/backend/app/agents/voyage/actions_daily.py
@@ -96,7 +96,14 @@ async def fetch(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
             f"{len(failed)} 个分类抓取失败：{'、'.join(failed)}；"
             "当天这些分类的新论文不会进池，请重试"
         )
-    elif categories and fetched == 0:
+    elif not categories:
+        # 一个分类都没订阅：不是故障，但必须说破——池子永远空着，所有文献库都断供
+        result["note"] = (
+            "还没有订阅任何 arXiv 分类，每日池不会有新论文进来；"
+            "请在 设置 → 每日新论文订阅分类 里添加要跟踪的分类。"
+        )
+        await ctx.log(result["note"], level="warning")
+    elif fetched == 0:
         # 全部分类都抓成功但一篇没有：周末/节假日是正常的，仍提示一句便于对照
         result["note"] = "所有订阅分类今天都没有新公告（周末或节假日时属正常）"
     return result

--- a/src/backend/app/agents/voyage/actions_proposal.py
+++ b/src/backend/app/agents/voyage/actions_proposal.py
@@ -54,8 +54,7 @@ from app.services.libraries import (
     get_source_library_ids,
     member_papers_stmt,
 )
-from app.services.literature.openalex import OpenAlexClient
-from app.services.literature.semantic_scholar import SemanticScholarClient
+from app.services.literature import get_openalex_client, get_s2_client
 from app.services.review import serialize_message
 
 DEFAULT_DEEP_KNOBS: dict[str, Any] = {
@@ -575,41 +574,40 @@ async def _external_search(
     results: list[dict[str, Any]] = []
     seen_titles: set[str] = set()
     ok = True
-    s2 = SemanticScholarClient()
-    openalex = OpenAlexClient()
-    try:
-        for query in queries:
-            rows: list[dict[str, Any]] = []
+    # 用模块级单例而不是裸构造：裸构造的客户端没有共享限速/缓存状态，还绕开
+    # set_clients 注入缝（#720 裸构造修复；进一步凭据轮转经 discovery 注册表）
+    s2 = get_s2_client()
+    openalex = get_openalex_client()
+    for query in queries:
+        rows: list[dict[str, Any]] = []
+        try:
+            rows = await s2.search_papers(query, limit=limit)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001 — S2 失败走 OpenAlex
             try:
-                rows = await s2.search_papers(query, limit=limit)
+                rows = await openalex.search_works(query, limit=limit)
             except asyncio.CancelledError:
                 raise
-            except Exception:  # noqa: BLE001 — S2 失败走 OpenAlex
-                try:
-                    rows = await openalex.search_works(query, limit=limit)
-                except asyncio.CancelledError:
-                    raise
-                except Exception:  # noqa: BLE001 — 双通道均失败：降级
-                    ok = False
-            for row in rows:
-                title = str(row.get("title") or "").strip()
-                key = title.lower()
-                if not title or key in seen_titles:
-                    continue
-                seen_titles.add(key)
-                results.append(
-                    {
-                        "title": title,
-                        "year": row.get("year"),
-                        "venue": row.get("venue") or row.get("journal"),
-                        "url": row.get("url"),
-                        "abstract": (str(row.get("abstract") or ""))[:400] or None,
-                    }
-                )
-            await _log(ctx, f"外部检索「{query}」→ 累计 {len(results)} 篇")
-    finally:
-        await s2.aclose()
-        await openalex.aclose()
+            except Exception:  # noqa: BLE001 — 双通道均失败：降级
+                ok = False
+        for row in rows:
+            title = str(row.get("title") or "").strip()
+            key = title.lower()
+            if not title or key in seen_titles:
+                continue
+            seen_titles.add(key)
+            results.append(
+                {
+                    "title": title,
+                    "year": row.get("year"),
+                    "venue": row.get("venue") or row.get("journal"),
+                    "url": row.get("url"),
+                    "abstract": (str(row.get("abstract") or ""))[:400] or None,
+                }
+            )
+        await _log(ctx, f"外部检索「{query}」→ 累计 {len(results)} 篇")
+    # 单例客户端是全进程共用的连接池，不在这里 aclose（裸构造时代的收尾已退役）
     return results[: limit * 2], ok
 
 

--- a/src/backend/app/agents/voyage/actions_review.py
+++ b/src/backend/app/agents/voyage/actions_review.py
@@ -37,8 +37,7 @@ from app.models.review import ReviewMessage, ReviewSession
 from app.services import latex_compile
 from app.services import paper_review as pr
 from app.services.figure_annotate import prepare_image_for_llm
-from app.services.literature.openalex import OpenAlexClient
-from app.services.literature.semantic_scholar import SemanticScholarClient
+from app.services.literature import get_openalex_client, get_s2_client
 from app.services.review import serialize_message
 
 _MAX_JSON_ATTEMPTS = 3  # 首次 + 重试 2 次（评审员 JSON 严格校验）
@@ -258,48 +257,46 @@ async def review_citation_check(ctx: ActionContext, params: dict[str, Any]) -> d
         done = ctx.checkpoint["citation_check"]
         return {"total": done.get("total", 0), "skipped": True}
 
-    s2 = SemanticScholarClient()
-    openalex = OpenAlexClient()
-    try:
-        async with get_sessionmaker()() as session:
-            manuscript = await _get_manuscript(session, ctx)
-            review_session = await _get_review_session(session, ctx)
-            files = await pr.load_tex_files(session, manuscript.id)
-            fact_citations = list(_fact_pack(manuscript).get("citations") or [])
-            cited = pr.extract_citations(files)
-            items = await pr.check_citation_existence(
-                session, cited, fact_citations, s2=s2, openalex=openalex
+    # 同 actions_proposal：单例客户端保共享限速/缓存与测试注入缝（#720 裸构造修复）
+    s2 = get_s2_client()
+    openalex = get_openalex_client()
+    async with get_sessionmaker()() as session:
+        manuscript = await _get_manuscript(session, ctx)
+        review_session = await _get_review_session(session, ctx)
+        files = await pr.load_tex_files(session, manuscript.id)
+        fact_citations = list(_fact_pack(manuscript).get("citations") or [])
+        cited = pr.extract_citations(files)
+        items = await pr.check_citation_existence(
+            session, cited, fact_citations, s2=s2, openalex=openalex
+        )
+
+        # 支撑性（LLM）：fabricated 不判；超出上限标 not_checked
+        by_key = {str(c.get("bibkey")): c for c in fact_citations if c.get("bibkey")}
+        checked = 0
+        for item in items:
+            if item["existence"] == "fabricated" or checked >= MAX_SUPPORT_CHECKS:
+                continue
+            entry = by_key.get(item["bibkey"]) or {}
+            brief = await _cited_paper_brief(session, entry, item["context_snippet"])
+            user = (
+                f"引用语境（\\cite{{{item['bibkey']}}} 前后 2 句）：\n"
+                f"{item['context_snippet']}\n\n被引论文：\n{brief}"
             )
-
-            # 支撑性（LLM）：fabricated 不判；超出上限标 not_checked
-            by_key = {str(c.get("bibkey")): c for c in fact_citations if c.get("bibkey")}
-            checked = 0
-            for item in items:
-                if item["existence"] == "fabricated" or checked >= MAX_SUPPORT_CHECKS:
-                    continue
-                entry = by_key.get(item["bibkey"]) or {}
-                brief = await _cited_paper_brief(session, entry, item["context_snippet"])
-                user = (
-                    f"引用语境（\\cite{{{item['bibkey']}}} 前后 2 句）：\n"
-                    f"{item['context_snippet']}\n\n被引论文：\n{brief}"
+            try:
+                verdict = await _complete_json(
+                    ctx, system=SUPPORT_SYSTEM_PROMPT, user=user, validate=_validate_support
                 )
-                try:
-                    verdict = await _complete_json(
-                        ctx, system=SUPPORT_SYSTEM_PROMPT, user=user, validate=_validate_support
-                    )
-                    item["support"] = verdict["support"]
-                except asyncio.CancelledError:
-                    raise
-                except Exception:  # noqa: BLE001 — 单条支撑性判定失败不打断核验
-                    item["support"] = "not_checked"
-                checked += 1
+                item["support"] = verdict["support"]
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001 — 单条支撑性判定失败不打断核验
+                item["support"] = "not_checked"
+            checked += 1
 
-            citation_check = {"total": len(items), "items": items}
-            ctx.checkpoint["citation_check"] = citation_check
-            await _merge_payload(session, review_session, {"citation_check": citation_check})
-    finally:
-        await s2.aclose()
-        await openalex.aclose()
+        citation_check = {"total": len(items), "items": items}
+        ctx.checkpoint["citation_check"] = citation_check
+        await _merge_payload(session, review_session, {"citation_check": citation_check})
+    # 单例客户端是全进程共用的连接池，不在这里 aclose（裸构造时代的收尾已退役）
 
     counts: dict[str, int] = {}
     for item in citation_check["items"]:

--- a/src/backend/app/agents/voyage/actions_wiki.py
+++ b/src/backend/app/agents/voyage/actions_wiki.py
@@ -65,12 +65,12 @@ from app.services.libraries import (
     remember_rejected,
 )
 from app.services.literature import get_arxiv_client, get_openalex_client, get_s2_client
+from app.services.literature import sources as literature_sources
 from app.services.literature.arxiv import normalize_arxiv_id
 from app.services.literature.pdf_extract import extract_figures, extract_full_text, save_pdf
 from app.services.paper_enrich import paper_embedding_text
 from app.services.paper_wiki import upsert_wiki
 from app.services.papers import delete_membership_hard
-from app.services.projects import DEFAULT_ARXIV_CATEGORIES
 from app.services.relevance import (
     build_direction_query,
     build_relevance_context,
@@ -502,10 +502,9 @@ async def search_candidates(ctx: ActionContext, params: dict[str, Any]) -> dict[
         definition = library_definition(library)
         direction_query = build_direction_query(definition, library.name)
         keywords_def = definition.get("keywords") or {}
-        # 稀疏 definition 容忍：无 arxiv_categories 时回退默认 cs.* 分类
-        categories = list(keywords_def.get("arxiv_categories") or []) or list(
-            DEFAULT_ARXIV_CATEGORIES
-        )
+        # 分类只认库自己的 definition：没配就不带分类过滤，走纯关键词检索。
+        # 以前这里回退默认 cs.* 三件套——非 CS 的库会被静默灌进计算机论文（#720 A4）。
+        categories = list(keywords_def.get("arxiv_categories") or [])
         include = list(keywords_def.get("include") or [])
         # 排除词与包括词不同：包括词配窄了会让库悄无声息收不到东西，所以同步时不拿它筛；
         # 排除词是用户明确说「我不要这个」，漏掉它反而是失职，三条路径一律生效。
@@ -571,6 +570,41 @@ async def search_candidates(ctx: ActionContext, params: dict[str, Any]) -> dict[
         params = _params(ctx)
         terms = [t for t in (params.get("query_terms") or []) if str(t).strip()] or include
         days = TIME_RANGE_DAYS.get(str(params.get("time_range") or ""))
+        if not categories and not terms:
+            # 关键词、分类两头都空：查询会退化成「窗口内全 arXiv」的无界抓取，
+            # 那不是用户想要的库，是灾难。如实停下并把该配什么讲清楚。
+            messages = [
+                "文献库没有配置检索关键词，也没有指定 arXiv 分类，本次未执行检索。"
+                "请在收录设置里补充「包括关键词」或分类后重试。"
+            ]
+            window = timedelta(days=days or 30 * int(knobs["months_back"]))
+            window_since = (now - window).isoformat()
+            diagnostics = {
+                "source": "arxiv",
+                "source_fetched": 0,
+                "prescreened": 0,
+                "query_found": 0,
+                "inserted": 0,
+                "window_since": window_since,
+                "source_latest_at": None,
+                "cap_hit": False,
+                "status": "warning",
+                "messages": messages,
+            }
+            ctx.checkpoint["ingest_search_stats"] = diagnostics
+            ctx.checkpoint["watermark_candidate"] = now.isoformat()
+            await ctx.log(messages[0], level="warning")
+            return {
+                "source": "arxiv",
+                "found": 0,
+                "inserted": 0,
+                "new_papers": [],
+                "window_since": window_since,
+                "mode": mode,
+                "source_latest_at": None,
+                "diagnostic_status": "warning",
+                "diagnostic_messages": messages,
+            }
         query_signature = hashlib.sha256(
             json.dumps(
                 {
@@ -691,7 +725,8 @@ async def search_candidates(ctx: ActionContext, params: dict[str, Any]) -> dict[
             new_papers.append(paper)
             return True
 
-        arxiv = get_arxiv_client()
+        # 经源注册表取 arXiv 适配器；get_arxiv_client 模块属性保留为客户端注入缝
+        arxiv = literature_sources.require_source("arxiv", client=get_arxiv_client())
         while next_start < limit:
             # 页大小问客户端要，别写死：下面拿 len(entries) < page_size 判末页，
             # 一旦要的比客户端肯给的多，第一页就会被误判成末页，搜索静默截断。
@@ -778,7 +813,7 @@ async def snowball(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]
     if depth == 0:
         return {"skipped": True, "reason": "snowball_depth=0"}
 
-    s2 = get_s2_client()
+    s2 = literature_sources.require_source("semantic", client=get_s2_client())
     failed: list[dict[str, str]] = []
     new_papers: list[Paper] = []
     inserted = 0
@@ -824,14 +859,14 @@ async def snowball(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]
                     break
                 processed_seeds += 1
                 try:
-                    refs = await s2.get_references(f"arXiv:{seed}")
-                    cits = await s2.get_citations(f"arXiv:{seed}")
+                    # snowball 能力 = 参考文献 + 施引文献的合并清单（顺序同旧拼接）
+                    expanded = await s2.snowball(f"arXiv:{seed}")
                 except asyncio.CancelledError:
                     raise
                 except Exception as e:  # noqa: BLE001 — 单个种子失败不打断批处理
                     failed.append({"id": seed, "error": f"{type(e).__name__}: {e}"})
                     continue
-                for item in refs + cits:
+                for item in expanded:
                     if inserted >= max_new:
                         break
                     ext = item.get("externalIds") or {}
@@ -1085,7 +1120,7 @@ def _compile_limit(knobs: dict[str, Any]) -> int:
 async def fetch_extract(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
     knobs = _knobs(ctx)
     top_n = _compile_limit(knobs)
-    arxiv = get_arxiv_client()
+    arxiv = literature_sources.require_source("arxiv", client=get_arxiv_client())
     fetched = 0
     degraded = 0
     failed: list[dict[str, str]] = []
@@ -1160,10 +1195,13 @@ async def fetch_extract(ctx: ActionContext, params: dict[str, Any]) -> dict[str,
             need_date = paper.published_at is None and not paper.arxiv_id
             if (not paper.affiliations or need_date) and (paper.arxiv_id or paper.doi):
                 try:
+                    openalex = literature_sources.require_source(
+                        "openalex", client=get_openalex_client()
+                    )
                     meta = (
-                        await get_openalex_client().get_by_arxiv(paper.arxiv_id)
+                        await openalex.resolve("arxiv", paper.arxiv_id)
                         if paper.arxiv_id
-                        else await get_openalex_client().get_by_doi(paper.doi)
+                        else await openalex.resolve("doi", paper.doi)
                     )
                     if not paper.affiliations:
                         apply_author_affiliations(paper, (meta or {}).get("authors"))

--- a/src/backend/app/agents/voyage/actions_writing.py
+++ b/src/backend/app/agents/voyage/actions_writing.py
@@ -43,7 +43,7 @@ from app.models.manuscript import Manuscript, ManuscriptFile
 from app.services import latex_compile
 from app.services.citations import citation_key_for
 from app.services.crdt_rooms import get_crdt_rooms
-from app.services.literature.semantic_scholar import SemanticScholarClient
+from app.services.literature import get_s2_client
 
 MAX_SECTION_REWRITES = 2  # 静态校验违规重写次数上限
 S2_RELATED_LIMIT = 10  # Related Work 的 S2 title 检索 top-N
@@ -548,13 +548,13 @@ async def writing_section(ctx: ActionContext, params: dict[str, Any]) -> dict[st
 
 async def _s2_candidates(title: str) -> list[dict[str, Any]]:
     """S2 title 检索 top10 → 候选条目（不可达时返回空，降级为仅库内候选）。"""
-    client = SemanticScholarClient()
+    # 单例客户端（共享限速/缓存/注入缝，#720 裸构造修复）；单例不能在这里 aclose——
+    # 关掉的是全进程共用的连接池
+    client = get_s2_client()
     try:
         hits = await client.search_papers(title, limit=S2_RELATED_LIMIT)
     except Exception:  # noqa: BLE001 — 外部 API 失败降级，不阻塞写作
         return []
-    finally:
-        await client.aclose()
     candidates: list[dict[str, Any]] = []
     for hit in hits:
         hit_title = str(hit.get("title") or "").strip()

--- a/src/backend/app/models/daily_feed.py
+++ b/src/backend/app/models/daily_feed.py
@@ -18,8 +18,8 @@ from app.core.db import Base
 from app.models.base import JSONVariant, TimestampMixin, UUIDPrimaryKeyMixin
 from app.models.paper import Paper
 
-# 默认订阅分类；可在 system_settings 的 daily_feed_categories 键覆盖
-DEFAULT_DAILY_CATEGORIES = ["cs.AI", "cs.CL", "cs.CV"]
+# 订阅分类没有代码级默认（#720 A4）：以前这里写死 cs.AI/cs.CL/cs.CV，非 CS
+# 用户会被静默塞满不相干论文。订阅只存 system_settings 的 daily_feed_categories 键。
 
 # 池滚动保留天数（含当天）
 #: 保留天数的**默认值**。运行时以 SystemSetting daily_feed_retention_days 为准

--- a/src/backend/app/schemas/literature_discovery.py
+++ b/src/backend/app/schemas/literature_discovery.py
@@ -67,7 +67,24 @@ class SourceSearchPage(BaseModel):
 
 
 class SourceAdapter(Protocol):
-    """真实来源客户端需要实现的最小异步合同。"""
+    """真实来源客户端需要实现的最小异步合同。
+
+    ``search`` 是唯一必选能力。其余能力**按源自愿实现**，调用方用
+    ``hasattr`` 探测（源注册表 services/literature/sources.py 的内置源
+    即范本），签名约定如下：
+
+    - ``fetch_new(category) -> (entries, batch_at)``：当天新公告增量池
+      （每日推送的供给面；目前只有 arXiv 有「当天公告」这个概念）。
+    - ``resolve(kind, value) -> record | None``：按外部标识解析元数据，
+      kind ∈ {"arxiv", "doi", "corpus_id", …}；能解析哪些 kind 在注册表
+      的 ``resolve_kinds`` 元数据里声明，级联顺序由 ``resolve_priority``
+      决定（paper_import 的 arXiv → OpenAlex 兜底级联从这里派生）。
+    - ``download_pdf(paper_ref) -> bytes``：按源内标识取 PDF 原文。
+    - ``snowball(paper_ref) -> records``：引文扩展（参考文献 + 施引文献）。
+
+    能力方法返回**源原生记录形状**，不做跨源归一化——归一化只发生在
+    ``search`` 的 LiteratureCandidate 出口；这是既有调用点字节等价的前提。
+    """
 
     name: str
 

--- a/src/backend/app/services/daily_feed.py
+++ b/src/backend/app/services/daily_feed.py
@@ -24,7 +24,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.embedding_space import EmbeddingSpace, active_space
 from app.models.daily_feed import (
-    DEFAULT_DAILY_CATEGORIES,
     DailyFeedEntry,
     DailyFeedLike,
 )
@@ -41,6 +40,7 @@ from app.services import topic_shelf as shelf_service
 from app.services.dedup import pool_dedup_key
 from app.services.libraries import can_manage_library, ensure_membership, find_pool_paper
 from app.services.literature import get_arxiv_client
+from app.services.literature import sources as literature_sources
 from app.services.paper_import import _parse_iso
 
 logger = logging.getLogger(__name__)
@@ -82,9 +82,15 @@ def _today_utc() -> dt.date:
 
 
 async def get_categories(session: AsyncSession) -> list[str]:
+    """订阅分类。没配过就是**空**——不再缺省成 cs.* 三件套（#720 A4）。
+
+    以前静默回退 ["cs.AI","cs.CL","cs.CV"]：非 CS 用户的每日池被填满不相干
+    的论文，还以为系统坏了。现在空列表如实返回，抓取端拿到空就不抓，
+    API/前端提示「先在设置里订阅分类」。
+    """
     row = await session.get(SystemSetting, CATEGORIES_SETTING_KEY)
-    if row is None or not isinstance(row.value, list) or not row.value:
-        return list(DEFAULT_DAILY_CATEGORIES)
+    if row is None or not isinstance(row.value, list):
+        return []
     return [str(c) for c in row.value]
 
 
@@ -98,8 +104,8 @@ async def set_categories(session: AsyncSession, categories: list[str]) -> list[s
             raise InvalidCategoryError(cat)
         if cat not in cleaned:
             cleaned.append(cat)
-    if not cleaned:
-        raise InvalidCategoryError("(empty)")
+    # 允许清空：空订阅是合法状态（池子停止进新论文，界面另有提示），
+    # 不再用「至少留一个分类」逼着用户保留不相干的缺省
     row = await session.get(SystemSetting, CATEGORIES_SETTING_KEY)
     if row is None:
         session.add(SystemSetting(key=CATEGORIES_SETTING_KEY, value=cleaned))
@@ -293,7 +299,8 @@ async def fetch_new_by_category(
     状态取值：``ok``（抓到了，可能是 0 篇——周末/无公告是正常的）、``error``。
     """
     categories = await get_categories(session)
-    client = get_arxiv_client()
+    # 经源注册表取 arXiv 适配器；get_arxiv_client 模块属性保留为客户端注入缝
+    client = literature_sources.require_source("arxiv", client=get_arxiv_client())
     by_category: dict[str, list[dict[str, Any]]] = {}
     statuses: dict[str, dict[str, Any]] = {}
     for category in categories:
@@ -564,6 +571,23 @@ async def create_daily_feed_voyage(
 # ---- 池浏览 ----
 
 
+def _category_rank_case(subscribed: list[str]) -> Any:
+    """订阅顺序 → 列表排序优先级的 CASE 表达式。
+
+    LIKE 序列化文本的写法与列表接口的 category 过滤同口径（categories 是
+    JSON 数组，PG/sqlite 通用）。空订阅返回常量 0（全部同级，按日期排）。
+    """
+    whens = [
+        (
+            (DailyFeedEntry.primary_category == category)
+            | cast(DailyFeedEntry.categories, String).like(f'%"{category}"%'),
+            index,
+        )
+        for index, category in enumerate(subscribed)
+    ]
+    return case(*whens, else_=len(subscribed)) if whens else literal(0)
+
+
 def _like_count_sq() -> Any:
     return (
         select(func.count(DailyFeedLike.id))
@@ -759,21 +783,10 @@ async def list_papers(
     total = (await session.execute(count_stmt)).scalar_one()
 
     likes_sq = _like_count_sq()
-    # 分类优先级打头：cs.CL 的排最前，cs.RO 的排最后（一篇同时挂两者按 cs.CL 算）。
-    # LIKE 序列化文本的写法与上面 category 过滤同口径，PG/sqlite 通用。
-    category_rank = case(
-        (
-            (DailyFeedEntry.primary_category == "cs.CL")
-            | cast(DailyFeedEntry.categories, String).like('%"cs.CL"%'),
-            0,
-        ),
-        (
-            (DailyFeedEntry.primary_category == "cs.RO")
-            | cast(DailyFeedEntry.categories, String).like('%"cs.RO"%'),
-            2,
-        ),
-        else_=1,
-    )
+    # 分类优先级打头：按**订阅列表的顺序**排（越靠前的分类越先出现；一篇挂多个
+    # 分类按最靠前的算）。以前写死 cs.CL 最前、cs.RO 最后——CS 分类学不该长在
+    # 代码里，顺序跟着用户自己的订阅走（#720 A4）。没订阅分类时全部同级。
+    category_rank = _category_rank_case(await get_categories(session))
     # 同分类里，新工作排在交叉提交（更新）前面：新工作才是当天真正的新东西
     announce_rank = case((DailyFeedEntry.announce_type == "new", 0), else_=1)
     if sort == "relevance":
@@ -1697,13 +1710,16 @@ async def todays_batch_available(session: AsyncSession) -> tuple[bool, str | Non
     """
     categories = await get_categories(session)
     if not categories:
-        return True, None
+        # 没订阅任何分类：无可收之物，不该开一轮同步（空转还会把当天锁死）
+        return False, None
 
     today = _today_utc()
     latest: dt.date | None = None
     for category in categories:
         try:
-            entries, batch_at = await get_arxiv_client().fetch_new(category)
+            entries, batch_at = await literature_sources.require_source(
+                "arxiv", client=get_arxiv_client()
+            ).fetch_new(category)
         except Exception:  # noqa: BLE001 — 探测失败不下结论，交给正式抓取去报错
             logger.warning("daily feed probe failed for %s", category, exc_info=True)
             return True, None

--- a/src/backend/app/services/literature/runtime.py
+++ b/src/backend/app/services/literature/runtime.py
@@ -10,7 +10,6 @@ import asyncio
 import hashlib
 import json
 import logging
-import threading
 import uuid
 from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime
@@ -37,9 +36,10 @@ from app.schemas.literature_discovery import (
 from app.services import literature_settings
 from app.services.interdisciplinary_retrieval import rerank_interdisciplinary
 from app.services.literature import discovery_runs
+from app.services.literature import sources as source_registry
 from app.services.literature.discovery import candidate_dedup_key, validate_candidate
 from app.services.literature.discovery_ranking import SCORING_VERSION, rank_candidates
-from app.services.literature.multi_source import MultiSourceClient, ProviderRequestError
+from app.services.literature.multi_source import ProviderRequestError
 from app.services.literature.retrieval_quality import (
     ExecutableQuery,
     QueryGenerationError,
@@ -50,11 +50,24 @@ from app.services.literature.retrieval_quality import (
     model_rerank,
 )
 
+# 内置适配器实现已收拢到 sources.py（#720 注册表）；这里保留同名再导出，
+# 既有测试与外部引用（tests/test_literature_discovery_runtime 等）不随迁移失效。
+from app.services.literature.sources import (  # noqa: F401
+    ArxivAdapter,
+    MultiSourceAdapter,
+    OpenAlexAdapter,
+    RotatingAdapter,
+    SemanticScholarAdapter,
+    _candidate_from_arxiv,
+    _candidate_from_generic,
+    _candidate_from_openalex,
+    _candidate_from_semantic,
+)
+from app.services.literature.sources import credential_pool as _credential_pool_impl
+
 logger = logging.getLogger(__name__)
 _REGISTRY_CACHE: tuple[str, AdapterRegistry] | None = None
 _REGISTRY_LOCK = asyncio.Lock()
-_ROTATION_LOCK = threading.Lock()
-_ROTATION_INDEX: dict[str, int] = {}
 
 
 class SourceExecutionError(RuntimeError):
@@ -79,175 +92,6 @@ class AdapterRegistry:
         return set(self._adapters)
 
 
-class RotatingAdapter:
-    """Select one configured credential without persisting it in a run."""
-
-    def __init__(self, name: str, adapters: Sequence[SourceAdapter]) -> None:
-        if not adapters:
-            raise ValueError("at least one adapter is required")
-        self.name = name
-        self._adapters = tuple(adapters)
-
-    async def search(self, request: SourceSearchRequest) -> SourceSearchPage:
-        with _ROTATION_LOCK:
-            index = _ROTATION_INDEX.get(self.name, 0)
-            _ROTATION_INDEX[self.name] = index + 1
-        return await self._adapters[index % len(self._adapters)].search(request)
-
-
-class OpenAlexAdapter:
-    name = "openalex"
-
-    def __init__(self, client: Any) -> None:
-        self.client = client
-
-    async def search(self, request: SourceSearchRequest) -> SourceSearchPage:
-        rows = await self.client.search_works(
-            request.query,
-            limit=request.limit,
-            start_year=request.start_year,
-            end_year=request.end_year,
-        )
-        return SourceSearchPage(
-            source=self.name,
-            items=[_candidate_from_openalex(row) for row in rows],
-            fetched_count=len(rows),
-        )
-
-
-class SemanticScholarAdapter:
-    name = "semantic"
-
-    def __init__(self, client: Any) -> None:
-        self.client = client
-
-    async def search(self, request: SourceSearchRequest) -> SourceSearchPage:
-        rows = await self.client.search_papers(
-            request.query,
-            limit=request.limit,
-            start_year=request.start_year,
-            end_year=request.end_year,
-        )
-        return SourceSearchPage(
-            source=self.name,
-            items=[_candidate_from_semantic(row) for row in rows],
-            fetched_count=len(rows),
-        )
-
-
-class ArxivAdapter:
-    name = "arxiv"
-
-    def __init__(self, client: Any) -> None:
-        self.client = client
-
-    async def search(self, request: SourceSearchRequest) -> SourceSearchPage:
-        since = datetime(request.start_year, 1, 1, tzinfo=UTC) if request.start_year else None
-        until = datetime(request.end_year, 12, 31, 23, 59, tzinfo=UTC) if request.end_year else None
-        if hasattr(self.client, "search_raw"):
-            rows = await self.client.search_raw(
-                request.query, since=since, until=until, limit=request.limit
-            )
-        else:
-            rows = await self.client.search(
-                keywords=[request.query], since=since, until=until, limit=request.limit
-            )
-        return SourceSearchPage(
-            source=self.name,
-            items=[_candidate_from_arxiv(row) for row in rows],
-            fetched_count=len(rows),
-        )
-
-
-class MultiSourceAdapter:
-    """Adapter for providers that share the normalized YFR-compatible client."""
-
-    def __init__(self, name: str, client: MultiSourceClient) -> None:
-        self.name = name
-        self.client = client
-
-    async def search(self, request: SourceSearchRequest) -> SourceSearchPage:
-        rows = await self.client.search_source(self.name, request)
-        return SourceSearchPage(
-            source=self.name,
-            items=[validate_candidate(_candidate_from_generic(self.name, row)) for row in rows],
-            fetched_count=len(rows),
-        )
-
-
-def _candidate_from_openalex(row: Mapping[str, Any]) -> LiteratureCandidate:
-    return validate_candidate(
-        LiteratureCandidate(
-            source="openalex",
-            title=str(row.get("title") or "Untitled"),
-            abstract=row.get("abstract"),
-            authors=row.get("authors") or [],
-            year=row.get("year"),
-            venue=row.get("venue"),
-            doi=row.get("doi"),
-            url=row.get("url"),
-            citation_count=row.get("cited_by_count"),
-            metadata=dict(row),
-        )
-    )
-
-
-def _candidate_from_semantic(row: Mapping[str, Any]) -> LiteratureCandidate:
-    external = row.get("externalIds") or {}
-    return validate_candidate(
-        LiteratureCandidate(
-            source="semantic",
-            title=str(row.get("title") or "Untitled"),
-            abstract=row.get("abstract"),
-            authors=[a for a in row.get("authors") or [] if isinstance(a, Mapping)],
-            year=row.get("year"),
-            venue=row.get("venue"),
-            doi=external.get("DOI"),
-            arxiv_id=external.get("ArXiv"),
-            semantic_scholar_id=row.get("paperId"),
-            url=row.get("url"),
-            citation_count=row.get("citationCount"),
-            metadata=dict(row),
-        )
-    )
-
-
-def _candidate_from_arxiv(row: Mapping[str, Any]) -> LiteratureCandidate:
-    return validate_candidate(
-        LiteratureCandidate(
-            source="arxiv",
-            title=str(row.get("title") or "Untitled"),
-            abstract=row.get("abstract"),
-            authors=row.get("authors") or [],
-            year=row.get("year"),
-            doi=row.get("doi"),
-            arxiv_id=row.get("arxiv_id"),
-            url=row.get("url"),
-            pdf_url=row.get("pdf_url"),
-            oa_status="oa" if row.get("pdf_url") else None,
-            metadata=dict(row),
-        )
-    )
-
-
-def _candidate_from_generic(source: str, row: Mapping[str, Any]) -> LiteratureCandidate:
-    return LiteratureCandidate(
-        source=source,
-        title=str(row.get("title") or "Untitled"),
-        abstract=row.get("abstract"),
-        authors=row.get("authors") or [],
-        year=row.get("year"),
-        venue=row.get("venue"),
-        doi=row.get("doi"),
-        pmid=row.get("pmid"),
-        url=row.get("url"),
-        pdf_url=row.get("pdf_url"),
-        oa_status=row.get("oa_status"),
-        citation_count=row.get("citation_count"),
-        metadata=dict(row.get("metadata") or row),
-    )
-
-
 def _config_values(run: LiteratureSearchRun) -> tuple[list[str], list[str], dict[str, float]]:
     config = run.source_config if isinstance(run.source_config, dict) else {}
     sources = discovery_runs.enabled_sources(run.source_config, run.query_plan)
@@ -260,15 +104,8 @@ def _config_values(run: LiteratureSearchRun) -> tuple[list[str], list[str], dict
 
 
 def _credential_pool(settings: Mapping[str, Any], source: str, fallback: str = "") -> list[str]:
-    configured = settings.get("provider_keys")
-    # 「这个源没配」和「配了但空（= 管理员停用了）」必须分开：只看池子空不空的话，
-    # 停用等于无效——照样回落到环境变量里的凭据，而且没有任何提示。
-    declared = isinstance(configured, Mapping) and source in configured
-    values = configured.get(source) if declared else None
-    pool = [str(value).strip() for value in values or [] if str(value).strip()]
-    if declared:
-        return pool
-    return [item for value in fallback.replace(";", ",").split(",") if (item := value.strip())]
+    """兼容再导出：实现在 sources.credential_pool（注册表装配也用同一份语义）。"""
+    return _credential_pool_impl(settings, source, fallback)
 
 
 def _registry_fingerprint(settings: Mapping[str, Any]) -> str:
@@ -277,56 +114,24 @@ def _registry_fingerprint(settings: Mapping[str, Any]) -> str:
 
 
 async def build_adapter_registry(runtime_settings: Mapping[str, Any]) -> AdapterRegistry:
-    """Build or reuse adapters from trusted, decrypted administrator settings."""
+    """Build or reuse adapters from trusted, decrypted administrator settings.
+
+    适配器构造从源注册表（sources.register_source）逐项派生，不再硬编码清单；
+    内置三源（arxiv / semantic / openalex）与多源提供方的装配方式与收拢前
+    逐字节一致（key 池、RotatingAdapter 轮转、共享 MultiSourceClient）。
+    """
     global _REGISTRY_CACHE
-    fingerprint = _registry_fingerprint(runtime_settings)
+    # 指纹除设置外并入注册源清单：运行期挂上新源后，旧缓存注册表不能再复用
+    fingerprint = _registry_fingerprint(
+        {"settings": dict(runtime_settings), "sources": list(source_registry.source_ids())}
+    )
     async with _REGISTRY_LOCK:
         if _REGISTRY_CACHE is not None and _REGISTRY_CACHE[0] == fingerprint:
             return _REGISTRY_CACHE[1]
 
-        app_settings = get_settings()
-        openalex_keys = _credential_pool(runtime_settings, "openalex") or [""]
-        semantic_keys = _credential_pool(runtime_settings, "semantic", app_settings.s2_api_key) or [
-            ""
-        ]
-
-        from app.services.literature.arxiv import ArxivClient
-        from app.services.literature.openalex import OpenAlexClient
-        from app.services.literature.semantic_scholar import SemanticScholarClient
-
-        multi_source = MultiSourceClient(
-            provider_keys=runtime_settings.get("provider_keys")
-            if isinstance(runtime_settings.get("provider_keys"), Mapping)
-            else None
-        )
+        context = source_registry.build_context(runtime_settings)
         registry = AdapterRegistry(
-            (
-                RotatingAdapter(
-                    "openalex",
-                    [OpenAlexAdapter(OpenAlexClient(api_key=key or None)) for key in openalex_keys],
-                ),
-                RotatingAdapter(
-                    "semantic",
-                    [
-                        SemanticScholarAdapter(SemanticScholarClient(api_key=key or None))
-                        for key in semantic_keys
-                    ],
-                ),
-                ArxivAdapter(ArxivClient()),
-                *(
-                    MultiSourceAdapter(source, multi_source)
-                    for source in (
-                        "pubmed",
-                        "crossref",
-                        "europepmc",
-                        "hal",
-                        "core",
-                        "base",
-                        "sciverse",
-                        "unpaywall",
-                    )
-                ),
-            )
+            tuple(spec.build(context) for spec in source_registry.specs())
         )
         _REGISTRY_CACHE = (fingerprint, registry)
         return registry

--- a/src/backend/app/services/literature/sources.py
+++ b/src/backend/app/services/literature/sources.py
@@ -1,0 +1,514 @@
+"""文献源注册表：源 id → 适配器，全后端唯一的源分派点（#720）。
+
+以前有三套并行的「源清单」：discovery 的 AdapterRegistry 硬编码构造、
+literature_settings.SUPPORTED_SOURCES 手写元组、以及 12 处直接 import
+客户端的旁路。三套各自演化，新增一个源要改三处，漏一处就出现
+「设置里配得上、检索里用不到」的裂缝。本模块收拢成一张表：
+
+- ``register_source`` 是与 extraction 的 register_schema / runners 的
+  register 同款的注册缝：内置源在模块底部注册，学科包/插件后续挂新源
+  也走这一道，不再改任何清单常量。
+- literature_settings 的可选源清单（supported_sources()）与 discovery 的
+  AdapterRegistry 构造都从这张表派生，顺序 = 注册顺序。
+- 旁路调用点改为 ``get_source()/require_source()`` 取适配器再调能力方法；
+  适配器内部包的仍是 ``app.services.literature`` 的模块级单例客户端，
+  行为（限速状态、缓存、测试注入缝 set_clients）与直连时代逐字节一致。
+
+能力模型：``search`` 是唯一必选能力；``fetch_new`` / ``resolve`` /
+``download_pdf`` / ``snowball`` 等按源实现，调用方用 ``hasattr`` 探测
+（见 schemas/literature_discovery.SourceAdapter 的说明）。解析级联
+（arXiv → OpenAlex → S2）的顺序也是注册元数据（resolve_kinds +
+resolve_priority），不再散落在 paper_import 的函数排布里。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from threading import Lock
+from typing import Any
+
+from app.core.config import get_settings
+from app.schemas.literature_discovery import (
+    LiteratureCandidate,
+    SourceSearchPage,
+    SourceSearchRequest,
+)
+from app.services.literature.discovery import validate_candidate
+from app.services.literature.multi_source import MultiSourceClient
+
+# ---- 适配器实现（原 runtime.py 的内置适配器，随注册表一起收拢到这里） ----
+
+_ROTATION_LOCK = Lock()
+_ROTATION_INDEX: dict[str, int] = {}
+
+
+class RotatingAdapter:
+    """Select one configured credential without persisting it in a run."""
+
+    def __init__(self, name: str, adapters: list[Any] | tuple[Any, ...]) -> None:
+        if not adapters:
+            raise ValueError("at least one adapter is required")
+        self.name = name
+        self._adapters = tuple(adapters)
+
+    async def search(self, request: SourceSearchRequest) -> SourceSearchPage:
+        with _ROTATION_LOCK:
+            index = _ROTATION_INDEX.get(self.name, 0)
+            _ROTATION_INDEX[self.name] = index + 1
+        return await self._adapters[index % len(self._adapters)].search(request)
+
+
+class OpenAlexAdapter:
+    name = "openalex"
+    #: 能按哪些标识解析元数据（capability：resolve）
+    resolve_kinds = ("arxiv", "doi")
+
+    def __init__(self, client: Any) -> None:
+        self.client = client
+
+    async def search(self, request: SourceSearchRequest) -> SourceSearchPage:
+        rows = await self.client.search_works(
+            request.query,
+            limit=request.limit,
+            start_year=request.start_year,
+            end_year=request.end_year,
+        )
+        return SourceSearchPage(
+            source=self.name,
+            items=[_candidate_from_openalex(row) for row in rows],
+            fetched_count=len(rows),
+        )
+
+    # —— 可选能力：均为对客户端的薄委托，不做任何字段加工（字节等价要求） ——
+
+    async def resolve(self, kind: str, value: str) -> dict[str, Any] | None:
+        """按外部标识取元数据记录；查不到返回 None。"""
+        if kind == "arxiv":
+            return await self.client.get_by_arxiv(value)
+        if kind == "doi":
+            return await self.client.get_by_doi(value)
+        raise ValueError(f"openalex cannot resolve identifier kind: {kind}")
+
+    async def search_works(self, query: str, **kwargs: Any) -> list[dict[str, Any]]:
+        return await self.client.search_works(query, **kwargs)
+
+
+class SemanticScholarAdapter:
+    name = "semantic"
+    resolve_kinds = ("corpus_id",)
+
+    def __init__(self, client: Any) -> None:
+        self.client = client
+
+    async def search(self, request: SourceSearchRequest) -> SourceSearchPage:
+        rows = await self.client.search_papers(
+            request.query,
+            limit=request.limit,
+            start_year=request.start_year,
+            end_year=request.end_year,
+        )
+        return SourceSearchPage(
+            source=self.name,
+            items=[_candidate_from_semantic(row) for row in rows],
+            fetched_count=len(rows),
+        )
+
+    # —— 可选能力 ——
+
+    async def resolve(self, kind: str, value: str) -> dict[str, Any] | None:
+        if kind == "corpus_id":
+            return await self.client.get_paper(f"CorpusId:{value}")
+        raise ValueError(f"semantic scholar cannot resolve identifier kind: {kind}")
+
+    async def snowball(self, paper_ref: str) -> list[dict[str, Any]]:
+        """引文扩展：参考文献 + 施引文献，一次种子一份合并清单。
+
+        顺序固定为「参考文献在前、施引在后」——与旁路时代 ``refs + cits``
+        的拼接顺序一致，去重责任在调用方（保持原有行为）。
+        """
+        refs = await self.client.get_references(paper_ref)
+        cits = await self.client.get_citations(paper_ref)
+        return refs + cits
+
+    async def search_papers(self, query: str, **kwargs: Any) -> list[dict[str, Any]]:
+        return await self.client.search_papers(query, **kwargs)
+
+    async def get_references(self, paper_ref: str, **kwargs: Any) -> list[dict[str, Any]]:
+        return await self.client.get_references(paper_ref, **kwargs)
+
+    async def get_citations(self, paper_ref: str, **kwargs: Any) -> list[dict[str, Any]]:
+        return await self.client.get_citations(paper_ref, **kwargs)
+
+    async def get_paper(self, paper_ref: str, **kwargs: Any) -> dict[str, Any]:
+        return await self.client.get_paper(paper_ref, **kwargs)
+
+
+class ArxivAdapter:
+    name = "arxiv"
+    resolve_kinds = ("arxiv",)
+
+    def __init__(self, client: Any) -> None:
+        self.client = client
+
+    @property
+    def page_size(self) -> int:
+        """arXiv 分页大小由客户端决定（调用方据此判断末页，不能写死）。"""
+        return self.client.page_size
+
+    async def search(self, request: SourceSearchRequest) -> SourceSearchPage:
+        since = datetime(request.start_year, 1, 1, tzinfo=UTC) if request.start_year else None
+        until = datetime(request.end_year, 12, 31, 23, 59, tzinfo=UTC) if request.end_year else None
+        if hasattr(self.client, "search_raw"):
+            rows = await self.client.search_raw(
+                request.query, since=since, until=until, limit=request.limit
+            )
+        else:
+            rows = await self.client.search(
+                keywords=[request.query], since=since, until=until, limit=request.limit
+            )
+        return SourceSearchPage(
+            source=self.name,
+            items=[_candidate_from_arxiv(row) for row in rows],
+            fetched_count=len(rows),
+        )
+
+    # —— 可选能力 ——
+
+    async def fetch_new(self, category: str) -> tuple[list[dict[str, Any]], datetime | None]:
+        """当天新公告列表（每日池的增量供给）。"""
+        return await self.client.fetch_new(category)
+
+    async def resolve(self, kind: str, value: str) -> dict[str, Any] | None:
+        if kind == "arxiv":
+            entries = await self.client.fetch_by_ids([value])
+            return next((e for e in entries if e.get("title")), None)
+        raise ValueError(f"arxiv cannot resolve identifier kind: {kind}")
+
+    async def fetch_by_ids(self, arxiv_ids: list[str]) -> list[dict[str, Any]]:
+        return await self.client.fetch_by_ids(arxiv_ids)
+
+    async def download_pdf(self, arxiv_id: str) -> bytes:
+        return await self.client.download_pdf(arxiv_id)
+
+    async def search_page(self, **kwargs: Any) -> list[dict[str, Any]]:
+        return await self.client.search_page(**kwargs)
+
+
+class MultiSourceAdapter:
+    """Adapter for providers that share the normalized YFR-compatible client."""
+
+    def __init__(self, name: str, client: MultiSourceClient) -> None:
+        self.name = name
+        self.client = client
+
+    async def search(self, request: SourceSearchRequest) -> SourceSearchPage:
+        rows = await self.client.search_source(self.name, request)
+        return SourceSearchPage(
+            source=self.name,
+            items=[validate_candidate(_candidate_from_generic(self.name, row)) for row in rows],
+            fetched_count=len(rows),
+        )
+
+
+def _candidate_from_openalex(row: Mapping[str, Any]) -> LiteratureCandidate:
+    return validate_candidate(
+        LiteratureCandidate(
+            source="openalex",
+            title=str(row.get("title") or "Untitled"),
+            abstract=row.get("abstract"),
+            authors=row.get("authors") or [],
+            year=row.get("year"),
+            venue=row.get("venue"),
+            doi=row.get("doi"),
+            url=row.get("url"),
+            citation_count=row.get("cited_by_count"),
+            metadata=dict(row),
+        )
+    )
+
+
+def _candidate_from_semantic(row: Mapping[str, Any]) -> LiteratureCandidate:
+    external = row.get("externalIds") or {}
+    return validate_candidate(
+        LiteratureCandidate(
+            source="semantic",
+            title=str(row.get("title") or "Untitled"),
+            abstract=row.get("abstract"),
+            authors=[a for a in row.get("authors") or [] if isinstance(a, Mapping)],
+            year=row.get("year"),
+            venue=row.get("venue"),
+            doi=external.get("DOI"),
+            arxiv_id=external.get("ArXiv"),
+            semantic_scholar_id=row.get("paperId"),
+            url=row.get("url"),
+            citation_count=row.get("citationCount"),
+            metadata=dict(row),
+        )
+    )
+
+
+def _candidate_from_arxiv(row: Mapping[str, Any]) -> LiteratureCandidate:
+    return validate_candidate(
+        LiteratureCandidate(
+            source="arxiv",
+            title=str(row.get("title") or "Untitled"),
+            abstract=row.get("abstract"),
+            authors=row.get("authors") or [],
+            year=row.get("year"),
+            doi=row.get("doi"),
+            arxiv_id=row.get("arxiv_id"),
+            url=row.get("url"),
+            pdf_url=row.get("pdf_url"),
+            oa_status="oa" if row.get("pdf_url") else None,
+            metadata=dict(row),
+        )
+    )
+
+
+def _candidate_from_generic(source: str, row: Mapping[str, Any]) -> LiteratureCandidate:
+    return LiteratureCandidate(
+        source=source,
+        title=str(row.get("title") or "Untitled"),
+        abstract=row.get("abstract"),
+        authors=row.get("authors") or [],
+        year=row.get("year"),
+        venue=row.get("venue"),
+        doi=row.get("doi"),
+        pmid=row.get("pmid"),
+        url=row.get("url"),
+        pdf_url=row.get("pdf_url"),
+        oa_status=row.get("oa_status"),
+        citation_count=row.get("citation_count"),
+        metadata=dict(row.get("metadata") or row),
+    )
+
+
+# ---- 注册表本体 ----
+
+
+def credential_pool(settings: Mapping[str, Any], source: str, fallback: str = "") -> list[str]:
+    configured = settings.get("provider_keys")
+    # 「这个源没配」和「配了但空（= 管理员停用了）」必须分开：只看池子空不空的话，
+    # 停用等于无效——照样回落到环境变量里的凭据，而且没有任何提示。
+    declared = isinstance(configured, Mapping) and source in configured
+    values = configured.get(source) if declared else None
+    pool = [str(value).strip() for value in values or [] if str(value).strip()]
+    if declared:
+        return pool
+    return [item for value in fallback.replace(";", ",").split(",") if (item := value.strip())]
+
+
+@dataclass(frozen=True)
+class SourceBuildContext:
+    """凭据化构建的输入：管理员运行时设置 + 应用设置 + 共享的多源客户端。"""
+
+    runtime_settings: Mapping[str, Any]
+    app_settings: Any
+    multi_source: MultiSourceClient
+
+    def credential_pool(self, source: str, fallback: str = "") -> list[str]:
+        return credential_pool(self.runtime_settings, source, fallback)
+
+
+@dataclass(frozen=True)
+class SourceSpec:
+    """一个文献源的注册信息。
+
+    - ``build``：凭据化构建（discovery 检索用）——从管理员设置里取 key 池，
+      可能包成 RotatingAdapter 做 key 轮转。
+    - ``default_factory``：免凭据构建（其余链路用）——包模块级单例客户端，
+      保住单例的限速状态 / 缓存 / set_clients 测试注入缝；``client`` 参数
+      允许调用方显式给客户端（各调用模块保留自己的 get_*_client 注入缝）。
+    - ``selectable``：是否出现在管理设置的可选源列表（unpaywall 只做 OA
+      解析，不参与检索选择，与收拢前口径一致）。
+    - ``resolve_kinds`` + ``resolve_priority``：解析级联元数据；
+      ``resolvers_for(kind)`` 按 priority 升序给出级联顺序。
+    """
+
+    id: str
+    build: Callable[[SourceBuildContext], Any]
+    default_factory: Callable[[Any | None], Any] | None = None
+    selectable: bool = True
+    resolve_kinds: tuple[str, ...] = ()
+    resolve_priority: int = 100
+
+
+_SPECS: dict[str, SourceSpec] = {}
+_REGISTER_LOCK = Lock()
+
+
+def register_source(spec: SourceSpec) -> None:
+    """注册一个文献源。重名直接拒绝——静默覆盖会把源分派变成 import 顺序问题。"""
+    key = spec.id.strip().lower()
+    if not key:
+        raise ValueError("literature source id must be non-empty")
+    with _REGISTER_LOCK:
+        if key in _SPECS:
+            raise ValueError(f"literature source already registered: {key!r}")
+        _SPECS[key] = spec
+
+
+def unregister_source(source_id: str) -> None:
+    """移除注册（插件卸载 / 测试清理用）；未注册时静默返回。"""
+    with _REGISTER_LOCK:
+        _SPECS.pop(source_id.strip().lower(), None)
+
+
+def specs() -> tuple[SourceSpec, ...]:
+    """全部注册源，按注册顺序（dict 插入序）。"""
+    return tuple(_SPECS.values())
+
+
+def source_ids() -> tuple[str, ...]:
+    return tuple(_SPECS)
+
+
+def selectable_source_ids() -> tuple[str, ...]:
+    """管理设置里可勾选的源清单（literature_settings.supported_sources() 的来源）。"""
+    return tuple(spec.id for spec in _SPECS.values() if spec.selectable)
+
+
+def get_source(source_id: str, *, client: Any | None = None) -> Any | None:
+    """取一个源的免凭据适配器；未注册或该源没有默认构建方式时返回 None。
+
+    ``client`` 用于沿用调用模块自己的客户端注入缝（daily_feed / paper_import /
+    actions_wiki 的 get_*_client 模块属性是既有测试与调试面，不因收拢注册表
+    而作废）；缺省时各源包自己的模块级单例。
+    """
+    spec = _SPECS.get(source_id.strip().lower())
+    if spec is None or spec.default_factory is None:
+        return None
+    return spec.default_factory(client)
+
+
+def require_source(source_id: str, *, client: Any | None = None) -> Any:
+    """同 get_source，但未注册时抛错——内置源缺席属于装配错误，不该静默降级。"""
+    adapter = get_source(source_id, client=client)
+    if adapter is None:
+        raise LookupError(f"literature source not registered: {source_id!r}")
+    return adapter
+
+
+def resolvers_for(kind: str) -> tuple[str, ...]:
+    """能解析某类标识的源 id，按 resolve_priority 升序（= 级联尝试顺序）。
+
+    arXiv 号：arxiv → openalex（限流兜底）；DOI：openalex；Corpus ID：semantic。
+    顺序是注册元数据——paper_import 的解析级联从这里取，不再自行排布。
+    """
+    matched = [spec for spec in _SPECS.values() if kind in spec.resolve_kinds]
+    matched.sort(key=lambda spec: spec.resolve_priority)
+    return tuple(spec.id for spec in matched)
+
+
+# ---- 内置源注册 ----
+
+#: 共享的免凭据多源客户端（懒建：多数进程用不到这些源的免凭据形态）
+_default_multi_source: MultiSourceClient | None = None
+
+
+def _shared_multi_source() -> MultiSourceClient:
+    global _default_multi_source
+    if _default_multi_source is None:
+        _default_multi_source = MultiSourceClient()
+    return _default_multi_source
+
+
+def _default_openalex(client: Any | None) -> OpenAlexAdapter:
+    from app.services import literature
+
+    return OpenAlexAdapter(client if client is not None else literature.get_openalex_client())
+
+
+def _default_semantic(client: Any | None) -> SemanticScholarAdapter:
+    from app.services import literature
+
+    return SemanticScholarAdapter(client if client is not None else literature.get_s2_client())
+
+
+def _default_arxiv(client: Any | None) -> ArxivAdapter:
+    from app.services import literature
+
+    return ArxivAdapter(client if client is not None else literature.get_arxiv_client())
+
+
+def _build_openalex(ctx: SourceBuildContext) -> RotatingAdapter:
+    from app.services.literature.openalex import OpenAlexClient
+
+    keys = ctx.credential_pool("openalex") or [""]
+    return RotatingAdapter(
+        "openalex", [OpenAlexAdapter(OpenAlexClient(api_key=key or None)) for key in keys]
+    )
+
+
+def _build_semantic(ctx: SourceBuildContext) -> RotatingAdapter:
+    from app.services.literature.semantic_scholar import SemanticScholarClient
+
+    keys = ctx.credential_pool("semantic", ctx.app_settings.s2_api_key) or [""]
+    return RotatingAdapter(
+        "semantic",
+        [SemanticScholarAdapter(SemanticScholarClient(api_key=key or None)) for key in keys],
+    )
+
+
+def _build_arxiv(ctx: SourceBuildContext) -> ArxivAdapter:  # noqa: ARG001 — 无凭据可用
+    from app.services.literature.arxiv import ArxivClient
+
+    return ArxivAdapter(ArxivClient())
+
+
+def _multi_source_spec(name: str, *, selectable: bool = True) -> SourceSpec:
+    return SourceSpec(
+        id=name,
+        build=lambda ctx: MultiSourceAdapter(name, ctx.multi_source),
+        default_factory=lambda client: MultiSourceAdapter(name, client or _shared_multi_source()),
+        selectable=selectable,
+    )
+
+
+def build_context(runtime_settings: Mapping[str, Any]) -> SourceBuildContext:
+    """从管理员运行时设置构建一次注册表装配的上下文（discovery 用）。"""
+    return SourceBuildContext(
+        runtime_settings=runtime_settings,
+        app_settings=get_settings(),
+        multi_source=MultiSourceClient(
+            provider_keys=runtime_settings.get("provider_keys")
+            if isinstance(runtime_settings.get("provider_keys"), Mapping)
+            else None
+        ),
+    )
+
+
+# 注册顺序即 SUPPORTED_SOURCES 顺序（openalex → semantic → arxiv → 多源提供方），
+# 与收拢前 literature_settings 的手写元组逐项一致；unpaywall 只注册不进可选清单。
+register_source(
+    SourceSpec(
+        id="openalex",
+        build=_build_openalex,
+        default_factory=_default_openalex,
+        resolve_kinds=("arxiv", "doi"),
+        resolve_priority=1,
+    )
+)
+register_source(
+    SourceSpec(
+        id="semantic",
+        build=_build_semantic,
+        default_factory=_default_semantic,
+        resolve_kinds=("corpus_id",),
+        resolve_priority=2,
+    )
+)
+register_source(
+    SourceSpec(
+        id="arxiv",
+        build=_build_arxiv,
+        default_factory=_default_arxiv,
+        resolve_kinds=("arxiv",),
+        resolve_priority=0,  # arXiv 号先问 arXiv 本尊，限流才轮到 OpenAlex
+    )
+)
+for _name in ("pubmed", "crossref", "europepmc", "hal", "core", "base", "sciverse"):
+    register_source(_multi_source_spec(_name))
+register_source(_multi_source_spec("unpaywall", selectable=False))

--- a/src/backend/app/services/literature_settings.py
+++ b/src/backend/app/services/literature_settings.py
@@ -19,22 +19,24 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import decrypt_secret, encrypt_secret
 from app.models.system_setting import SystemSetting
+from app.services.literature import sources as source_registry
 
 SETTING_KEY = "literature_search"
 _SETTING_LOCK_ID = zlib.crc32(SETTING_KEY.encode("utf-8"))
-SUPPORTED_SOURCES = (
-    "openalex",
-    "semantic",
-    "arxiv",
-    "pubmed",
-    "crossref",
-    "europepmc",
-    "hal",
-    "core",
-    "base",
-    "sciverse",
-)
-CREDENTIAL_SOURCES = (*SUPPORTED_SOURCES, "easyscholar")
+
+
+def supported_sources() -> tuple[str, ...]:
+    """可选源清单从源注册表派生（#720）：注册即可选，不再维护手写元组。
+
+    调用时实时读注册表——插件运行期用 register_source 挂新源后，设置校验
+    立刻认得它，不存在「注册了但设置里报 unsupported」的窗口。
+    """
+    return source_registry.selectable_source_ids()
+
+
+def credential_sources() -> tuple[str, ...]:
+    # easyscholar 只做期刊分级（venue_metrics），不是检索源，仅在凭据面出现
+    return (*supported_sources(), "easyscholar")
 DEFAULT_SCORE_WEIGHTS = {
     "relevance": 0.45,
     "evidence_quality": 0.20,
@@ -94,7 +96,7 @@ def _normalize(data: Any) -> dict[str, Any]:
     sources = list(
         dict.fromkeys(str(item).strip().lower() for item in raw_sources if str(item).strip())
     )
-    unknown = [item for item in sources if item not in SUPPORTED_SOURCES]
+    unknown = [item for item in sources if item not in supported_sources()]
     if unknown:
         raise InvalidLiteratureSettingError("sources", f"unsupported source: {unknown[0]}")
 
@@ -255,7 +257,7 @@ async def update_settings(session: AsyncSession, data: Mapping[str, Any]) -> dic
         encrypted: dict[str, list[str]] = {}
         for source, values in raw_pools.items():
             source_name = str(source).strip().lower()
-            if source_name not in CREDENTIAL_SOURCES:
+            if source_name not in credential_sources():
                 raise InvalidLiteratureSettingError(
                     "provider_keys", f"unsupported source: {source_name}"
                 )
@@ -291,7 +293,7 @@ async def update_settings(session: AsyncSession, data: Mapping[str, Any]) -> dic
 
 def _validate_credential_source(source: str) -> str:
     source = source.strip().lower()
-    if source not in CREDENTIAL_SOURCES:
+    if source not in credential_sources():
         raise InvalidLiteratureSettingError("source", f"unsupported source: {source}")
     if source == "arxiv":
         raise InvalidLiteratureSettingError("source", "arxiv does not require credentials")

--- a/src/backend/app/services/openalex_align.py
+++ b/src/backend/app/services/openalex_align.py
@@ -19,6 +19,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm.attributes import flag_modified
 
 from app.models.paper import Paper
+
+# #720 注册表豁免：书目图对齐是 OpenAlex 语义专属（openalex_id、DataCite DOI、
+# 标题模糊匹配阈值都绑定这一家的数据模型），不存在「换个源也能对齐」的抽象；
+# 经注册表间接一层只会掩盖这种耦合。客户端仍取模块级单例（共享限速/缓存/注入缝）。
 from app.services.literature import get_openalex_client
 from app.services.literature.openalex import OpenAlexClient
 

--- a/src/backend/app/services/paper_enrich.py
+++ b/src/backend/app/services/paper_enrich.py
@@ -160,7 +160,7 @@ async def enrich_paper(
     - target 提供时按其 definition 打分（课题/库工作台），个人书架 import 无 target 跳过。
     - 每步 best-effort：抛错发 error 事件但继续；已就绪发 skipped。
     """
-    from app.services.literature import get_arxiv_client
+    from app.services.literature import sources as literature_sources
     from app.services.literature.pdf_extract import extract_full_text, save_pdf
 
     # 先固定 id：rollback 会让 ORM 对象过期，之后再同步读其属性会触发意外 IO
@@ -182,7 +182,9 @@ async def enrich_paper(
         await emit("download", "skipped", "no arxiv id")
     else:
         try:
-            content = await get_arxiv_client().download_pdf(paper.arxiv_id)
+            content = await literature_sources.require_source("arxiv").download_pdf(
+                paper.arxiv_id
+            )
             paper.pdf_path = str(save_pdf(str(paper_id), content))
             await session.commit()
             await emit("download", "ok")

--- a/src/backend/app/services/paper_import.py
+++ b/src/backend/app/services/paper_import.py
@@ -19,12 +19,30 @@ from app.services.libraries import (
     get_membership,
 )
 from app.services.literature import get_arxiv_client, get_openalex_client, get_s2_client
+from app.services.literature import sources as literature_sources
 from app.services.literature.arxiv import ArxivRateLimitedError, normalize_arxiv_id
 
 logger = logging.getLogger(__name__)
 
 _BRACES_RE = re.compile(r"[{}]")
 _WS_RE = re.compile(r"\s+")
+
+#: 各源的客户端注入缝：模块属性 get_*_client 是既有测试/调试面（monkeypatch
+#: 这里的名字即可换掉客户端），适配器形状则由源注册表决定。lambda 里按名字
+#: 现取，保证 monkeypatch 对后续调用生效。
+_CLIENT_SEAMS: dict[str, Any] = {
+    "arxiv": lambda: get_arxiv_client(),
+    "openalex": lambda: get_openalex_client(),
+    "semantic": lambda: get_s2_client(),
+}
+
+
+def _source(source_id: str) -> Any:
+    """经注册表取源适配器（客户端沿用本模块的注入缝）。"""
+    seam = _CLIENT_SEAMS.get(source_id)
+    return literature_sources.require_source(
+        source_id, client=seam() if seam is not None else None
+    )
 
 
 class ParseFailedError(Exception):
@@ -106,7 +124,7 @@ async def _fields_from_openalex_arxiv(arxiv_id: str) -> dict[str, Any]:
     用户手里就是那个编号，让他因为上游限流而干等着，等于我们把别人的故障转嫁给他。
     """
     normalized = normalize_arxiv_id(arxiv_id)
-    meta = await get_openalex_client().get_by_arxiv(normalized)
+    meta = await _source("openalex").resolve("arxiv", normalized)
     if meta is None or not meta.get("title"):
         raise ParseFailedError(f"arXiv 正在限流，OpenAlex 上也查不到 {normalized}")
     return {
@@ -138,19 +156,41 @@ def _fields_from_arxiv_entry(entry: dict[str, Any], fallback_id: str) -> dict[st
     }
 
 
+async def _fields_from_arxiv_source(arxiv_id: str) -> dict[str, Any]:
+    """arXiv 本尊解析一个编号（级联首选；限流上抛给级联循环兜底）。"""
+    entry = await _source("arxiv").resolve("arxiv", arxiv_id)
+    if entry is None:
+        raise ParseFailedError(f"arxiv 上查不到编号 {arxiv_id}")
+    return _fields_from_arxiv_entry(entry, arxiv_id)
+
+
+#: 按 (源 id, 标识类型) 索引的字段构造器。级联**顺序**不写在这里——由注册表的
+#: resolve 元数据（sources.resolvers_for）给出：arXiv 号先问 arXiv，限流才轮到
+#: OpenAlex。字段映射按源各有一套（半篇元数据的取舍不同），所以留在本模块。
+_FIELD_BUILDERS: dict[tuple[str, str], Any] = {
+    ("arxiv", "arxiv"): lambda value: _fields_from_arxiv_source(value),
+    ("openalex", "arxiv"): lambda value: _fields_from_openalex_arxiv(value),
+}
+
+
 async def _fields_from_arxiv(arxiv_id: str) -> dict[str, Any]:
     normalized = normalize_arxiv_id(arxiv_id)
-    try:
-        entries = await get_arxiv_client().fetch_by_ids([normalized])
-    except ArxivRateLimitedError:
-        # arXiv 限流是常态（尤其每日抓取跑完之后）。这条路以前直接抛到端点、变成
-        # 一句「Internal Server Error」——用户既不知道发生了什么，也不知道要不要重试。
-        logger.warning("arxiv rate-limited, falling back to OpenAlex for %s", normalized)
-        return await _fields_from_openalex_arxiv(normalized)
-    entry = next((e for e in entries if e.get("title")), None)
-    if entry is None:
-        raise ParseFailedError(f"arxiv 上查不到编号 {normalized}")
-    return _fields_from_arxiv_entry(entry, normalized)
+    chain = [
+        source_id
+        for source_id in literature_sources.resolvers_for("arxiv")
+        if (source_id, "arxiv") in _FIELD_BUILDERS
+    ]
+    for index, source_id in enumerate(chain):
+        try:
+            return await _FIELD_BUILDERS[(source_id, "arxiv")](normalized)
+        except ArxivRateLimitedError:
+            # arXiv 限流是常态（尤其每日抓取跑完之后）。这条路以前直接抛到端点、变成
+            # 一句「Internal Server Error」——用户既不知道发生了什么，也不知道要不要重试。
+            # 只有「可重试」的失败才继续级联；「查不到」是终局答案，不换源重问。
+            if index + 1 >= len(chain):
+                raise
+            logger.warning("arxiv rate-limited, falling back to OpenAlex for %s", normalized)
+    raise ParseFailedError(f"arxiv 上查不到编号 {normalized}")  # chain 为空的防御位
 
 
 #: 批量解析里「逐项兜底」的墙钟预算。接口是同步的，超了就把剩下的记成查不到，
@@ -168,7 +208,7 @@ async def resolve_arxiv_fields_batch(arxiv_ids: list[str]) -> list[dict[str, Any
     unique_ids = list(dict.fromkeys(normalized))
     rate_limited = False
     try:
-        entries = await get_arxiv_client().fetch_by_ids(unique_ids)
+        entries = await _source("arxiv").fetch_by_ids(unique_ids)
     except ArxivRateLimitedError:
         logger.warning("arxiv rate-limited while resolving %d anchors", len(unique_ids))
         entries = []
@@ -218,7 +258,8 @@ async def resolve_arxiv_fields_batch(arxiv_ids: list[str]) -> list[dict[str, Any
 
 async def _fields_from_doi(doi: str) -> dict[str, Any]:
     doi = doi.strip().removeprefix("https://doi.org/")
-    meta = await get_openalex_client().get_by_doi(doi)
+    # DOI 目前只有 OpenAlex 能解析（resolvers_for("doi")）；注册新源后自动排进级联
+    meta = await _source("openalex").resolve("doi", doi)
     if meta is None or not meta.get("title"):
         raise ParseFailedError(f"OpenAlex 上查不到 DOI {doi}")
     return {
@@ -246,7 +287,7 @@ def normalize_corpus_id(raw: str) -> str:
 async def _fields_from_corpus_id(corpus_id: str) -> dict[str, Any]:
     normalized = normalize_corpus_id(corpus_id)
     try:
-        meta = await get_s2_client().get_paper(f"CorpusId:{normalized}")
+        meta = await _source("semantic").resolve("corpus_id", normalized)
     except Exception as e:  # noqa: BLE001 - upstream failures become a readable import error
         raise ParseFailedError(
             f"Semantic Scholar 上查不到 Corpus ID {normalized}（{type(e).__name__}）"

--- a/src/backend/app/services/papers.py
+++ b/src/backend/app/services/papers.py
@@ -1166,7 +1166,7 @@ async def fetch_pdf(
     - 下载失败 → PdfFetchFailedError（路由映射 502）
     - 全文抽取失败只记日志，不影响 PDF 落盘
     """
-    from app.services.literature import get_arxiv_client
+    from app.services.literature import sources as literature_sources
     from app.services.literature.pdf_extract import save_pdf
 
     if paper.pdf_path and Path(paper.pdf_path).exists():
@@ -1174,7 +1174,7 @@ async def fetch_pdf(
     if not paper.arxiv_id:
         raise PdfSourceUnsupportedError("论文没有 arxiv 编号，暂不支持自动获取 PDF")
     try:
-        content = await get_arxiv_client().download_pdf(paper.arxiv_id)
+        content = await literature_sources.require_source("arxiv").download_pdf(paper.arxiv_id)
     except asyncio.CancelledError:
         raise
     except Exception as e:

--- a/src/backend/app/services/projects.py
+++ b/src/backend/app/services/projects.py
@@ -13,10 +13,6 @@ from app.schemas.project import ProjectCreate, ProjectUpdate
 
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
 
-# 稀疏 definition 缺 arxiv_categories 时的检索默认分类（actions_wiki 也用）
-DEFAULT_ARXIV_CATEGORIES = ["cs.CL", "cs.AI", "cs.LG"]
-
-
 def slugify(name: str) -> str:
     slug = _SLUG_RE.sub("-", name.lower()).strip("-")
     return slug or uuid.uuid4().hex[:8]

--- a/src/backend/app/tools/external.py
+++ b/src/backend/app/tools/external.py
@@ -1,4 +1,7 @@
-"""外部文献只读工具：库外检索、引文/参考文献、按 id 查元数据（走 arxiv/S2/OpenAlex）。
+"""外部文献只读工具：库外检索、引文/参考文献、按 id 查元数据。
+
+数据源经文献源注册表（services/literature/sources）取适配器，不再直连客户端；
+适配器包的是同一批模块级单例，限速/缓存行为不变。
 
 全部访问外部 HTTP API（``network=True``），带 Redis 缓存 + 限速；失败抛 ``ValueError``
 （内部循环转成回给 LLM 的错误消息，外部 MCP 转成 tool error）。
@@ -9,7 +12,7 @@ from __future__ import annotations
 from typing import Any
 
 from app.core.db import get_sessionmaker
-from app.services.literature import get_openalex_client, get_s2_client
+from app.services.literature.sources import require_source
 from app.tools.context import ToolContext
 from app.tools.registry import tool
 from app.tools.scope import readable_paper
@@ -50,12 +53,12 @@ async def external_search(ctx: ToolContext, args: dict[str, Any]) -> dict[str, A
         raise ValueError("external_search 需要非空 query")
     k = min(_MAX_K, max(1, int(args.get("k") or 5)))
     try:
-        rows = await get_s2_client().search_papers(query, limit=k)
+        rows = await require_source("semantic").search_papers(query, limit=k)
         if rows:
             return {"source": "semantic_scholar", "results": [_s2_brief(r) for r in rows]}
     except Exception:  # noqa: BLE001 — S2 不可用则降级 OpenAlex
         rows = []
-    works = await get_openalex_client().search_works(query, limit=k)
+    works = await require_source("openalex").search_works(query, limit=k)
     return {
         "source": "openalex",
         "results": [
@@ -106,7 +109,7 @@ _REF_SCHEMA = {
 )
 async def get_references(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
     ref = await _resolve_ref(ctx, args)
-    rows = await get_s2_client().get_references(ref, limit=50)
+    rows = await require_source("semantic").get_references(ref, limit=50)
     return {"paper_ref": ref, "references": [_s2_brief(r) for r in rows]}
 
 
@@ -119,7 +122,7 @@ async def get_references(ctx: ToolContext, args: dict[str, Any]) -> dict[str, An
 )
 async def get_citations(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
     ref = await _resolve_ref(ctx, args)
-    rows = await get_s2_client().get_citations(ref, limit=50)
+    rows = await require_source("semantic").get_citations(ref, limit=50)
     return {"paper_ref": ref, "citations": [_s2_brief(r) for r in rows]}
 
 
@@ -138,7 +141,7 @@ async def lookup_paper(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]
     doi = str(args.get("doi") or "").strip()
     if not doi:
         raise ValueError("lookup_paper 需要 doi")
-    work = await get_openalex_client().get_by_doi(doi)
+    work = await require_source("openalex").resolve("doi", doi)
     if not work:
         return {"doi": doi, "found": False}
     return {

--- a/src/backend/tests/test_daily_feed.py
+++ b/src/backend/tests/test_daily_feed.py
@@ -10,6 +10,23 @@ from tests.conftest import make_project_with_library, register_and_login
 pytestmark = pytest.mark.asyncio
 
 
+@pytest.fixture(autouse=True)
+def _daily_subscription_default(monkeypatch):
+    """订阅分类不再有代码级缺省（#720 A4），但本文件的存量测试都写于「默认
+    cs.AI/cs.CL/cs.CV」时代。为免逐个测试补订阅，这里给**本文件**装回一个
+    测试级缺省：没配过时返回历史三件套，显式 set_categories 的测试不受影响。
+    「没配过就是空 + 提示」的新行为本身在 tests/test_no_cs_defaults.py 单测。"""
+    from app.services import daily_feed
+
+    real = daily_feed.get_categories
+
+    async def with_test_default(session):
+        stored = await real(session)
+        return stored or ["cs.AI", "cs.CL", "cs.CV"]
+
+    monkeypatch.setattr(daily_feed, "get_categories", with_test_default)
+
+
 def _rss_entry(arxiv_id: str, title: str, *, announce: str = "new") -> dict:
     return {
         "arxiv_id": arxiv_id,
@@ -54,6 +71,9 @@ async def _run_sync(monkeypatch, by_category: dict[str, list[dict]]) -> dict:
 
     monkeypatch.setattr(daily_feed, "get_arxiv_client", lambda: _StubArxiv(by_category))
     async with get_sessionmaker()() as session:
+        # 订阅分类不再有代码级缺省（#720）：按替身数据显式订阅（空替身给一个占位分类，
+        # 维持「订阅了但今天没公告」的旧语义）
+        await daily_feed.set_categories(session, list(by_category) or ["cs.AI"])
         return await daily_feed.sync_daily_feed(session)
 
 
@@ -519,6 +539,7 @@ async def test_categories_admin_and_refresh(client, queue_stub):
     mh = {"Authorization": f"Bearer {member}"}
 
     resp = await client.get("/api/daily/categories", headers=mh)
+    # 本文件的 autouse fixture 播种了历史三件套；「没配过就是空」见 test_no_cs_defaults
     assert resp.json()["categories"] == ["cs.AI", "cs.CL", "cs.CV"]
 
     # 任何登录用户都能改分类（admin 治理已随 #614 移除）；非法格式 422

--- a/src/backend/tests/test_no_cs_defaults.py
+++ b/src/backend/tests/test_no_cs_defaults.py
@@ -1,0 +1,199 @@
+"""CS 分类学去缺省（#720 审计 A4）+ 裸构造修复的回归。
+
+以前三处缺省把 cs.* 长在代码里：每日订阅回退 cs.AI/cs.CL/cs.CV、wiki 建库
+回退 cs.CL/cs.AI/cs.LG、每日列表排序写死 cs.CL/cs.RO。非 CS 用户会被静默灌
+计算机论文。现在：没配就是空 + 明确提示，绝不替用户选学科。
+"""
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from app.core.db import get_sessionmaker
+from app.services import daily_feed
+from app.services.literature import reset_clients, set_clients
+from tests.conftest import make_project_with_library, register_and_login
+
+pytestmark = pytest.mark.asyncio
+
+
+class _ExplodingArxiv:
+    """没订阅分类时**一次都不该**打数据源；打了就是回退缺省又复活了。"""
+
+    async def fetch_new(self, category: str):
+        raise AssertionError(f"unexpected fetch for {category}")
+
+
+async def test_daily_categories_have_no_code_default(client):
+    await register_and_login(client)
+    async with get_sessionmaker()() as session:
+        # 没配过 = 空，不再回退 cs.AI/cs.CL/cs.CV
+        assert await daily_feed.get_categories(session) == []
+        # 配了还能清空（空订阅是合法状态，池子停止进新论文）
+        await daily_feed.set_categories(session, ["stat.ML"])
+        assert await daily_feed.get_categories(session) == ["stat.ML"]
+        await daily_feed.set_categories(session, [])
+        assert await daily_feed.get_categories(session) == []
+
+
+async def test_daily_fetch_and_probe_do_nothing_without_subscription(client, monkeypatch):
+    await register_and_login(client)
+    monkeypatch.setattr(daily_feed, "get_arxiv_client", lambda: _ExplodingArxiv())
+    async with get_sessionmaker()() as session:
+        categories, by_category, statuses = await daily_feed.fetch_new_by_category(session)
+        assert categories == [] and by_category == {} and statuses == {}
+        # 探测同理：无可收之物 → 不开同步轮（以前这个分支不可达，语义是「照常探」）
+        assert await daily_feed.todays_batch_available(session) == (False, None)
+
+
+async def test_wiki_bootstrap_refuses_unbounded_search(client, monkeypatch):
+    """关键词、分类两头都空：如实报警并跳过检索，而不是回退 cs.* 或全网抓取。"""
+    from app.agents.voyage import actions_wiki
+    from app.agents.voyage.actions import ActionContext
+    from app.core.llm.router import LLMRouter
+    from app.models.voyage import VoyageRun
+
+    token = await register_and_login(client, email="no-default-cats@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, library_id = await make_project_with_library(
+        client, headers, name="no-cats", definition={"statement": "keyword-free library"}
+    )
+    async with get_sessionmaker()() as session:
+        run = VoyageRun(
+            kind="wiki_bootstrap",
+            status="executing",
+            project_id=uuid.UUID(project_id),
+            library_id=library_id,
+            goal="bootstrap without categories or keywords",
+            checkpoint={"params": {"mode": "search", "knobs": {"max_papers": 5}}},
+        )
+        session.add(run)
+        await session.commit()
+        run_id = run.id
+
+    monkeypatch.setattr(actions_wiki, "get_arxiv_client", lambda: _ExplodingArxiv())
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+    ctx = ActionContext(run=run, llm=LLMRouter(), checkpoint=dict(run.checkpoint))
+    result = await actions_wiki.search_candidates(ctx, {})
+    assert result["found"] == 0 and result["inserted"] == 0
+    assert result["diagnostic_status"] == "warning"
+    assert any("关键词" in message for message in result["diagnostic_messages"])
+    # 有明确条件时照常检索（见 test_wiki_keyword_only_search_omits_category_filter）
+
+
+async def test_wiki_keyword_only_search_omits_category_filter(client, monkeypatch):
+    """definition 只有关键词：检索照跑，但不带任何分类过滤（更不带 cs.* 缺省）。"""
+    from app.agents.voyage import actions_wiki
+    from app.agents.voyage.actions import ActionContext
+    from app.core.llm.router import LLMRouter
+    from app.models.voyage import VoyageRun
+
+    class _RecordingArxiv:
+        page_size = 100
+
+        def __init__(self) -> None:
+            self.calls: list[dict] = []
+
+        async def search_page(self, **kwargs):
+            self.calls.append(dict(kwargs))
+            return []
+
+    token = await register_and_login(client, email="kw-only-cats@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    project_id, library_id = await make_project_with_library(
+        client,
+        headers,
+        name="kw-only",
+        definition={"statement": "keyword only", "keywords": {"include": ["spintronics"]}},
+    )
+    async with get_sessionmaker()() as session:
+        run = VoyageRun(
+            kind="wiki_bootstrap",
+            status="executing",
+            project_id=uuid.UUID(project_id),
+            library_id=library_id,
+            goal="keyword-only bootstrap",
+            checkpoint={"params": {"mode": "search", "knobs": {"max_papers": 5}}},
+        )
+        session.add(run)
+        await session.commit()
+        run_id = run.id
+
+    arxiv = _RecordingArxiv()
+    monkeypatch.setattr(actions_wiki, "get_arxiv_client", lambda: arxiv)
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, run_id)
+    ctx = ActionContext(run=run, llm=LLMRouter(), checkpoint=dict(run.checkpoint))
+    result = await actions_wiki.search_candidates(ctx, {})
+    assert result["found"] == 0
+    assert len(arxiv.calls) == 1
+    assert arxiv.calls[0]["categories"] == []
+    assert arxiv.calls[0]["keywords"] == ["spintronics"]
+
+
+async def test_daily_list_ranks_by_subscription_order(client, monkeypatch):
+    """列表分类优先级 = 订阅顺序（以前写死 cs.CL 最前 / cs.RO 最后）。"""
+    from tests.test_daily_feed import _rss_entry, _StubArxiv
+
+    token = await register_and_login(client, email="rank-order@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    monkeypatch.setattr(
+        daily_feed,
+        "get_arxiv_client",
+        lambda: _StubArxiv(
+            {
+                "q-bio.NC": [_rss_entry("2608.31001", "Neuro Paper")],
+                "stat.ML": [_rss_entry("2608.31002", "Stats Paper")],
+            }
+        ),
+    )
+    async with get_sessionmaker()() as session:
+        # 非 CS 订阅照样有先后：排订阅列表前面的分类先出现
+        await daily_feed.set_categories(session, ["stat.ML", "q-bio.NC"])
+        _, by_category, _ = await daily_feed.fetch_new_by_category(session)
+        await daily_feed.upsert_entries(session, by_category=by_category)
+
+    resp = await client.get("/api/daily/papers", params={"sort": "date"}, headers=headers)
+    titles = [item["title"] for item in resp.json()["items"]]
+    assert titles.index("Stats Paper") < titles.index("Neuro Paper"), titles
+
+
+async def test_proposal_external_search_uses_shared_singletons():
+    """裸构造修复：外部检索走 set_clients 可注入的模块级单例，而非私建客户端。"""
+    from app.agents.voyage.actions_proposal import _external_search
+
+    class _S2:
+        async def search_papers(self, query, *, limit):
+            return [{"title": f"S2 hit for {query}", "year": 2026, "url": "https://s2"}]
+
+    class _OpenAlex:
+        async def search_works(self, query, *, limit):  # pragma: no cover - S2 命中则不落到这
+            raise AssertionError("openalex fallback should not run")
+
+    set_clients(s2=_S2(), openalex=_OpenAlex())  # type: ignore[arg-type]
+    try:
+        ctx = SimpleNamespace(bus=None, run=None)
+        results, ok = await _external_search(ctx, ["quantum sensing"], limit=3)
+    finally:
+        reset_clients()
+    assert ok and [r["title"] for r in results] == ["S2 hit for quantum sensing"]
+
+
+async def test_writing_related_candidates_use_shared_singleton():
+    from app.agents.voyage.actions_writing import _s2_candidates
+
+    class _S2:
+        async def search_papers(self, query, *, limit):
+            return [{"title": "Related", "year": 2025, "authors": [{"name": "A"}]}]
+
+        async def aclose(self):  # pragma: no cover — 单例绝不能被这条链路关掉
+            raise AssertionError("shared client must not be closed")
+
+    set_clients(s2=_S2())  # type: ignore[arg-type]
+    try:
+        candidates = await _s2_candidates("some manuscript title")
+    finally:
+        reset_clients()
+    assert candidates and candidates[0]["title"] == "Related"

--- a/src/backend/tests/test_source_registry.py
+++ b/src/backend/tests/test_source_registry.py
@@ -1,0 +1,163 @@
+"""文献源注册表（#720）：注册缝、能力探测、解析级联顺序、单例注入缝。
+
+注册表是全后端唯一的源分派点：SUPPORTED_SOURCES 派生、discovery 适配器装配、
+旁路调用点取适配器都走它。这里测的是「缝本身」；各链路的等价性由既有链路
+测试兜底（旁路改道后必须原样通过）。
+"""
+
+from typing import Any
+
+import pytest
+
+from app.services import literature_settings
+from app.services.literature import reset_clients, set_clients, sources
+from app.services.literature.arxiv import ArxivClient
+
+pytestmark = pytest.mark.asyncio
+
+
+class _FakeAdapter:
+    name = "fakesource"
+
+    async def search(self, request):  # pragma: no cover - 形状占位
+        raise AssertionError("not exercised")
+
+
+def _fake_spec(source_id: str = "fakesource", **overrides: Any) -> sources.SourceSpec:
+    params: dict[str, Any] = {
+        "id": source_id,
+        "build": lambda ctx: _FakeAdapter(),
+        "default_factory": lambda client: _FakeAdapter(),
+    }
+    params.update(overrides)
+    return sources.SourceSpec(**params)
+
+
+async def test_register_source_seam_and_derived_supported_list():
+    baseline = sources.selectable_source_ids()
+    # 内置源清单与收拢前的手写元组逐项一致（顺序也是）
+    assert baseline == (
+        "openalex",
+        "semantic",
+        "arxiv",
+        "pubmed",
+        "crossref",
+        "europepmc",
+        "hal",
+        "core",
+        "base",
+        "sciverse",
+    )
+    assert "unpaywall" in sources.source_ids()  # 注册但不可选（OA 解析专用）
+
+    sources.register_source(_fake_spec())
+    try:
+        assert "fakesource" in sources.source_ids()
+        # 设置校验实时读注册表：新源立即可选，凭据面也认得
+        assert "fakesource" in literature_settings.supported_sources()
+        assert "fakesource" in literature_settings.credential_sources()
+        # 重名注册直接拒绝，不静默覆盖
+        with pytest.raises(ValueError, match="already registered"):
+            sources.register_source(_fake_spec())
+    finally:
+        sources.unregister_source("fakesource")
+    assert "fakesource" not in sources.source_ids()
+    assert sources.selectable_source_ids() == baseline
+
+
+async def test_build_adapter_registry_follows_registrations():
+    from app.services.literature import runtime
+
+    registry = await runtime.build_adapter_registry({})
+    assert registry.names() == set(sources.source_ids())
+
+    sources.register_source(_fake_spec())
+    try:
+        # 指纹并入注册清单：同一份设置下，注册新源后不会复用旧缓存
+        registry = await runtime.build_adapter_registry({})
+        assert "fakesource" in registry.names()
+        assert isinstance(registry.get("fakesource"), _FakeAdapter)
+    finally:
+        sources.unregister_source("fakesource")
+    registry = await runtime.build_adapter_registry({})
+    assert "fakesource" not in registry.names()
+
+
+async def test_capability_probing_and_resolver_order():
+    arxiv = sources.require_source("arxiv")
+    semantic = sources.require_source("semantic")
+    openalex = sources.require_source("openalex")
+
+    # 能力按源自愿实现，调用方 hasattr 探测（Protocol 文档约定）
+    assert hasattr(arxiv, "fetch_new") and hasattr(arxiv, "download_pdf")
+    assert not hasattr(semantic, "fetch_new") and not hasattr(openalex, "download_pdf")
+    assert hasattr(semantic, "snowball")
+
+    # 解析级联顺序是注册元数据：arXiv 号先问 arXiv 本尊，限流才轮到 OpenAlex
+    assert sources.resolvers_for("arxiv") == ("arxiv", "openalex")
+    assert sources.resolvers_for("doi") == ("openalex",)
+    assert sources.resolvers_for("corpus_id") == ("semantic",)
+    assert sources.resolvers_for("unknown-kind") == ()
+
+
+async def test_default_adapter_wraps_singleton_and_honors_injection():
+    class _StubArxiv:
+        page_size = 7
+
+        async def download_pdf(self, arxiv_id: str) -> bytes:
+            return b"%PDF stub " + arxiv_id.encode()
+
+    stub = _StubArxiv()
+    set_clients(arxiv=stub)  # type: ignore[arg-type] — 结构性替身，与既有测试同款
+    try:
+        adapter = sources.require_source("arxiv")
+        # 免凭据适配器包的是模块级单例：set_clients 注入立刻生效（限速/缓存/测试缝不变）
+        assert adapter.client is stub
+        assert adapter.page_size == 7
+        assert await adapter.download_pdf("2608.00001") == b"%PDF stub 2608.00001"
+    finally:
+        reset_clients()
+
+    # 调用方显式给客户端时（各模块的 get_*_client 注入缝），以显式为准
+    own = ArxivClient()
+    assert sources.require_source("arxiv", client=own).client is own
+
+    with pytest.raises(LookupError):
+        sources.require_source("never-registered")
+    assert sources.get_source("never-registered") is None
+
+
+async def test_resolve_capability_shapes():
+    class _StubArxiv:
+        async def fetch_by_ids(self, ids):
+            assert ids == ["2608.00042"]
+            return [{"arxiv_id": "2608.00042"}, {"arxiv_id": "2608.00042", "title": "Hit"}]
+
+    entry = await sources.require_source("arxiv", client=_StubArxiv()).resolve(
+        "arxiv", "2608.00042"
+    )
+    assert entry == {"arxiv_id": "2608.00042", "title": "Hit"}  # 取第一条有 title 的
+
+    class _StubOpenAlex:
+        async def get_by_doi(self, doi):
+            return {"title": f"doi:{doi}"}
+
+        async def get_by_arxiv(self, arxiv_id):
+            return {"title": f"arxiv:{arxiv_id}"}
+
+    openalex = sources.require_source("openalex", client=_StubOpenAlex())
+    assert (await openalex.resolve("doi", "10.1/x"))["title"] == "doi:10.1/x"
+    assert (await openalex.resolve("arxiv", "2608.1"))["title"] == "arxiv:2608.1"
+    with pytest.raises(ValueError, match="cannot resolve"):
+        await openalex.resolve("corpus_id", "1")
+
+    class _StubS2:
+        async def get_references(self, ref):
+            return [{"title": "ref"}]
+
+        async def get_citations(self, ref):
+            return [{"title": "cit"}]
+
+    merged = await sources.require_source("semantic", client=_StubS2()).snowball("arXiv:1")
+    # 参考文献在前、施引在后——与旁路时代 refs + cits 的拼接顺序一致
+    assert [row["title"] for row in merged] == ["ref", "cit"]

--- a/src/backend/tests/test_wiki_ingest.py
+++ b/src/backend/tests/test_wiki_ingest.py
@@ -657,8 +657,15 @@ async def test_concurrent_scoring_failure_isolation(client, queue_stub, wiki_moc
         assert by_status.get("compiled", 0) == 1  # 通过阈值且未失败的那篇成功编译
 
 
-async def test_sparse_definition_bootstrap_smoke(client, queue_stub, wiki_mocks):
-    """稀疏 definition（只有 statement）也能跑通 bootstrap 全链路（默认 cs.* 分类兜底）。"""
+async def test_sparse_definition_bootstrap_skips_search_with_honest_warning(
+    client, queue_stub, wiki_mocks
+):
+    """稀疏 definition（只有 statement）：不再回退默认 cs.* 分类（#720 A4）。
+
+    关键词、分类两头都空时查询会退化成「窗口内全 arXiv」，以前靠 cs.* 兜底把
+    非 CS 的库悄悄变成计算机文献库。现在如实跳过检索并在诊断里讲清楚该配什么；
+    链路照常走完（后续步骤对空候选是幂等的），不留 paused_error。
+    """
     token = await register_and_login(client)
     headers = {"Authorization": f"Bearer {token}"}
     project_id, _library_id = await make_project_with_library(
@@ -682,13 +689,14 @@ async def test_sparse_definition_bootstrap_smoke(client, queue_stub, wiki_mocks)
     resp = await client.get(f"/api/voyages/{run_id}", headers=headers)
     detail = resp.json()
     assert detail["status"] == "done", detail
-    assert [s["status"] for s in detail["steps"]] == ["passed"] * 8
-    assert detail["steps"][0]["observation"]["inserted"] == 3  # 默认分类兜底后仍能检索
+    search_obs = detail["steps"][0]["observation"]
+    assert search_obs["found"] == 0 and search_obs["inserted"] == 0
+    assert search_obs["diagnostic_status"] == "warning"
+    assert any("关键词" in message for message in search_obs["diagnostic_messages"])
 
     async with get_sessionmaker()() as session:
         rows = await project_paper_rows(session, project_id=project_id)
-        # 3 候选：2 编译 + 1 淘汰（淘汰的整行删掉；无 rubric 时打分只用 statement）
-        assert sorted(m.status for _, m in rows) == ["compiled", "compiled"]
+        assert rows == []  # 没有检索条件就不该收进任何论文
 
 
 async def test_incremental_pulls_from_daily_feed_without_arxiv(client, queue_stub, wiki_mocks):

--- a/src/frontend/src/features/daily/DailyPage.tsx
+++ b/src/frontend/src/features/daily/DailyPage.tsx
@@ -1199,6 +1199,18 @@ export function DailyPage() {
                   desc={tr('后端不可用或接口尚未就绪，稍后重试。', 'Backend unavailable — try again later.')}
                 />
               ) : items.length === 0 ? (
+                /* 没订阅分类时池子永远是空的——这不是「今天没新论文」，要把原因和去处说清楚 */
+                !filtered && categoriesQuery.data?.categories.length === 0 ? (
+                  <EmptyState
+                    compact
+                    icon="book"
+                    title={tr('还没有订阅分类', 'No subscribed categories yet')}
+                    desc={tr(
+                      '先在 设置 → 每日新论文订阅分类 里添加要跟踪的 arXiv 分类，每日新论文才会进池。',
+                      'Add the arXiv categories you want to follow in Settings → Daily subscribed categories, and new papers will start flowing in.',
+                    )}
+                  />
+                ) : (
                 <EmptyState
                   compact
                   icon="book"
@@ -1212,6 +1224,7 @@ export function DailyPage() {
                         )
                   }
                 />
+                )
               ) : (
                 items.map((p, i) => {
                   // 与上一条日期不同 → 插入粘性日期头。按相关性排时日期是交错的，


### PR DESCRIPTION
Closes #720. Part of #715 (audit items 5+6 — twelve direct-connection bypasses, three parallel source registries, and CS taxonomy baked into defaults).

## One registry, two channels
`services/literature/sources.py` becomes the single dispatch point: `register_source()` (duplicate-rejecting, matching the runner/extraction seams), the 11 built-ins registered at module bottom, and per-source specs carrying resolve kinds and cascade priority. Two build channels reflect reality: the credentialed discovery channel (key pools + rotation, byte-for-byte the old assembly) and a credential-free channel wrapping the existing module singletons — preserving rate-limit state, caches, and every test injection seam. `SUPPORTED_SOURCES` derives from the registry; the discovery cache fingerprint includes the registered set.

## Bypasses routed (each byte-compatible)
Daily-feed fetch, wiki search/snowball/fetch-extract, the paper-import resolve cascade (order now registry metadata, rate-limit-only fallthrough semantics preserved), full-text fetch, and the five agent-tool sites all go through the registry; `openalex_align` is exempted with the reason documented (bibliographic-graph alignment is OpenAlex-semantic). The three bare-constructor sites move to the singletons — restoring key rotation — and their `aclose()` calls are removed (closing a now-shared client would tear down the process-wide pool; a sentinel test pins this).

## CS defaults removed
No more silent `cs.*` fallbacks: an unconfigured daily feed is honestly empty with UI guidance instead of fetching CS papers; library builds with keywords but no categories search unfiltered; with neither, the run completes with a diagnostic instead of unbounded fetching; the hardcoded category ranking branches become parameterized by subscription order. Release note: deployments that never configured subscriptions will stop receiving new daily papers until they do — the honest behavior the audit called for.

Verification: baseline and branch full suites share the identical failure set (4, all pre-existing/flaky, each green standalone); +12 new tests (registry seam, capability dispatch, no-CS-defaults matrix, singleton-injection sentinels); goldens byte-identical; frontend build green; rebased onto #726 with zero conflicts and a targeted 159-test re-run.