### PR TITLE
fix: server-profile owner guard for admin surfaces

### DIFF
--- a/src/backend/app/api/admin_llm.py
+++ b/src/backend/app/api/admin_llm.py
@@ -1,4 +1,6 @@
-"""管理端 LLM 配置路由（仅 role=admin，docs/task-system.md §7（原 api-m1.md §2））。"""
+"""LLM 配置路由（仅平台主人：桌面档=本人；服务器档=首位用户）。
+
+接口清单见 docs/task-system.md §7（原 api-m1.md §2）。"""
 
 import uuid
 
@@ -6,7 +8,6 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.auth import current_active_user
 from app.core.db import get_session
 from app.models.llm_config import LLMCallLog, LLMProviderConfig
 from app.schemas.llm_admin import (
@@ -23,9 +24,10 @@ from app.schemas.llm_admin import (
     UsageRow,
 )
 from app.services import llm_admin as llm_admin_service
+from app.services.owner import require_owner
 
 router = APIRouter(
-    prefix="/admin/llm", tags=["admin-llm"], dependencies=[Depends(current_active_user)]
+    prefix="/admin/llm", tags=["admin-llm"], dependencies=[Depends(require_owner)]
 )
 
 

--- a/src/backend/app/api/admin_settings.py
+++ b/src/backend/app/api/admin_settings.py
@@ -1,9 +1,8 @@
-"""管理端全局设置路由（仅 role=admin）：机构抽取模式、论文级向量总闸等。"""
+"""平台设置路由（仅平台主人：桌面档=本人；服务器档=首位用户）：机构抽取模式、论文级向量总闸等。"""
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.auth import current_active_user
 from app.core.db import get_session
 from app.schemas.admin_settings import (
     AffiliationModeRead,
@@ -39,9 +38,10 @@ from app.services import literature_settings as literature_settings_service
 from app.services import managed_command_watchdog as watchdog_service
 from app.services import tts as tts_service
 from app.services.literature.multi_source import provider_failure_detail
+from app.services.owner import require_owner
 
 router = APIRouter(
-    prefix="/admin/settings", tags=["admin-settings"], dependencies=[Depends(current_active_user)]
+    prefix="/admin/settings", tags=["admin-settings"], dependencies=[Depends(require_owner)]
 )
 
 

--- a/src/backend/app/api/daily.py
+++ b/src/backend/app/api/daily.py
@@ -1,7 +1,8 @@
 """每日新论文池路由：/daily。
 
 全部署共享：登录即可浏览/点赞/收录（收录目标各自校验写权限）；
-订阅分类管理与手动刷新仅 admin。业务逻辑在 services/daily_feed.py。
+全局参数（分类/扫描范围/保留期/抓取时刻/探测上限）与手动刷新仅平台主人
+（桌面档=本人；服务器档=首位用户，#722）。业务逻辑在 services/daily_feed.py。
 """
 
 import asyncio
@@ -54,6 +55,7 @@ from app.services import library_chat as library_chat_service
 from app.services import paper_enrich as paper_enrich_service
 from app.services import papers as papers_service
 from app.services.embedding import embed_query
+from app.services.owner import require_owner
 
 logger = logging.getLogger(__name__)
 
@@ -354,9 +356,9 @@ async def get_sync_scope(
 async def set_sync_scope(
     payload: LibrarySyncScopeUpdate,
     session: AsyncSession = Depends(get_session),
-    _: User = Depends(current_active_user),
+    _: User = Depends(require_owner),
 ) -> LibrarySyncScopeRead:
-    """改扫描范围（admin）。
+    """改扫描范围（仅平台主人）。
 
     - ``since_last``（默认）：从这个库**上次成功同步**那天算起。正常情况下就是当天
       那批（和 daily 一样省），漏了几天会自动多扫几天（和 full 一样能自愈）。
@@ -380,9 +382,9 @@ async def get_retention(
 async def set_retention(
     payload: DailyRetentionUpdate,
     session: AsyncSession = Depends(get_session),
-    _: User = Depends(current_active_user),
+    _: User = Depends(require_owner),
 ) -> DailyRetentionRead:
-    """改保留天数（admin）。
+    """改保留天数（仅平台主人）。
 
     这不只是「每日页显示几天」：每日池同时是**库同步的取数窗口**，同步会全量重扫它。
     所以保留期也就是「一个文献库最多能漏几天还能自愈」——掉出窗口的论文永久错过，
@@ -405,9 +407,9 @@ async def get_sync_time(
 async def set_sync_time(
     payload: DailySyncTimeUpdate,
     session: AsyncSession = Depends(get_session),
-    _: User = Depends(current_active_user),
+    _: User = Depends(require_owner),
 ) -> DailySyncTimeRead:
-    """改抓取时刻（admin）。
+    """改抓取时刻（仅平台主人）。
 
     arXiv 每天约北京时间 10:00 放新公告，早于这个点跑只会拿到**前一天**的列表。
     库同步与发表匹配的时刻由它派生（+90 / +150 分钟），不必分别设置。
@@ -429,9 +431,9 @@ async def get_probe_attempts(
 async def set_probe_attempts(
     payload: DailyProbeAttemptsUpdate,
     session: AsyncSession = Depends(get_session),
-    _: User = Depends(current_active_user),
+    _: User = Depends(require_owner),
 ) -> DailyProbeAttemptsRead:
-    """改探测次数上限（admin）。
+    """改探测次数上限（仅平台主人）。
 
     从抓取时刻起每 15 分钟探一次，探满这么多次仍没有今天的批次就当天收工——
     这是**正常结束**，不会留下失败的任务。默认 10 次 ≈ 覆盖 2.5 小时。
@@ -452,7 +454,7 @@ async def get_categories(
 async def set_categories(
     payload: DailyCategoriesUpdate,
     session: AsyncSession = Depends(get_session),
-    user: User = Depends(current_active_user),
+    _: User = Depends(require_owner),
 ) -> DailyCategoriesRead:
     try:
         categories = await daily_service.set_categories(session, payload.categories)
@@ -537,10 +539,10 @@ async def compile_entry(
 @router.post("/refresh", status_code=status.HTTP_202_ACCEPTED)
 async def refresh(
     session: AsyncSession = Depends(get_session),
-    user: User = Depends(current_active_user),
+    user: User = Depends(require_owner),
     queue: TaskQueue = Depends(get_task_queue),
 ) -> dict[str, str]:
-    """手动触发一次抓取（验证/补抓用）：建任务 + 入队，返回 voyage_id 供跳转任务详情。
+    """手动触发一次抓取（仅平台主人，验证/补抓用）：建任务 + 入队，返回 voyage_id 供跳转任务详情。
 
     互斥是全局单例——已有一次抓取在跑就 409（比按天去重的 job_id 更准：同一天里
     上一次失败后仍可立刻重来，而正在跑的绝不会被重复触发）。

--- a/src/backend/app/api/experiments.py
+++ b/src/backend/app/api/experiments.py
@@ -202,7 +202,7 @@ async def _manage_exp_project(session: AsyncSession, project_id: uuid.UUID, user
     if project is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
     if not projects_service.can_manage_project(project, user):
-        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="OWNER_OR_ADMIN_REQUIRED")
+        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="OWNER_REQUIRED")
     return project
 
 

--- a/src/backend/app/api/ideas.py
+++ b/src/backend/app/api/ideas.py
@@ -176,7 +176,7 @@ async def _manage_idea_project(session: AsyncSession, project_id: uuid.UUID, use
     """项目 + 管理权限（回收站/删除用）。"""
     project = await _member_project(session, project_id, user)
     if not projects_service.can_manage_project(project, user):
-        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="OWNER_OR_ADMIN_REQUIRED")
+        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="OWNER_REQUIRED")
     return project
 
 

--- a/src/backend/app/api/manuscripts.py
+++ b/src/backend/app/api/manuscripts.py
@@ -424,7 +424,7 @@ async def _manage_manuscript_project(session: AsyncSession, manuscript: Manuscri
         session, project_id=manuscript.project_id, user_id=user.id
     )
     if project is None or not projects_service.can_manage_project(project, user):
-        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="OWNER_OR_ADMIN_REQUIRED")
+        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="OWNER_REQUIRED")
     return project
 
 
@@ -475,7 +475,7 @@ async def batch_manuscripts(
     if project is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
     if not projects_service.can_manage_project(project, user):
-        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="OWNER_OR_ADMIN_REQUIRED")
+        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="OWNER_REQUIRED")
     if data.action == "trash":
         n = await manuscripts_service.trash_manuscripts(
             session, project_id=project_id, ids=data.ids
@@ -502,7 +502,7 @@ async def empty_manuscript_trash(
     if project is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="PROJECT_NOT_FOUND")
     if not projects_service.can_manage_project(project, user):
-        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="OWNER_OR_ADMIN_REQUIRED")
+        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="OWNER_REQUIRED")
     n = await manuscripts_service.purge_manuscripts(session, project_id=project_id, ids=None)
     return BatchResult(affected=n)
 

--- a/src/backend/app/services/owner.py
+++ b/src/backend/app/services/owner.py
@@ -1,0 +1,70 @@
+"""平台主人（owner）判定：admin 面只对「机器的主人」开放（#722，审计 #715 第 9 项）。
+
+为什么需要它：治理字段（role 等）已随个人化定位删除（#614）——桌面档只有一个用户，
+机器的主人不需要被自己治理。但 server 档 + 邀请码注册仍被支持（小团队自部署共用一台），
+#616 把 require_admin 一刀切换成 current_active_user 后，任何注册用户都能改全局 LLM
+密钥、文献源密钥、向量空间。这里恢复一个不需要任何新字段/迁移的最小守卫：
+
+- desktop 档：恒为主人——唯一用户即机器的主人，不查库；
+- server 档：主人 = created_at 最早的活跃用户（并列取 id 小者，保证确定性）。
+  部署这台机器的人总是第一个注册的人，这个判据天然成立。
+
+局限（有意为之）：
+- owner id 进程内缓存一次：后续注册的用户不可能「挤掉」既有主人，也免得每个 admin
+  请求都扫 users 表；代价是首用户被停用后，其他人要接管 admin 面得先动库再重启进程。
+  owner 的显式转移/多 owner 属后续工作，不在本守卫范围。
+"""
+
+import uuid
+
+from fastapi import Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# 例外地从 api 层拿 current_active_user：require_owner 是给路由挂的 FastAPI 依赖，
+# 认证栈（fastapi-users）装配在 app.api.auth，不值得为一个依赖再拆一层。无循环导入。
+from app.api.auth import current_active_user
+from app.core.config import get_settings
+from app.core.db import get_session
+from app.models.user import User
+
+# 进程内缓存的 owner id；None = 尚未解析（或库里还没有用户）。
+_owner_id: uuid.UUID | None = None
+
+
+def reset_owner_cache() -> None:
+    """丢弃缓存的 owner id（测试夹具每个用例重建库后必须调用）。"""
+    global _owner_id
+    _owner_id = None
+
+
+async def _resolve_owner_id(session: AsyncSession) -> uuid.UUID | None:
+    global _owner_id
+    if _owner_id is None:
+        _owner_id = (
+            await session.execute(
+                select(User.id)
+                .where(User.is_active.is_(True))
+                .order_by(User.created_at.asc(), User.id.asc())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+    return _owner_id
+
+
+async def is_owner(session: AsyncSession, user: User) -> bool:
+    """这个用户是不是平台主人（桌面档=本人；服务器档=首位用户）。"""
+    if get_settings().is_desktop:
+        return True
+    owner_id = await _resolve_owner_id(session)
+    return owner_id is not None and user.id == owner_id
+
+
+async def require_owner(
+    user: User = Depends(current_active_user),
+    session: AsyncSession = Depends(get_session),
+) -> User:
+    """FastAPI 依赖：仅平台主人放行，否则 403 OWNER_REQUIRED（未登录仍是 401）。"""
+    if not await is_owner(session, user):
+        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="OWNER_REQUIRED")
+    return user

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -3,12 +3,15 @@
 注意：必须在 import app 之前设置环境变量（Settings 是 lru_cache 的）。
 """
 
+import datetime as dt
+import itertools
 import os
 import re
 import tempfile
 
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select as sa_select
 
 _TMPDIR = tempfile.mkdtemp(prefix="polaris-test-")
 os.environ["POLARIS_ENV"] = "dev"
@@ -24,12 +27,14 @@ os.environ["POLARIS_OPENALEX_ALIGN_ON_ENRICH"] = "0"
 # 不该有意外文件产物；投影专项测试（test_file_projection.py）用 fixture 单独开
 os.environ["POLARIS_FILE_PROJECTION"] = "0"
 
-from app.core.db import Base, dispose_engine, get_engine  # noqa: E402
+from app.core.db import Base, dispose_engine, get_engine, get_sessionmaker  # noqa: E402
 from app.core.events import get_event_bus  # noqa: E402
 from app.core.llm.router import reset_llm_router  # noqa: E402
 from app.core.queue import get_task_queue  # noqa: E402
 from app.core.redis import get_redis_dep  # noqa: E402
 from app.main import create_app  # noqa: E402
+from app.models.user import User  # noqa: E402
+from app.services.owner import reset_owner_cache  # noqa: E402
 
 import app.models  # noqa: E402,F401  isort: skip  注册全部表
 
@@ -44,6 +49,16 @@ async def app():
     reset_llm_router()  # 丢弃路由缓存，避免跨测试串味
     yield create_app()
     await dispose_engine()
+
+
+@pytest_asyncio.fixture(autouse=True)
+def _fresh_owner_cache():
+    """owner id 是进程内缓存（#722）：每个用例都换新库/新用户集，先清缓存再跑。
+
+    autouse 而不是挂在 app 夹具里——不经 app 夹具的用例也可能间接触发解析，
+    统一在这里清一次最不容易漏。"""
+    reset_owner_cache()
+    yield
 
 
 @pytest_asyncio.fixture
@@ -332,6 +347,26 @@ def _username_from_email(email: str) -> str:
     return (uname + "_u")[:32] if len(uname) < 3 else uname[:32]
 
 
+# 本机 dev 虚拟机的容器墙钟每 ~10 秒跳 ±1 秒（#234 的根因）：连续两次注册的
+# created_at 可能倒挂，「服务器档 owner = created_at 最早的用户」（#722）会被随机
+# 翻车。注册成功后把 created_at 钉成进程内单调递增，还原生产环境（时钟正常）本来
+# 就成立的「注册顺序 == created_at 顺序」，测试才有确定性。
+_register_seq = itertools.count()
+_register_epoch: dt.datetime | None = None
+
+
+async def _pin_created_at(email: str) -> None:
+    global _register_epoch
+    if _register_epoch is None:
+        _register_epoch = dt.datetime.now(dt.UTC)
+    async with get_sessionmaker()() as session:
+        user = (
+            await session.execute(sa_select(User).where(User.email == email))
+        ).scalar_one()
+        user.created_at = _register_epoch + dt.timedelta(seconds=next(_register_seq))
+        await session.commit()
+
+
 async def register_and_login(
     client: AsyncClient, email: str = "alice@example.com", username: str | None = None
 ) -> str:
@@ -347,6 +382,7 @@ async def register_and_login(
         },
     )
     assert resp.status_code == 201, resp.text
+    await _pin_created_at(email)
     resp = await client.post(
         "/api/auth/jwt/login",
         data={"username": email, "password": "str0ng-password"},

--- a/src/backend/tests/test_admin_document_processing_settings.py
+++ b/src/backend/tests/test_admin_document_processing_settings.py
@@ -37,9 +37,10 @@ async def test_document_processing_settings_roundtrip_and_permissions(client):
     assert payload["mineru_concurrency"] == 4
     assert payload["mineru_credentials"] == []
 
-    # 管理端点对任何登录用户开放（#614）
+    # admin 面回到单一主人守卫（#722）：第二个注册用户 403
     response = await client.get("/api/admin/settings/document-processing", headers=member)
-    assert response.status_code == 200
+    assert response.status_code == 403
+    assert response.json()["detail"] == "OWNER_REQUIRED"
 
 
 async def test_document_processing_settings_reject_unsafe_policy_and_url(client):

--- a/src/backend/tests/test_admin_literature_settings.py
+++ b/src/backend/tests/test_admin_literature_settings.py
@@ -39,9 +39,10 @@ async def test_literature_settings_roundtrip_masks_provider_keys(client):
     assert response.status_code == 200
     assert response.json()["provider_keys"]["sciverse"][1]["configured"] is True
 
-    # 管理端点对任何登录用户开放（#614）
+    # admin 面回到单一主人守卫（#722）：第二个注册用户 403
     response = await client.get("/api/admin/settings/literature-search", headers=member)
-    assert response.status_code == 200
+    assert response.status_code == 403
+    assert response.json()["detail"] == "OWNER_REQUIRED"
 
 
 async def test_literature_settings_reject_invalid_source_and_year_window(client):
@@ -160,9 +161,13 @@ async def test_provider_credential_crud_has_stable_id_and_runtime_enable_gate(cl
         runtime = await literature_settings.get_runtime_settings(session)
     assert runtime["provider_keys"]["openalex"] == ["replacement-secret-5678"]
 
-    # 任何登录用户都能删（#614）
+    # 非主人不能删（#722）；主人删除后再删 → 404
     response = await client.delete(
         f"/api/admin/settings/literature-search/credentials/{credential_id}", headers=member
+    )
+    assert response.status_code == 403
+    response = await client.delete(
+        f"/api/admin/settings/literature-search/credentials/{credential_id}", headers=admin
     )
     assert response.status_code == 204
     response = await client.delete(

--- a/src/backend/tests/test_admin_llm.py
+++ b/src/backend/tests/test_admin_llm.py
@@ -93,8 +93,8 @@ async def _admin_and_member(client):
     )
 
 
-async def test_admin_llm_requires_login(client):
-    """role 治理移除（#614）后管理端点对任何登录用户开放；未登录仍 401。"""
+async def test_admin_llm_owner_only(client):
+    """admin 面回到单一主人守卫（#722）：首位用户放行，其余登录用户 403，未登录 401。"""
     admin, member = await _admin_and_member(client)
     for method, url in [
         ("GET", "/api/admin/llm/providers"),
@@ -104,7 +104,8 @@ async def test_admin_llm_requires_login(client):
         resp = await client.request(method, url)
         assert resp.status_code == 401, (method, url, resp.status_code)
         resp = await client.request(method, url, headers=member)
-        assert resp.status_code == 200, (method, url, resp.status_code)
+        assert resp.status_code == 403, (method, url, resp.status_code)
+        assert resp.json()["detail"] == "OWNER_REQUIRED"
     resp = await client.get("/api/admin/llm/providers", headers=admin)
     assert resp.status_code == 200
 
@@ -303,11 +304,13 @@ async def _fake_provider_id(client, admin) -> str:
     return resp.json()["id"]
 
 
-async def test_test_model_open_to_any_user(client):
+async def test_test_model_owner_only(client):
     admin, member = await _admin_and_member(client)
     provider_id = await _fake_provider_id(client, admin)
     body = {"provider_id": provider_id, "model": "fake-default", "capability": "chat"}
     resp = await client.post("/api/admin/llm/test-model", json=body, headers=member)
+    assert resp.status_code == 403  # admin 面整体回到主人守卫（#722）
+    resp = await client.post("/api/admin/llm/test-model", json=body, headers=admin)
     assert resp.status_code == 200
 
 

--- a/src/backend/tests/test_affiliations.py
+++ b/src/backend/tests/test_affiliations.py
@@ -271,9 +271,13 @@ async def test_affiliation_mode_admin_endpoint(client):
 
     resp = await client.get("/api/admin/settings/affiliation-mode", headers=ah)
     assert resp.status_code == 200 and resp.json()["mode"] == "on_add"
-    # 任何登录用户都能改（admin 治理已随 #614 移除）；非法值 422（schema Literal 校验）
+    # 只有平台主人能改（#722）；非法值 422（schema Literal 校验）
     resp = await client.put(
         "/api/admin/settings/affiliation-mode", json={"mode": "on_compile"}, headers=mh
+    )
+    assert resp.status_code == 403 and resp.json()["detail"] == "OWNER_REQUIRED"
+    resp = await client.put(
+        "/api/admin/settings/affiliation-mode", json={"mode": "on_compile"}, headers=ah
     )
     assert resp.status_code == 200 and resp.json()["mode"] == "on_compile"
     resp = await client.put(

--- a/src/backend/tests/test_daily_embed_search_export.py
+++ b/src/backend/tests/test_daily_embed_search_export.py
@@ -148,12 +148,12 @@ async def test_backfill_counts(client, monkeypatch):
     assert resp.status_code == 200
     assert resp.json() == {"embedded": 0, "skipped": 1, "failed": 0}
 
-    # 管理端点对任何登录用户开放（#614）
+    # admin 面回到单一主人守卫（#722）：第二个注册用户 403
     other = await register_and_login(client, email="bob@example.com")
     resp = await client.post(
         "/api/admin/settings/daily-embed/backfill", headers={"Authorization": f"Bearer {other}"}
     )
-    assert resp.status_code == 200
+    assert resp.status_code == 403
 
 
 # ---- 3. 语义检索（sqlite 下回退关键词） ----

--- a/src/backend/tests/test_daily_feed.py
+++ b/src/backend/tests/test_daily_feed.py
@@ -542,9 +542,9 @@ async def test_categories_admin_and_refresh(client, queue_stub):
     # 本文件的 autouse fixture 播种了历史三件套；「没配过就是空」见 test_no_cs_defaults
     assert resp.json()["categories"] == ["cs.AI", "cs.CL", "cs.CV"]
 
-    # 任何登录用户都能改分类（admin 治理已随 #614 移除）；非法格式 422
+    # 分类只有平台主人能改（#722）；非法格式 422
     resp = await client.put("/api/daily/categories", json={"categories": ["cs.LG"]}, headers=mh)
-    assert resp.status_code == 200 and resp.json()["categories"] == ["cs.LG"]
+    assert resp.status_code == 403 and resp.json()["detail"] == "OWNER_REQUIRED"
 
     resp = await client.put(
         "/api/daily/categories", json={"categories": ["cs.LG", "stat.ML"]}, headers=ah
@@ -1022,10 +1022,10 @@ async def test_sync_time_is_admin_configurable(client):
     async with get_sessionmaker()() as session:
         assert await daily_feed.get_sync_time(session) == (3, 45)
 
-    # 任何登录用户都能改（#614）
+    # 只有平台主人能改（#722）
     other = {"Authorization": f"Bearer {await register_and_login(client, email='u2@e.com')}"}
     resp = await client.put("/api/daily/sync-time", json={"hour": 5, "minute": 0}, headers=other)
-    assert resp.status_code == 200
+    assert resp.status_code == 403
 
 
 async def test_due_now_gates_on_the_configured_time(client):
@@ -1250,7 +1250,7 @@ async def test_max_probe_attempts_defaults_to_ten_and_is_configurable(client):
 
     assert (
         await client.put("/api/daily/probe-attempts", json={"attempts": 4}, headers=member)
-    ).status_code == 200  # 任何登录用户都能改（#614）
+    ).status_code == 403  # 只有平台主人能改（#722）
 
     resp = await client.put("/api/daily/probe-attempts", json={"attempts": 4}, headers=admin)
     assert resp.status_code == 200 and resp.json()["attempts"] == 4
@@ -1465,7 +1465,7 @@ async def test_retention_defaults_to_two_weeks_and_is_configurable(client):
     other = {"Authorization": f"Bearer {await register_and_login(client, email='r2@e.com')}"}
     assert (
         await client.put("/api/daily/retention", json={"days": 3}, headers=other)
-    ).status_code == 200  # 任何登录用户都能改（#614）
+    ).status_code == 403  # 只有平台主人能改（#722）
 
 
 async def test_cleanup_uses_the_configured_retention(client, monkeypatch):

--- a/src/backend/tests/test_llm_call_logs.py
+++ b/src/backend/tests/test_llm_call_logs.py
@@ -140,9 +140,9 @@ async def _admin_and_member(client):
     )
 
 
-async def test_call_log_endpoints_require_login(client):
-    """role 治理移除（#614）后管理端点对任何登录用户开放；未登录仍 401。"""
-    _, member = await _admin_and_member(client)
+async def test_call_log_endpoints_owner_only(client):
+    """admin 面回到单一主人守卫（#722）：首位用户放行，其余登录用户 403，未登录 401。"""
+    admin, member = await _admin_and_member(client)
     for method, url, body in [
         ("GET", "/api/admin/llm/call-logs", None),
         ("GET", "/api/admin/llm/call-logs/settings", None),
@@ -150,6 +150,8 @@ async def test_call_log_endpoints_require_login(client):
         resp = await client.request(method, url, json=body)
         assert resp.status_code == 401, (method, url, resp.status_code)
         resp = await client.request(method, url, json=body, headers=member)
+        assert resp.status_code == 403, (method, url, resp.status_code)
+        resp = await client.request(method, url, json=body, headers=admin)
         assert resp.status_code == 200, (method, url, resp.status_code)
 
 

--- a/src/backend/tests/test_owner_guard.py
+++ b/src/backend/tests/test_owner_guard.py
@@ -1,0 +1,57 @@
+"""admin 面的单一主人守卫（#722）：桌面档=本人；服务器档=首位注册用户。
+
+#616 移除 require_admin 后 server 档任何注册用户都能改全局 LLM 密钥/源密钥/向量空间
+（审计 #715 第 9 项）；这里钉住恢复后的口径。
+"""
+
+from app.core.config import get_settings
+from tests.conftest import register_and_login
+
+# 两个 router 各取一个探针端点：守卫挂在 router 级，一个通则全通、一个堵则全堵。
+ADMIN_PROBES = [
+    ("GET", "/api/admin/settings/affiliation-mode"),
+    ("GET", "/api/admin/llm/providers"),
+]
+
+
+async def _owner_and_second(client):
+    owner = await register_and_login(client, email="owner@example.com")
+    second = await register_and_login(client, email="second@example.com")
+    return {"Authorization": f"Bearer {owner}"}, {"Authorization": f"Bearer {second}"}
+
+
+async def test_server_profile_only_first_user_passes_admin(client):
+    owner, second = await _owner_and_second(client)
+    for method, url in ADMIN_PROBES:
+        # 第二个用户先发请求也占不了坑：解析出的 owner 仍是 created_at 最早的首位用户
+        resp = await client.request(method, url, headers=second)
+        assert resp.status_code == 403, (method, url, resp.status_code)
+        assert resp.json()["detail"] == "OWNER_REQUIRED"
+        resp = await client.request(method, url, headers=owner)
+        assert resp.status_code == 200, (method, url, resp.status_code)
+
+
+async def test_server_profile_daily_admin_endpoints_are_owner_only(client):
+    owner, second = await _owner_and_second(client)
+    resp = await client.put("/api/daily/retention", json={"days": 21}, headers=second)
+    assert resp.status_code == 403 and resp.json()["detail"] == "OWNER_REQUIRED"
+    # 读端点保持全员开放
+    resp = await client.get("/api/daily/retention", headers=second)
+    assert resp.status_code == 200
+    resp = await client.put("/api/daily/retention", json={"days": 21}, headers=owner)
+    assert resp.status_code == 200 and resp.json() == {"days": 21}
+
+
+async def test_desktop_profile_any_user_is_owner(client, monkeypatch):
+    """桌面档唯一用户即机器的主人：守卫恒放行，不查库。"""
+    owner, second = await _owner_and_second(client)
+    monkeypatch.setattr(get_settings(), "profile", "desktop")
+    for method, url in ADMIN_PROBES:
+        resp = await client.request(method, url, headers=second)
+        assert resp.status_code == 200, (method, url, resp.status_code)
+
+
+async def test_admin_endpoints_still_require_login(client):
+    for method, url in ADMIN_PROBES:
+        resp = await client.request(method, url)
+        assert resp.status_code == 401, (method, url, resp.status_code)

--- a/src/backend/tests/test_tts.py
+++ b/src/backend/tests/test_tts.py
@@ -69,9 +69,10 @@ async def test_admin_and_personal_tts_settings(client):
     admin = await _headers(client)
     member = await _headers(client, "tts-member@example.com")
 
-    # 管理端点对任何登录用户开放（#614）
-    allowed = await client.get("/api/admin/settings/tts", headers=member)
-    assert allowed.status_code == 200
+    # admin 面回到单一主人守卫（#722）：第二个注册用户 403
+    denied = await client.get("/api/admin/settings/tts", headers=member)
+    assert denied.status_code == 403
+    assert denied.json()["detail"] == "OWNER_REQUIRED"
 
     payload = {
         "enabled": True,


### PR DESCRIPTION
Closes #722. Part of #715 (audit item 9 — after #616 any invite-code registrant could edit global LLM/source keys on a server deployment).

- `services/owner.py`: on desktop every user is the owner (the machine's person, no query); on server the owner is the earliest-created active user with a deterministic `(created_at, id)` tiebreak — no new columns, no migration. `require_owner` returns 403 `OWNER_REQUIRED` (401 stays 401). Documented limitation: the owner id caches per process, so a later registrant can never displace the owner; explicit owner transfer is future work
- mounted on the `/admin/settings` and `/admin/llm` routers and the six daily admin endpoints (the exact set `require_admin` guarded before #616); read endpoints and the deliberately-open single-user surfaces untouched; docstrings now tell the truth
- the stale `OWNER_OR_ADMIN_REQUIRED` code becomes `OWNER_REQUIRED` (5 sites; no frontend match existed)
- an intermittent combined-run failure was chased to its real root: this machine's stepping wall clock can invert `created_at` between consecutive registrations, randomly changing "first user". Fixed both ways — an autouse owner-cache reset and test registrations pinning monotonically increasing `created_at` (restoring the ordering production actually guarantees); the offending trio ran green three consecutive rounds

Verification: full suite **1735 passed, 0 failed** on the rebased tree (the new CI baseline); 4 new guard tests, 9 existing files updated from the #614-era "any active user" assertions; goldens untouched; ruff green.