### PR TITLE
fix: backend and frontend suites join CI; repair the three legacy failures

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -1,5 +1,5 @@
-# Workspace-level Node checks for the plugin kernel line of work: the vendored
-# cordis runtime contract test and (as packages appear) kernel lint/tests.
+# Workspace-level Node checks: the vendored cordis runtime contract test,
+# kernel lint/tests (as packages appear), and the frontend vitest suite (#728).
 # Desktop/frontend build coverage lives in desktop-build.yml.
 name: node-ci
 
@@ -8,6 +8,7 @@ on:
     paths:
       - "vendor/**"
       - "src/kernel/**"
+      - "src/frontend/**"
       - "spikes/**"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
@@ -39,6 +40,9 @@ jobs:
 
       - name: Vendored runtime contract test
         run: pnpm --dir vendor/contract-smoke run test
+
+      - name: Frontend unit tests (vitest)
+        run: pnpm --dir src/frontend test
 
       - name: Kernel checks
         run: |

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,0 +1,33 @@
+# 后端全量 pytest 闸门（#728，堵住 #581「失败长期滞留 main」的口子）。
+# 套件在 desktop 档位自足：conftest 自带 SQLite(aiosqlite) + fakeredis 与全部
+# POLARIS_* 环境变量，不需要 postgres/redis 服务容器。
+# docker_integration 用例（要真 docker + 镜像）由 pyproject 的 addopts 默认 deselect。
+name: python-ci
+
+on:
+  pull_request:
+    paths:
+      - "src/backend/**"
+      - ".github/workflows/python-ci.yml"
+  workflow_dispatch:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    # 本机容器全量约 25 分钟，CI 裸机估 15-30 分钟——45 兜底
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: src/backend/pyproject.toml
+
+      - name: Install backend with dev extras
+        run: pip install -e "src/backend[dev]"
+
+      - name: Run backend test suite
+        working-directory: src/backend
+        run: python -m pytest -q -p no:cacheprovider

--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,9 @@ desktop-dist:   ## Package an installer for the current platform (unsigned)
 migrate:
 	cd src/backend && .venv/bin/alembic upgrade head
 
-test:           ## Backend tests + frontend build
+test:           ## Backend tests + frontend unit tests + frontend build
 	cd src/backend && .venv/bin/pytest -q
+	pnpm --dir src/frontend test
 	pnpm --dir src/frontend run build
 
 lint:

--- a/src/backend/alembic/env.py
+++ b/src/backend/alembic/env.py
@@ -15,7 +15,10 @@ from app.core.db import Base
 config = context.config
 
 if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+    # disable_existing_loggers 默认 True 会把此刻已创建的所有 logger（上面
+    # import app.models 已把 app.* 全拉起来）静默置为 disabled——同进程内跑
+    # 迁移（测试、desktop 档位）后应用日志就此消失（#581 第三个失败的根因）。
+    fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 if not config.get_main_option("sqlalchemy.url"):
     config.set_main_option("sqlalchemy.url", get_settings().database_url)

