### PR TITLE
fix: file-over-app phase 1 with a visible workspace projection

### DIFF
--- a/src/backend/app/agents/voyage/actions_wiki.py
+++ b/src/backend/app/agents/voyage/actions_wiki.py
@@ -36,6 +36,7 @@ from app.models.paper import Paper, new_paper
 from app.models.research_digest import LibraryResearchDigest
 from app.models.voyage import VoyageRun, VoyageStep
 from app.schemas.ingest import TIME_RANGE_DAYS
+from app.services import file_projection
 from app.services.affiliations import (
     apply_author_affiliations,
     extract_author_affiliations_llm,
@@ -1234,6 +1235,9 @@ async def fetch_extract(ctx: ActionContext, params: dict[str, Any]) -> dict[str,
                     )
             membership_of[paper.id].status = "fetched"  # 无全文也进入编译（退化用摘要）
             await session.commit()
+            # 常驻文件投影（#719）：PDF 到手即建可辨认别名；幂等（已投影则秒过），
+            # best-effort 不进 failed——投影失败不该算这篇论文抽取失败
+            file_projection.project_paper_pdf(paper)
             fetched += 1
 
     return {
@@ -1260,6 +1264,7 @@ async def compile_wiki(ctx: ActionContext, params: dict[str, Any]) -> dict[str, 
         library = await _resolve_library(session, ctx)
         if library is None:
             raise ValueError(f"library not found for run: {ctx.run.id}")
+        library_id = library.id  # session 关闭后还要用（批尾刷新文件投影）
         billing_user_id = _ingest_billing_owner(library)
         # 幂等断点：已 compiled 的不再进入（status=fetched 才编译）。外层只查 id，每篇
         # 编译在各自独立 session 内重新加载，避免多任务共享一个 AsyncSession。
@@ -1362,6 +1367,10 @@ async def compile_wiki(ctx: ActionContext, params: dict[str, Any]) -> dict[str, 
             compiled_brief.append(result)
 
     ctx.checkpoint["compiled_count"] = int(ctx.checkpoint.get("compiled_count") or 0) + compiled
+    # 常驻文件投影（#719）：本批有新解读才刷新，且整批只重建一次该库 vault——
+    # 逐篇重建是 O(N²) 的读写量，批量场景按批收口（best-effort，DB wins）
+    if compiled:
+        await file_projection.refresh_library_vault_by_id(library_id)
     return {
         "processed": len(paper_ids),
         "succeeded": compiled,

--- a/src/backend/app/cli/build_file_projection.py
+++ b/src/backend/app/cli/build_file_projection.py
@@ -1,0 +1,132 @@
+"""全量回填常驻文件投影（#719 file-over-app 一期）。
+
+存量数据一次性渲染进 ``<data_dir>/workspace/``（新数据由业务钩子增量刷新）::
+
+    python -m app.cli.build_file_projection                  # 全量：PDF + 笔记 + wiki vault
+    python -m app.cli.build_file_projection --library <uuid> # 只回填某个库（及其成员论文）
+    python -m app.cli.build_file_projection --force          # 已存在的 PDF 投影也删掉重建
+                                                             # （复制回退产生的过期副本靠它兜底）
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import uuid
+from contextlib import suppress
+
+from sqlalchemy import select
+
+from app.core.db import dispose_engine, get_sessionmaker
+from app.models.library_direction import DirectionLibrary, LibraryPaper
+from app.models.paper import Paper, PaperHighlight, PaperNote
+from app.services import file_projection
+
+logger = logging.getLogger(__name__)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--library", type=uuid.UUID, help="只回填该方向库（vault + 成员论文）")
+    parser.add_argument(
+        "--force", action="store_true", help="已存在的 PDF 投影也删掉重建（默认幂等跳过）"
+    )
+    return parser
+
+
+def _member_paper_ids(library_id: uuid.UUID):
+    return select(LibraryPaper.paper_id).where(LibraryPaper.library_id == library_id)
+
+
+async def _run(args: argparse.Namespace) -> None:
+    if not file_projection.projection_enabled():
+        print("文件投影开关已关（POLARIS_FILE_PROJECTION=0），先打开再回填。")
+        raise SystemExit(1)
+    stats = {"pdfs": 0, "pdf_skipped": 0, "notes": 0, "vaults": 0, "failed": 0}
+    try:
+        async with get_sessionmaker()() as session:
+            # ---- PDF 别名 ----
+            stmt = select(Paper).where(Paper.pdf_path.is_not(None)).order_by(Paper.created_at)
+            if args.library:
+                stmt = stmt.where(Paper.id.in_(_member_paper_ids(args.library)))
+            papers = (await session.execute(stmt)).scalars().all()
+            pdf_dir = file_projection.workspace_root() / file_projection.PDF_DIR
+            for i, paper in enumerate(papers, start=1):
+                try:
+                    if args.force:
+                        with suppress(OSError):
+                            (pdf_dir / file_projection.paper_pdf_filename(paper)).unlink(
+                                missing_ok=True
+                            )
+                    if file_projection.project_paper_pdf(paper) is not None:
+                        stats["pdfs"] += 1
+                    else:
+                        stats["pdf_skipped"] += 1  # 原件缺失 / 投影失败（细节见日志）
+                except Exception:  # noqa: BLE001 — 单篇失败不拖垮整批
+                    logger.warning("pdf projection failed for %s", paper.id, exc_info=True)
+                    stats["failed"] += 1
+                if i % 100 == 0 or i == len(papers):
+                    print(f"papers: {i}/{len(papers)}")
+
+            # ---- 笔记 / 划线 ----
+            note_ids = select(PaperNote.paper_id).union(select(PaperHighlight.paper_id))
+            if args.library:
+                note_ids = (
+                    select(PaperNote.paper_id)
+                    .where(PaperNote.paper_id.in_(_member_paper_ids(args.library)))
+                    .union(
+                        select(PaperHighlight.paper_id).where(
+                            PaperHighlight.paper_id.in_(_member_paper_ids(args.library))
+                        )
+                    )
+                )
+            paper_ids = [pid for (pid,) in (await session.execute(note_ids)).all()]
+            for i, paper_id in enumerate(paper_ids, start=1):
+                try:
+                    await file_projection.refresh_paper_notes(session, paper_id)
+                    stats["notes"] += 1
+                except Exception:  # noqa: BLE001
+                    logger.warning("notes projection failed for %s", paper_id, exc_info=True)
+                    stats["failed"] += 1
+                if i % 100 == 0 or i == len(paper_ids):
+                    print(f"notes: {i}/{len(paper_ids)}")
+
+            # ---- wiki vault（跳过没有已编译/已收录成员的空库，同全量导出口径）----
+            lib_stmt = select(DirectionLibrary).order_by(DirectionLibrary.created_at)
+            if args.library:
+                lib_stmt = lib_stmt.where(DirectionLibrary.id == args.library)
+            libraries = (await session.execute(lib_stmt)).scalars().all()
+            for library in libraries:
+                has_members = (
+                    await session.execute(
+                        select(LibraryPaper.paper_id)
+                        .where(
+                            LibraryPaper.library_id == library.id,
+                            LibraryPaper.status.in_(("compiled", "included")),
+                        )
+                        .limit(1)
+                    )
+                ).first() is not None
+                if not has_members:
+                    continue
+                try:
+                    await file_projection.refresh_library_vault(session, library)
+                    stats["vaults"] += 1
+                    print(f"vault: {library.name}")
+                except Exception:  # noqa: BLE001
+                    logger.warning("vault projection failed for %s", library.id, exc_info=True)
+                    stats["failed"] += 1
+        print(json.dumps(stats, ensure_ascii=False, indent=2))
+    finally:
+        await dispose_engine()
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    asyncio.run(_run(_parser().parse_args()))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/backend/app/core/config.py
+++ b/src/backend/app/core/config.py
@@ -236,6 +236,10 @@ class Settings(BaseSettings):
 
     # ---- 文件卷（PDF/全文等产物；容器内挂 /srv/data）----
     data_dir: str = "./data"
+    # 常驻文件投影（#719 file-over-app 一期）：在 <data_dir>/workspace/ 下维护一份
+    # 用户可见的文件副本（PDF 别名 / 笔记 md / wiki vault）。DB 仍是唯一真源，
+    # 关掉只是停止刷新文件，不影响任何业务功能（测试套件与 golden 环境关）。
+    file_projection: bool = True
     # 文献 API（arXiv/S2/OpenAlex）出站代理，如 http://host.docker.internal:7897；
     # LLM/内网服务不走此代理
     outbound_proxy: str | None = None

--- a/src/backend/app/services/daily_feed.py
+++ b/src/backend/app/services/daily_feed.py
@@ -1204,6 +1204,10 @@ async def compile_entry_wiki(
     # 单篇概念上链：正文里的 [[双链]] 建词条并关联。不传成员行 → 记账落平台级
     # （library_id 空）+ 触发编译的人，不把费用摊给某个不相干的库。
     await link_paper_concepts(session, paper, llm=get_llm_router(), user_id=user_id)
+    # 常驻文件投影（#719）：解读更新 → 刷新含它的库 vault（池论文常不属于任何库→跳过）
+    from app.services.file_projection import refresh_wiki_vaults_for_paper
+
+    await refresh_wiki_vaults_for_paper(session, paper.id)
     return wiki
 
 

--- a/src/backend/app/services/file_projection.py
+++ b/src/backend/app/services/file_projection.py
@@ -1,0 +1,296 @@
+"""常驻文件投影（#719，file-over-app 一期；审计 #715 第 4 项，设计报告 §17）。
+
+一期语义 = 「常驻投影」：**DB 仍是唯一真源**，``<data_dir>/workspace/`` 只是一份
+持续刷新的可见副本，让用户随时能用文件管理器 / Obsidian 看到自己的论文、笔记与解读
+（desktop 档位下即 userData/engine/data/workspace，见 #718）：
+
+    <data_dir>/workspace/
+        README.md                      （投影说明：DB 为准、勿在此改动期待回写）
+        papers/<citekey> - <标题>.pdf   （硬链接优先省空间，失败回退复制；
+                                          <data_dir>/papers/<uuid>.pdf 原件不动，
+                                          内部一切路径引用仍指向原件）
+        notes/<论文名>.md               （复用全量导出的笔记渲染器 render_paper_notes_md）
+        wiki/<库名>/…                   （复用 Obsidian vault 导出渲染，可直接用 Obsidian 打开）
+
+冲突规则（一期诚实边界）：**DB wins**。用户在 workspace/ 里的改动不会回写平台，
+且会在下一次对应数据变化时被整文件覆盖；「文件为源」的双向同步属后续阶段。
+
+所有刷新都 best-effort：失败只记日志，绝不阻断业务保存路径——投影是旁路，
+一次写文件失败不该让一次笔记保存 500。钩子受 ``POLARIS_FILE_PROJECTION`` 开关
+控制（默认开；测试套件与 golden 链在 conftest 里关，投影专项测试单独开）。
+存量数据回填走 ``python -m app.cli.build_file_projection``。
+"""
+
+import io
+import logging
+import os
+import shutil
+import uuid
+import zipfile
+from contextlib import suppress
+from pathlib import Path
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import get_settings
+from app.models.library_direction import DirectionLibrary, LibraryPaper
+from app.models.paper import Paper, PaperHighlight, PaperNote
+
+logger = logging.getLogger(__name__)
+
+# 注意：本模块顶层只 import models / config，服务层（full_export / wiki_export /
+# citations）一律函数内延迟 import——它们各自又 import 一大串 services，顶层引用
+# 会和 notes.py / papers.py 等挂钩子的模块构成循环导入。
+
+PDF_DIR = "papers"
+NOTES_DIR = "notes"
+WIKI_DIR = "wiki"
+
+_README = """# Polaris workspace（文件投影 / file projection）
+
+这里是你在 Polaris 里数据的一份**持续刷新的文件副本**，方便随时用文件管理器、
+PDF 阅读器或 Obsidian 直接查看：
+
+- `papers/`：已下载的论文 PDF，按「引用键 - 标题」命名；
+- `notes/`：论文笔记与 PDF 划线，一篇论文一个 Markdown 文件；
+- `wiki/<库名>/`：各文献库的论文解读，Obsidian vault 结构，可直接用 Obsidian 打开。
+
+注意：**平台数据库才是唯一的真源**。在这个目录里改动或删除文件不会同步回平台，
+且对应数据下次变化时这里的文件会被重新覆盖。想编辑笔记请回到平台里改；
+想带走一份独立的完整数据，请用平台的「全量导出」。
+
+Note: this folder is a continuously refreshed *projection* of your Polaris data.
+The database remains the source of truth — edits made here are not synced back
+and will be overwritten on the next refresh.
+"""
+
+
+def projection_enabled() -> bool:
+    return get_settings().file_projection
+
+
+def workspace_root() -> Path:
+    """投影根目录（不负责创建；建目录统一走 :func:`_ensure_workspace`）。"""
+    return Path(get_settings().data_dir) / "workspace"
+
+
+def _ensure_workspace() -> Path:
+    root = workspace_root()
+    root.mkdir(parents=True, exist_ok=True)
+    readme = root / "README.md"
+    if not readme.exists():  # 只在缺失时写：用户就算删了 README 也会补回，但不反复覆盖
+        readme.write_text(_README, encoding="utf-8")
+    return root
+
+
+# ---- 命名 ----
+
+
+def _display_name(title: str | None, paper_id: uuid.UUID) -> str:
+    """标题 → 安全文件名成分（剔除路径分隔/控制字符 + 80 字符截断 + 空标题兜底）。
+
+    直接复用全量导出的 safe_name（去重集合传空：投影按论文逐个刷新，没有一次
+    导出那样的全局视角，同名论文由后写者覆盖——一期接受，见模块 docstring）。
+    """
+    from app.services.full_export import safe_name
+
+    return safe_name(title, set(), fallback=str(paper_id)[:8])
+
+
+def paper_pdf_filename(paper: Paper) -> str:
+    """投影 PDF 文件名：``<citekey> - <安全化标题>.pdf``。
+
+    citekey 复用引用导出的 assign_citation_keys（单篇视角＝无冲突后缀），
+    与 papers.bib / 全量导出 pdfs/ 的命名同源，用户跨着看对得上。
+    """
+    from app.services.citations import assign_citation_keys
+
+    key = assign_citation_keys([paper])[paper.id]
+    return f"{key} - {_display_name(paper.title, paper.id)}.pdf"
+
+
+def _notes_filename(paper: Paper) -> str:
+    return f"{_display_name(paper.title, paper.id)}.md"
+
+
+# ---- PDF 投影 ----
+
+
+def project_paper_pdf(paper: Paper) -> Path | None:
+    """把 ``<data_dir>/papers/<uuid>.pdf`` 原件投影成用户可辨认的别名文件。
+
+    硬链接优先（零额外空间），文件系统不支持（跨设备 / 某些挂载卷）时回退复制。
+    幂等：目标已指向同一原件直接返回；元数据变化导致旧别名残留时，按 samefile
+    清掉旧硬链接再建新名（复制回退的旧副本识别不了，留给回填 CLI --force 兜底）。
+    """
+    if not projection_enabled():
+        return None
+    try:
+        src = Path(paper.pdf_path) if paper.pdf_path else None
+        if src is None or not src.is_file():
+            return None
+        pdf_dir = _ensure_workspace() / PDF_DIR
+        pdf_dir.mkdir(parents=True, exist_ok=True)
+        target = pdf_dir / paper_pdf_filename(paper)
+        if target.exists():
+            with suppress(OSError):
+                if target.samefile(src):
+                    return target  # 稳态：已投影且指向同一原件
+            target.unlink(missing_ok=True)  # 同名但不是本原件（复制回退/罕见撞名）→ 覆盖重建
+        # 旧别名清理：标题/citekey 变化后同一原件不该留两个投影名（仅硬链接可识别）
+        for existing in pdf_dir.glob("*.pdf"):
+            with suppress(OSError):
+                if existing.samefile(src):
+                    existing.unlink()
+        try:
+            os.link(src, target)
+        except OSError:
+            shutil.copyfile(src, target)  # 硬链接不可用（跨设备等）→ 回退复制
+        return target
+    except Exception:  # noqa: BLE001 — 投影是旁路，绝不打断业务写路径
+        logger.warning("file projection: pdf link failed for %s", paper.id, exc_info=True)
+        return None
+
+
+def remove_paper_projection(paper: Paper) -> None:
+    """论文本体被回收时清掉它的投影文件（PDF 别名 + 笔记 md）。
+
+    必须在原件 unlink **之前**调用：旧硬链接别名要靠 samefile 对着原件识别。
+    """
+    if not projection_enabled():
+        return
+    try:
+        root = workspace_root()
+        pdf_dir = root / PDF_DIR
+        with suppress(OSError):
+            (pdf_dir / paper_pdf_filename(paper)).unlink(missing_ok=True)
+        src = Path(paper.pdf_path) if paper.pdf_path else None
+        if src is not None and src.is_file() and pdf_dir.is_dir():
+            for existing in pdf_dir.glob("*.pdf"):
+                with suppress(OSError):
+                    if existing.samefile(src):
+                        existing.unlink()
+        with suppress(OSError):
+            (root / NOTES_DIR / _notes_filename(paper)).unlink(missing_ok=True)
+    except Exception:  # noqa: BLE001
+        logger.warning("file projection: cleanup failed for %s", paper.id, exc_info=True)
+
+
+# ---- 笔记 / 划线投影 ----
+
+
+async def refresh_paper_notes(session: AsyncSession, paper_id: uuid.UUID) -> None:
+    """重渲染一篇论文的 ``notes/<论文名>.md``；笔记划线都删光时移除文件。
+
+    渲染器与全量导出共用（full_export.render_paper_notes_md）。投影落在服务器
+    data_dir（desktop 档位即本人机器），所以带上该论文**全部作者**的笔记——
+    这是数据卷层面的投影，不是某个用户的视角导出。
+    """
+    if not projection_enabled():
+        return
+    try:
+        from app.services.full_export import render_paper_notes_md
+
+        paper = await session.get(Paper, paper_id)
+        if paper is None:
+            return
+        notes = list(
+            (
+                await session.execute(
+                    select(PaperNote)
+                    .where(PaperNote.paper_id == paper_id)
+                    .order_by(PaperNote.created_at)
+                )
+            ).scalars()
+        )
+        highlights = list(
+            (
+                await session.execute(
+                    select(PaperHighlight)
+                    .where(PaperHighlight.paper_id == paper_id)
+                    .order_by(PaperHighlight.page, PaperHighlight.created_at)
+                )
+            ).scalars()
+        )
+        target = workspace_root() / NOTES_DIR / _notes_filename(paper)
+        if not notes and not highlights:
+            with suppress(OSError):
+                target.unlink(missing_ok=True)  # 最后一条删掉 → 文件一并清走
+            return
+        _ensure_workspace()
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(render_paper_notes_md(paper, notes, highlights), encoding="utf-8")
+    except Exception:  # noqa: BLE001 — 冲突规则 DB wins：写失败只记日志，下次变化再覆盖
+        logger.warning("file projection: notes refresh failed for %s", paper_id, exc_info=True)
+
+
+# ---- wiki vault 投影 ----
+
+
+async def refresh_library_vault(session: AsyncSession, library: DirectionLibrary) -> None:
+    """整库重建 ``wiki/<库名>/``（复用 Obsidian vault 导出 builder，zip 原地解包）。
+
+    与 full_export._export_wiki 同一取舍：vault 里的图链重写 / 双链 / 笔记小节
+    全在 builder 里，宁可 zip→解包一趟也不复制那段渲染逻辑。整目录先清后建，
+    顺带带走已不在库里的论文页（DB wins）。
+    笔记视角取库创建者（desktop 单用户即本人）；vault 内的笔记小节只在编译时
+    刷新——逐条笔记保存只更新 notes/ 投影，不整库重建 vault（成本不成比例）。
+    """
+    if not projection_enabled():
+        return
+    try:
+        from app.services.wiki_export import build_obsidian_zip_for_libraries
+
+        data = await build_obsidian_zip_for_libraries(
+            session,
+            library_ids=[library.id],
+            title=library.name,
+            user_id=library.submitted_by,
+        )
+        name = _display_name(library.name, library.id)
+        target = _ensure_workspace() / WIKI_DIR / name
+        if target.exists():
+            shutil.rmtree(target)  # target 恒在 workspace/wiki/ 之下（name 已安全化）
+        target.mkdir(parents=True, exist_ok=True)
+        with zipfile.ZipFile(io.BytesIO(data)) as zf:
+            zf.extractall(target)  # 条目名都是 builder 生成的 slug，无穿越风险
+    except Exception:  # noqa: BLE001
+        logger.warning("file projection: vault refresh failed for %s", library.id, exc_info=True)
+
+
+async def refresh_wiki_vaults_for_paper(session: AsyncSession, paper_id: uuid.UUID) -> None:
+    """一篇论文解读更新后，刷新所有含它的库 vault（每日池论文可能不属于任何库→跳过）。"""
+    if not projection_enabled():
+        return
+    try:
+        libraries = (
+            (
+                await session.execute(
+                    select(DirectionLibrary)
+                    .join(LibraryPaper, LibraryPaper.library_id == DirectionLibrary.id)
+                    .where(LibraryPaper.paper_id == paper_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for library in libraries:
+            await refresh_library_vault(session, library)
+    except Exception:  # noqa: BLE001
+        logger.warning("file projection: vaults refresh failed for %s", paper_id, exc_info=True)
+
+
+async def refresh_library_vault_by_id(library_id: uuid.UUID) -> None:
+    """批量编译（voyage wiki.compile）收尾用：自开 session、整批只重建一次 vault。"""
+    if not projection_enabled():
+        return
+    try:
+        from app.core.db import get_sessionmaker
+
+        async with get_sessionmaker()() as session:
+            library = await session.get(DirectionLibrary, library_id)
+            if library is not None:
+                await refresh_library_vault(session, library)
+    except Exception:  # noqa: BLE001
+        logger.warning("file projection: vault refresh failed for %s", library_id, exc_info=True)

--- a/src/backend/app/services/full_export.py
+++ b/src/backend/app/services/full_export.py
@@ -23,7 +23,7 @@ import re
 import shutil
 import uuid
 import zipfile
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Sequence
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -90,7 +90,7 @@ def export_active_key(user_id: str) -> str:
 _UNSAFE_NAME_RE = re.compile(r'[\\/:*?"<>|\x00-\x1f]+')
 
 
-def _safe_name(name: str | None, used: set[str], fallback: str = "untitled") -> str:
+def safe_name(name: str | None, used: set[str], fallback: str = "untitled") -> str:
     base = _UNSAFE_NAME_RE.sub(" ", (name or "").strip()).strip(" .")[:80] or fallback
     candidate, n = base, 2
     # 大小写不敏感去重：macOS/Windows 文件系统大小写不敏感，解 zip 时会互相覆盖
@@ -151,7 +151,7 @@ async def _export_libraries(
     counts = manifest["counts"]
     used: set[str] = set()
     for library in await _user_libraries(session, user_id):
-        name = _safe_name(library.name, used, fallback=str(library.id)[:8])
+        name = safe_name(library.name, used, fallback=str(library.id)[:8])
         lib_dir = root / "libraries" / name
         try:
             member_rows = (
@@ -216,6 +216,41 @@ async def _export_libraries(
             _warn(manifest, "libraries", library.name, e)
 
 
+def render_paper_notes_md(
+    paper: Paper,
+    notes: Sequence[PaperNote],
+    highlights: Sequence[PaperHighlight],
+) -> str:
+    """一篇论文的笔记 + 划线 → 单个 Markdown 文本。
+
+    全量导出与常驻文件投影（services/file_projection.py，#719）共用同一渲染器：
+    两边各写一份必然漂移，而这份文件正是「离开平台也读得懂」的承诺本体。
+    frontmatter 带论文标识（arxiv_id / doi / 标题），离线也能定位是哪篇论文。
+    """
+    lines = [
+        "---",
+        f"title: {_yaml_str(paper.title)}",
+        f"paper_id: {_yaml_str(paper.id)}",
+        f"arxiv_id: {_yaml_str(paper.arxiv_id)}",
+        f"doi: {_yaml_str(paper.doi)}",
+        f"year: {_yaml_str(paper.year)}",
+        "---",
+        "",
+        f"# {paper.title}",
+    ]
+    if notes:
+        lines += ["", "## 笔记 Notes"]
+        for note in notes:
+            lines += ["", f"### {note.created_at:%Y-%m-%d %H:%M}", "", note.content]
+    if highlights:
+        lines += ["", "## 划线 Highlights"]
+        for hl in highlights:
+            lines += ["", f"- p.{hl.page}: > {hl.selected_text}"]
+            if hl.note:
+                lines += [f"  - {hl.note}"]
+    return "\n".join(lines) + "\n"
+
+
 async def _export_notes(
     session: AsyncSession, user_id: uuid.UUID, root: Path, manifest: dict[str, Any]
 ) -> None:
@@ -252,31 +287,13 @@ async def _export_notes(
     for entry in by_paper.values():
         paper: Paper = entry["paper"]
         try:
-            lines = [
-                "---",
-                f"title: {_yaml_str(paper.title)}",
-                f"paper_id: {_yaml_str(paper.id)}",
-                f"arxiv_id: {_yaml_str(paper.arxiv_id)}",
-                f"doi: {_yaml_str(paper.doi)}",
-                f"year: {_yaml_str(paper.year)}",
-                "---",
-                "",
-                f"# {paper.title}",
-            ]
-            if entry["notes"]:
-                lines += ["", "## 笔记 Notes"]
-                for note in entry["notes"]:
-                    lines += ["", f"### {note.created_at:%Y-%m-%d %H:%M}", "", note.content]
-            if entry["highlights"]:
-                lines += ["", "## 划线 Highlights"]
-                for hl in entry["highlights"]:
-                    lines += ["", f"- p.{hl.page}: > {hl.selected_text}"]
-                    if hl.note:
-                        lines += [f"  - {hl.note}"]
-            name = _safe_name(paper.title, used, fallback=str(paper.id)[:8])
+            name = safe_name(paper.title, used, fallback=str(paper.id)[:8])
             notes_dir = root / "notes"
             notes_dir.mkdir(parents=True, exist_ok=True)
-            (notes_dir / f"{name}.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+            (notes_dir / f"{name}.md").write_text(
+                render_paper_notes_md(paper, entry["notes"], entry["highlights"]),
+                encoding="utf-8",
+            )
         except Exception as e:  # noqa: BLE001
             _warn(manifest, "notes", paper.title, e)
 
@@ -308,7 +325,7 @@ async def _export_wiki(
             vault = await build_obsidian_zip_for_libraries(
                 session, library_ids=[library.id], title=library.name, user_id=user_id
             )
-            name = _safe_name(library.name, used, fallback=str(library.id)[:8])
+            name = safe_name(library.name, used, fallback=str(library.id)[:8])
             target = root / "wiki" / name
             target.mkdir(parents=True, exist_ok=True)
             with zipfile.ZipFile(io.BytesIO(vault)) as zf:
@@ -369,7 +386,7 @@ async def _export_discovery(
     used: set[str] = set()
     for run in runs:
         try:
-            name = _safe_name(run.goal, used, fallback=str(run.id)[:8])
+            name = safe_name(run.goal, used, fallback=str(run.id)[:8])
             run_dir = root / "discovery" / name
             nodes = await tree_for_run(session, run.id)
             _dump_json(
@@ -428,7 +445,7 @@ async def _export_experiments(
     used: set[str] = set()
     for experiment, idea_title in rows:
         try:
-            name = _safe_name(idea_title, used, fallback=str(experiment.id)[:8])
+            name = safe_name(idea_title, used, fallback=str(experiment.id)[:8])
             _dump_json(
                 root / "experiments" / name / "run.json",
                 {
@@ -496,7 +513,7 @@ async def _export_manuscripts(
     used: set[str] = set()
     for manuscript in manuscripts:
         try:
-            name = _safe_name(manuscript.title, used, fallback=str(manuscript.id)[:8])
+            name = safe_name(manuscript.title, used, fallback=str(manuscript.id)[:8])
             ms_dir = root / "manuscripts" / name
             source_dir = ms_dir / "source"
             for file in manuscript.files:

--- a/src/backend/app/services/highlights.py
+++ b/src/backend/app/services/highlights.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.paper import PaperHighlight
 from app.models.user import User
 from app.schemas.highlight import HighlightCreate
+from app.services import file_projection
 from app.services.notes import author_name_of
 
 
@@ -38,6 +39,8 @@ async def create_highlight(
     session.add(hl)
     await session.commit()
     await session.refresh(hl)
+    # 常驻文件投影（#719）：划线与笔记落同一个 notes/<论文名>.md，best-effort（DB wins）
+    await file_projection.refresh_paper_notes(session, paper_id)
     return hl
 
 
@@ -80,9 +83,12 @@ async def update_highlight(
             setattr(hl, key, updates[key])
     await session.commit()
     await session.refresh(hl)
+    await file_projection.refresh_paper_notes(session, hl.paper_id)  # 投影跟进（DB wins）
     return hl
 
 
 async def delete_highlight(session: AsyncSession, hl: PaperHighlight) -> None:
+    paper_id = hl.paper_id  # delete 后对象过期，先留住
     await session.delete(hl)
     await session.commit()
+    await file_projection.refresh_paper_notes(session, paper_id)  # 投影跟进（DB wins）

--- a/src/backend/app/services/notes.py
+++ b/src/backend/app/services/notes.py
@@ -15,6 +15,7 @@ from app.models.library_direction import LibraryPaper
 from app.models.paper import Paper, PaperNote
 from app.models.topic_shelf import TopicPaper
 from app.models.user import User
+from app.services import file_projection
 from app.services.libraries import get_source_library_ids
 
 
@@ -30,6 +31,9 @@ async def create_note(
     session.add(note)
     await session.commit()
     await session.refresh(note)
+    # 常驻文件投影（#719）：保存成功后 best-effort 重渲染该论文的笔记文件。
+    # 冲突规则 DB wins：投影失败只记日志，绝不影响这次保存。
+    await file_projection.refresh_paper_notes(session, paper_id)
     return note
 
 
@@ -67,12 +71,16 @@ async def update_note(session: AsyncSession, note: PaperNote, *, content: str) -
     note.content = content
     await session.commit()
     await session.refresh(note)
+    await file_projection.refresh_paper_notes(session, note.paper_id)  # 投影跟进（DB wins）
     return note
 
 
 async def delete_note(session: AsyncSession, note: PaperNote) -> None:
+    paper_id = note.paper_id  # delete 后对象过期，先留住
     await session.delete(note)
     await session.commit()
+    # 投影跟进：这是该论文最后一条笔记且没有划线时，文件一并清走
+    await file_projection.refresh_paper_notes(session, paper_id)
 
 
 async def list_project_notes(

--- a/src/backend/app/services/paper_enrich.py
+++ b/src/backend/app/services/paper_enrich.py
@@ -187,6 +187,9 @@ async def enrich_paper(
             )
             paper.pdf_path = str(save_pdf(str(paper_id), content))
             await session.commit()
+            from app.services.file_projection import project_paper_pdf
+
+            project_paper_pdf(paper)  # 常驻文件投影（#719）：best-effort，DB wins
             await emit("download", "ok")
         except asyncio.CancelledError:
             raise

--- a/src/backend/app/services/papers.py
+++ b/src/backend/app/services/papers.py
@@ -819,8 +819,11 @@ async def _paper_still_referenced(session: AsyncSession, paper: Paper) -> bool:
 
 def _remove_paper_files(paper: Paper) -> None:
     """尽力删除论文落盘文件：pdf/全文文件 + <papers_dir>/<id>/ 图片目录（失败只记日志）。"""
+    from app.services.file_projection import remove_paper_projection
     from app.services.literature.pdf_extract import papers_dir
 
+    # 投影清理必须在原件 unlink 之前：旧硬链接别名靠 samefile 对着原件识别（#719）
+    remove_paper_projection(paper)
     for raw in (paper.pdf_path, paper.full_text_path):
         if raw:
             try:
@@ -1102,6 +1105,11 @@ async def _process_saved_pdf(
     except Exception:  # noqa: BLE001
         logger.warning("chunk embed failed for paper %s", paper.id, exc_info=True)
     await session.refresh(paper)
+    # 常驻文件投影（#719）：PDF 入库完成 → 在 workspace/papers/ 下建可辨认的别名
+    # （硬链接优先，失败复制；best-effort，DB wins）。上传 / URL / 自动补下全走这里。
+    from app.services.file_projection import project_paper_pdf
+
+    project_paper_pdf(paper)
     return paper
 
 

--- a/src/backend/app/services/wiki_compile.py
+++ b/src/backend/app/services/wiki_compile.py
@@ -18,6 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.llm.base import Message
 from app.core.llm.router import LLMRouter, get_llm_router
 from app.models.paper import Paper
+from app.services import file_projection
 from app.services.affiliations import (
     AFFIL_COMPILE_INSTRUCTION,
     apply_author_affiliations,
@@ -303,4 +304,6 @@ async def recompile_paper(
     await link_paper_concepts(
         session, paper, membership, llm=llm, user_id=user_id, project_id=project_id
     )
+    # 常驻文件投影（#719）：解读更新 → 刷新所有含它的库 vault（best-effort，DB wins）
+    await file_projection.refresh_wiki_vaults_for_paper(session, paper.id)
     return view

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -20,6 +20,9 @@ os.environ["POLARIS_DATA_DIR"] = f"{_TMPDIR}/data"  # PDF/全文落盘目录（M
 os.environ["POLARIS_LLM_FAKE_FALLBACK"] = "1"  # 测试套件依赖确定性 fake provider
 # 补全钩子里的 OpenAlex 对齐是真实出网调用，离线测试一律关（专测用例自行开）
 os.environ["POLARIS_OPENALEX_ALIGN_ON_ENRICH"] = "0"
+# 常驻文件投影（#719）默认关：投影是 best-effort 文件旁路，全套件（含 golden 链）
+# 不该有意外文件产物；投影专项测试（test_file_projection.py）用 fixture 单独开
+os.environ["POLARIS_FILE_PROJECTION"] = "0"
 
 from app.core.db import Base, dispose_engine, get_engine  # noqa: E402
 from app.core.events import get_event_bus  # noqa: E402

--- a/src/backend/tests/test_file_projection.py
+++ b/src/backend/tests/test_file_projection.py
@@ -1,0 +1,280 @@
+"""常驻文件投影（#719 file-over-app 一期）：布局 / 双写钩子 / 回退与清理 / 回填 CLI。
+
+投影默认在测试套件关（conftest），本文件用 projection_on fixture 单独开，
+并把 data_dir 指到独立 tmp_path，互不污染。
+"""
+
+import os
+import uuid
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from app.core.config import get_settings
+from app.core.db import get_sessionmaker
+from tests.conftest import add_paper, ensure_project_library, register_and_login
+
+pytestmark = pytest.mark.asyncio
+
+FAKE_PDF = b"%PDF-1.4 fake body for projection tests"
+
+
+@pytest.fixture
+def projection_on(monkeypatch, tmp_path):
+    """开投影 + 独立 data_dir（get_settings 是 lru_cache 的，改 env 后须清缓存）。"""
+    monkeypatch.setenv("POLARIS_FILE_PROJECTION", "1")
+    monkeypatch.setenv("POLARIS_DATA_DIR", str(tmp_path / "data"))
+    get_settings.cache_clear()
+    yield tmp_path / "data"
+    get_settings.cache_clear()
+
+
+async def _make_project(client):
+    token = await register_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = await client.post("/api/projects", json={"name": "proj-projection"}, headers=headers)
+    return resp.json()["id"], headers
+
+
+def _attach_fake_pdf(paper) -> Path:
+    """按内部约定造 uuid 原件（<data_dir>/papers/<id>.pdf）并接到 paper 上。"""
+    from app.services.literature.pdf_extract import papers_dir
+
+    src = papers_dir() / f"{paper.id}.pdf"
+    src.write_bytes(FAKE_PDF)
+    paper.pdf_path = str(src)
+    return src
+
+
+async def test_pdf_projection_is_a_hardlink_with_citekey_name(client, projection_on):
+    from app.services import file_projection
+
+    project_id, _ = await _make_project(client)
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Deep Residual Learning",
+            authors=[{"name": "Kaiming He"}],
+            year=2016,
+            status="included",
+        )
+        src = _attach_fake_pdf(paper)
+        await session.commit()
+
+        target = file_projection.project_paper_pdf(paper)
+
+    assert target is not None
+    # citekey 与全量导出 papers.bib 同源：he2016deep
+    assert target.name == "he2016deep - Deep Residual Learning.pdf"
+    assert target.parent == projection_on / "workspace" / "papers"
+    # 硬链接：同一 inode，原件不动（内部路径引用全指向 uuid 原件）
+    assert os.path.samefile(target, src)
+    assert src.is_file()
+    # 顶层 README（诚实边界说明）随首次投影落位
+    readme = (projection_on / "workspace" / "README.md").read_text(encoding="utf-8")
+    assert "真源" in readme
+
+    # 幂等：重复投影不报错、还是同一个文件
+    async with get_sessionmaker()() as session:
+        paper2 = await session.get(type(paper), paper.id)
+        assert file_projection.project_paper_pdf(paper2) == target
+
+
+async def test_pdf_projection_falls_back_to_copy(client, projection_on, monkeypatch):
+    from app.services import file_projection
+
+    def _no_link(*args, **kwargs):
+        raise OSError("cross-device link")
+
+    monkeypatch.setattr(os, "link", _no_link)
+    project_id, _ = await _make_project(client)
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session, project_id=uuid.UUID(project_id), title="Copy Fallback Paper"
+        )
+        src = _attach_fake_pdf(paper)
+        await session.commit()
+        target = file_projection.project_paper_pdf(paper)
+    assert target is not None and target.is_file()
+    assert target.read_bytes() == FAKE_PDF
+    assert not os.path.samefile(target, src)  # 复制而非硬链接
+
+
+async def test_filenames_are_sanitized_and_truncated(client, projection_on):
+    from app.services import file_projection
+
+    project_id, _ = await _make_project(client)
+    nasty = 'A/B\\C:D*E?F"G<H>I|J' + "超长标题" * 60  # 特殊字符 + 远超 80 字符
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(session, project_id=uuid.UUID(project_id), title=nasty)
+        name = file_projection.paper_pdf_filename(paper)
+    assert not set(name) & set('/\\:*?"<>|')
+    # 标题成分截到 80 字符以内（与全量导出同一把尺子）
+    title_part = name.removesuffix(".pdf").split(" - ", 1)[1]
+    assert len(title_part) <= 80
+
+
+async def test_note_and_highlight_hooks_keep_the_notes_file_fresh(client, projection_on):
+    project_id, headers = await _make_project(client)
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session, project_id=uuid.UUID(project_id), title="Projected Paper", year=2026
+        )
+        await session.commit()
+        paper_id = str(paper.id)
+
+    notes_file = projection_on / "workspace" / "notes" / "Projected Paper.md"
+
+    # 建笔记 → 文件出现且含内容与 frontmatter
+    resp = await client.post(
+        f"/api/papers/{paper_id}/notes", json={"content": "重点：方法部分"}, headers=headers
+    )
+    assert resp.status_code == 201
+    note_id = resp.json()["id"]
+    body = notes_file.read_text(encoding="utf-8")
+    assert "重点：方法部分" in body
+    assert 'title: "Projected Paper"' in body
+
+    # 改笔记 → 文件跟着变
+    await client.patch(f"/api/notes/{note_id}", json={"content": "改过了"}, headers=headers)
+    body = notes_file.read_text(encoding="utf-8")
+    assert "改过了" in body and "重点：方法部分" not in body
+
+    # 加划线 → 同一文件的「划线」小节
+    resp = await client.post(
+        f"/api/papers/{paper_id}/highlights",
+        json={
+            "page": 3,
+            "rects": [{"x0": 0.1, "y0": 0.1, "x1": 0.5, "y1": 0.2}],
+            "selected_text": "the projected sentence",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201
+    hl_id = resp.json()["id"]
+    body = notes_file.read_text(encoding="utf-8")
+    assert "p.3: > the projected sentence" in body
+
+    # 删笔记 → 还剩划线，文件保留但笔记小节消失
+    await client.delete(f"/api/notes/{note_id}", headers=headers)
+    body = notes_file.read_text(encoding="utf-8")
+    assert "改过了" not in body and "the projected sentence" in body
+
+    # 删最后一条划线 → 文件整个清走
+    await client.delete(f"/api/highlights/{hl_id}", headers=headers)
+    assert not notes_file.exists()
+
+
+async def test_wiki_vault_projection_renders_an_obsidian_vault(client, projection_on):
+    from app.services import file_projection
+
+    project_id, _ = await _make_project(client)
+    async with get_sessionmaker()() as session:
+        await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Compiled Paper",
+            status="compiled",
+            wiki_content="## TL;DR\n\n投影用解读正文。\n",
+        )
+        library = await ensure_project_library(session, uuid.UUID(project_id))
+        await session.commit()
+        await file_projection.refresh_library_vault(session, library)
+        vault = projection_on / "workspace" / "wiki" / library.name
+
+    assert (vault / "index.md").is_file()
+    pages = list((vault / "papers").glob("*.md"))
+    assert len(pages) == 1
+    assert "投影用解读正文" in pages[0].read_text(encoding="utf-8")
+
+    # 按论文反查刷新（编译钩子走这条）：重建后 vault 仍在
+    async with get_sessionmaker()() as session:
+        from sqlalchemy import select
+
+        from app.models.paper import Paper
+
+        paper = (
+            await session.execute(select(Paper).where(Paper.title == "Compiled Paper"))
+        ).scalar_one()
+        await file_projection.refresh_wiki_vaults_for_paper(session, paper.id)
+    assert (vault / "index.md").is_file()
+
+
+async def test_remove_paper_projection_cleans_pdf_and_notes(client, projection_on):
+    from app.services import file_projection
+
+    project_id, headers = await _make_project(client)
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(session, project_id=uuid.UUID(project_id), title="Doomed Paper")
+        _attach_fake_pdf(paper)
+        await session.commit()
+        target = file_projection.project_paper_pdf(paper)
+        paper_id = str(paper.id)
+    await client.post(
+        f"/api/papers/{paper_id}/notes", json={"content": "临终笔记"}, headers=headers
+    )
+    notes_file = projection_on / "workspace" / "notes" / "Doomed Paper.md"
+    assert target.is_file() and notes_file.is_file()
+
+    async with get_sessionmaker()() as session:
+        from app.models.paper import Paper
+
+        paper = await session.get(Paper, uuid.UUID(paper_id))
+        file_projection.remove_paper_projection(paper)
+    assert not target.exists()
+    assert not notes_file.exists()
+
+
+async def test_projection_disabled_by_default_no_side_files(client):
+    """conftest 关着开关（golden 链同环境）：业务写路径不产生 workspace 旁路文件。"""
+    project_id, headers = await _make_project(client)
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(session, project_id=uuid.UUID(project_id), title="Silent Paper")
+        await session.commit()
+        paper_id = str(paper.id)
+    resp = await client.post(
+        f"/api/papers/{paper_id}/notes", json={"content": "无投影"}, headers=headers
+    )
+    assert resp.status_code == 201
+    assert not (Path(os.environ["POLARIS_DATA_DIR"]) / "workspace").exists()
+
+
+async def test_db_wins_conflict_rule_is_documented():
+    """一期诚实边界必须写在代码里：DB wins、投影不回写。"""
+    from app.services import file_projection
+
+    assert "DB wins" in (file_projection.__doc__ or "")
+    assert "不会回写" in (file_projection.__doc__ or "")
+
+
+async def test_backfill_cli_renders_existing_rows(client, projection_on, capsys):
+    from app.cli.build_file_projection import _run
+
+    project_id, headers = await _make_project(client)
+    async with get_sessionmaker()() as session:
+        paper = await add_paper(
+            session,
+            project_id=uuid.UUID(project_id),
+            title="Backfill Paper",
+            status="compiled",
+            wiki_content="## TL;DR\n\n回填解读。\n",
+        )
+        _attach_fake_pdf(paper)
+        await session.commit()
+        paper_id = str(paper.id)
+    # 存量笔记（钩子建过的文件先删掉，验证 CLI 能重建）
+    await client.post(
+        f"/api/papers/{paper_id}/notes", json={"content": "存量笔记"}, headers=headers
+    )
+    workspace = projection_on / "workspace"
+    (workspace / "notes" / "Backfill Paper.md").unlink()
+
+    await _run(Namespace(library=None, force=False))
+
+    out = capsys.readouterr().out
+    assert "papers: 1/1" in out
+    assert (workspace / "notes" / "Backfill Paper.md").read_text(encoding="utf-8").count("存量笔记")
+    assert list((workspace / "papers").glob("*.pdf"))
+    assert list((workspace / "wiki").iterdir())


### PR DESCRIPTION
Closes #719. Part of #715 (audit item 4 — notes/wiki lived only in the DB and PDFs hid behind UUIDs, inverting the §17 "files are the user's asset" design).

Phase 1 is an honest **projection**: the DB stays the source of truth, and a user-visible `workspace/` under the data dir is a continuously refreshed file view (true file-as-source is a later phase; the boundary is stated in a bilingual README at the workspace root and in the module docstring's DB-wins rule, both test-pinned).

- `papers/<citekey> - <title>.pdf`: hardlink (copy fallback) aliases of the UUID originals — internal references untouched, idempotent, stale aliases cleaned by inode identity
- `notes/<paper>.md` and `wiki/<library>/`: rendered by the **same** code as the full export (the note renderer was extracted to be shared; the vault builder unpacks in place) — no second implementation to drift
- best-effort dual-write hooks at nine sites (note/highlight create-update-delete, the three PDF ingestion paths, the three wiki-compile completion points, paper recycling before the original is unlinked); failures log and never block the save; voyage batch compiles refresh once per batch
- backfill CLI `build_file_projection` (--library/--force) for existing data
- gated by `POLARIS_FILE_PROJECTION` (default on; off in the test env so goldens and the suite see zero side files — the projection-specific tests opt in explicitly)

Verification: branch vs clean-baseline full suites share the identical 3-failure set (zero new; 1715 = baseline + exactly the 9 new tests); rebased across #725/#726/#727 (the literature-registry rewrite touched the same files as three hooks — merged semantically, 69-test targeted re-run green incl. goldens); no frontend changes.