--- a/src/backend/tests/test_experiment_env.py
+++ b/src/backend/tests/test_experiment_env.py
@@ -220,14 +220,24 @@ async def test_prompt_context_sections(client, queue_stub, fake_ssh, bus_recorde
 
 
 def test_prompt_with_context_unit():
-    """条件段单元测试：无参数时 prompt 原样；各开关独立生效。"""
+    """条件段单元测试：无参数时只有无条件段；各开关独立生效。
+
+    栈保护 / 技能指引 / 证据指引是安全与信任约定，**无条件**追加（#549 起），
+    所以旧的「空参数 == base 恒等」契约已过期——改断言「以 base 开头 + 不含
+    任何条件段」，条件段（eval_model / hf_mirror / extra_notes）仍逐一验证。
+    """
 
     def ctx(params):
         return ax.ActionContext(run=None, llm=None, checkpoint={"params": params})
 
     base = ax.CODE_SYSTEM_PROMPT
-    assert ax._prompt_with_context(base, ctx({})) == base
-    assert ax._prompt_with_context(base, ctx({"eval_model": "  ", "extra_notes": ""})) == base
+    empty = ax._prompt_with_context(base, ctx({}))
+    assert empty.startswith(base)
+    # 负向：空参数时不得混入任何条件段（评测模型的 llm_config.json / HF 镜像）
+    assert "llm_config.json" not in empty
+    assert "HF_ENDPOINT" not in empty and "https://hf-mirror.com" not in empty
+    # 空白参数与空参数等价（strip 后视同未填）
+    assert ax._prompt_with_context(base, ctx({"eval_model": "  ", "extra_notes": ""})) == empty
 
     with_eval = ax._prompt_with_context(base, ctx({"eval_model": EVAL_MODEL}))
     assert with_eval.startswith(base) and "llm_config.json" in with_eval

--- a/src/backend/tests/test_experiment_iterate.py
+++ b/src/backend/tests/test_experiment_iterate.py
@@ -253,7 +253,8 @@ async def test_no_improve_stop_budget_param(client, queue_stub, fake_ssh, bus_re
 async def test_debug_repeats_until_run_budget(client, queue_stub, fake_ssh, bus_recorder):
     """debug 不再按次数终止（旧限额 3 次）：只受轮数/时间预算约束。
     每轮都失败、decision 一直 debug → 修到 max_runs 截断；全部轮次失败 →
-    完成标准终检转提问（零主指标），报告仍按事实收口为 failed。"""
+    完成标准终检转提问（零主指标）。报告步不写终态（#367），failed 只由人拍板：
+    提问期间实验镜像「等你回复」，用户 abort 后 voyage/实验才双双落 failed。"""
     fake_ssh.run_exit = 1  # 每轮正式运行都失败
     fake_ssh.run_log = "Traceback: train boom\n"
     project_id, headers, exp_id, voyage_id = await _launch_experiment(
@@ -267,7 +268,8 @@ async def test_debug_repeats_until_run_budget(client, queue_stub, fake_ssh, bus_
     assert voyage_status == "paused_ask"
     assert observation["stopped_reason"] == "max_runs"
     resp = await client.get(f"/api/voyages/{voyage_id}", headers=headers)
-    assert resp.json()["open_ask"]["payload"]["ask_kind"] == "done_criteria"
+    ask = resp.json()["open_ask"]
+    assert ask["payload"]["ask_kind"] == "done_criteria"
     detail = await _get_detail(client, headers, exp_id)
     assert len(detail["runs"]) == 5  # 修过 4 次（超过旧限额 3）仍在继续，直到轮数预算
     assert all(r["status"] == "failed" for r in detail["runs"])
@@ -275,8 +277,21 @@ async def test_debug_repeats_until_run_budget(client, queue_stub, fake_ssh, bus_
     state = detail["iteration_state"]
     assert state["debug_count"] == 4  # 不再在 3 处截断
     assert state["stopped_reason"] == "max_runs"
-    assert detail["status"] == "failed"
+    # 报告已按事实生成，但报告步不写终态——提问期间实验镜像「等你回复」
+    assert detail["status"] == "waiting_user"
     assert detail["report"].startswith("## 实验报告")
+
+    # 人拍板放弃（唯一由用户决定的失败路径）→ voyage 与实验双双落 failed
+    resp = await client.post(
+        f"/api/voyages/{voyage_id}/asks/{ask['id']}/answer",
+        json={"choice": "abort"},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    resp = await client.get(f"/api/voyages/{voyage_id}", headers=headers)
+    assert resp.json()["status"] == "failed"
+    detail = await _get_detail(client, headers, exp_id)
+    assert detail["status"] == "failed"
 
 async def test_analyze_ask_pauses_then_guidance_continues(
     client, queue_stub, fake_ssh, bus_recorder


### PR DESCRIPTION
Closes #728. Closes #581. Part of #715 (audit items 18+19 — pytest and vitest ran in no workflow, which is how the legacy failures survived on main).

## The three repairs (two root causes ran deeper than the audit's guess)
- **prompt equality**: the unconditional stack-guard/skill/evidence sections are a safety contract since #549 — the test's `== base` identity was the stale part; now `startswith` plus negative content assertions, with the contract change documented
- **debug-until-budget**: not the gate helper — the tail asserted `failed` where the engine correctly parks at `waiting_user` (reports never self-declare failure; a human rules). The test now walks the full adjudication chain: report generated → run mirrors `waiting_user` → abort via the ask endpoint → voyage and experiment both `failed`
- **manuscript caplog**: the wording was fine — `test_concept_promotion` runs an in-process alembic migration whose `fileConfig()` silently disables every already-imported `app.*` logger (`disable_existing_loggers` defaults true), so caplog went deaf for the rest of the session. Root-treated in `alembic/env.py` (also fixing real log loss after desktop-profile migrations); the test itself is untouched. Reproduced and verified with the offending pair
- verified against sibling cases (32 + 14 green) and the migration trio

## CI
- new `python-ci.yml`: full backend pytest on `src/backend/**` PRs — the conftest is fully self-sufficient (SQLite + fakeredis + its own env), zero service setup, pip-cached, 45-minute budget against a measured 26-minute run; actionlint-clean
- `node-ci.yml` gains the frontend vitest step and the `src/frontend/**` path; the Makefile `test` target gains vitest

**First-ever fully green run: 1722 passed, 0 failed** (baseline for this gate). Frontend 180/180.