### PR TITLE
feat: plugin-namespaced LLM stages

### DIFF
--- a/src/backend/app/core/llm/fake.py
+++ b/src/backend/app/core/llm/fake.py
@@ -40,6 +40,12 @@ _CITATION_INTENT_MARKER = "POLARIS_CITATION_INTENT"  # 引文意图批量分类�
 _EXTRACT_SKELETON_MARKER = "POLARIS_EXTRACT_SKELETON"  # 骨架抽取（services/extraction/）
 _EXTRACT_METHOD_MARKER = "POLARIS_EXTRACT_METHOD"  # 方法卡抽取（services/extraction/，#663）
 _EXTRACT_GAPS_MARKER = "POLARIS_EXTRACT_GAPS"  # 缺口台账抽取（services/extraction/，#665）
+# 插件学科 schema 的通用兜底（#736）：约定 prompt 首行带 POLARIS_EXTRACT_ 前缀的
+# 专属 marker（如 POLARIS_EXTRACT_PICO）。上面三个内置 schema 的专用 handler
+# 先判、先返回，所以这个前缀兜底只会接住「fake 不认识的抽取 schema」——
+# 它按 system prompt 里的字段清单（field_spec_text 的确定性格式）反推一份
+# 合法 JSON，让学科包在无 key 演示/测试里也能走通全链。
+_EXTRACT_GENERIC_PREFIX = "POLARIS_EXTRACT_"
 # 库级 agentic RAG 三环节（services/library_rag.py，#644）
 _RAG_EXPAND_MARKER = "POLARIS_RAG_EXPAND"
 _RAG_RERANK_MARKER = "POLARIS_RAG_RERANK"
@@ -458,6 +464,10 @@ class FakeProvider(LLMProvider):
         # 缺口台账抽取：同上，整篇正文进 user prompt，须先于通用 marker 判断
         if _EXTRACT_GAPS_MARKER in full_text:
             return FakeProvider._respond_extract_gaps(last_user)
+        # 插件学科 schema 兜底：内置三个抽取 marker 都没接住、但带抽取前缀时，
+        # 按字段清单反推合法 JSON（见 _respond_extract_generic）
+        if _EXTRACT_GENERIC_PREFIX in full_text:
+            return FakeProvider._respond_extract_generic(full_text, last_user)
         # 发表机构解析（专门调用）：system prompt 带 POLARIS_AUTHOR_AFFIL，user prompt 内嵌
         # 标题页文本（可能含 TL;DR 等其他 marker），须先于通用 marker 判断；返回逐位作者映射
         if _AFFILIATIONS_MARKER in full_text:
@@ -704,6 +714,44 @@ class FakeProvider(LLMProvider):
             },
             ensure_ascii=False,
         )
+
+    @staticmethod
+    def _respond_extract_generic(full_text: str, last_user: str) -> str:
+        """插件学科 schema 的通用抽取兜底（#736）。
+
+        不认识具体 schema，就把 system prompt 里的字段清单读回来——那份清单是
+        field_spec_text() 确定性生成的（「一段文本」「字符串数组」「对象数组」三种
+        句式），据此逐字段造一份能过归一化的 JSON。text 字段回显标题（测试据此
+        断言 prompt 带对了论文），entries 的枚举键取第一个合法取值。
+        """
+        m = re.search(r"标题：(.+)", last_user)
+        title = m.group(1).strip() if m else "未知论文"
+        payload: dict[str, Any] = {}
+        for line in full_text.splitlines():
+            text_m = re.match(r'- "([^"]+)"：一段文本', line)
+            list_m = re.match(r'- "([^"]+)"：字符串数组', line)
+            entries_m = re.match(
+                r'- "([^"]+)"：对象数组，最多 \d+ 条，每条含且仅含键 (.+?)；', line
+            )
+            if text_m:
+                name = text_m.group(1)
+                payload[name] = f"《{title}》的 {name}（fake generic extraction）"
+            elif list_m:
+                payload[list_m.group(1)] = [f"{list_m.group(1)} 条目一（fake generic）"]
+            elif entries_m:
+                entry: dict[str, str] = {}
+                for key_name, choices in re.findall(
+                    r'"([^"]+)"（(?:取值限 ([^）]+)|不超过 \d+ 字)）', entries_m.group(2)
+                ):
+                    entry[key_name] = (
+                        choices.split(" / ")[0].strip()
+                        if choices
+                        else f"（fake generic）{key_name}"
+                    )
+                if entry:
+                    payload[entries_m.group(1)] = [entry]
+        payload["confidence"] = 0.7
+        return json.dumps(payload, ensure_ascii=False)
 
     # ---- 库级 agentic RAG（services/library_rag.py 的三个 system prompt 对齐，#644） ----
 

--- a/src/backend/app/core/llm/router.py
+++ b/src/backend/app/core/llm/router.py
@@ -9,6 +9,7 @@
 
 import asyncio
 import logging
+import re
 import time
 import uuid
 from collections.abc import AsyncIterator, Sequence
@@ -102,6 +103,92 @@ STAGES = (
     "hyp_compare",
 )
 
+# ---- 插件命名空间环节（#736，设计报告 §19） ----
+#
+# 上面的 STAGES 元组是内置集合，保持 38 项不动；学科包/插件要挂自己的 LLM 环节时
+# 不再改核心表，而是在运行时注册一个三段式名字 ``plugin:<pack>:<stage>``。
+# 段字符集限 [a-z0-9-]：环节名会进 model_routes / llm_usage / llm_call_logs 的
+# stage 列和前端表格，放开大小写/下划线只会带来「同名不同串」的对账地狱。
+# 总长限 32：三张表的 stage 列都是 String(32)（放宽列宽是另一条改造线的事，
+# 这里先守住不写进截断串）。
+#
+# 与「没显式配路由就回退 default」的内置规则不同，插件环节多一级回退：注册时
+# 可以声明一个**内置** fallback 环节（如 extract_skeleton），语义是「没单独配路由
+# 时按这个内置环节的路由调用」。这不违背下面「界面说什么就是什么」的教训——
+# 那条教训针对的是设置页画着「跟随默认」实际却走别处的行；插件环节在设置页
+# 只有配了路由才出现（没有「跟随默认」的行画在那里骗人），fallback 是插件作者
+# 显式声明、可在注册处查证的行为。fallback 只准指向内置环节：允许指向另一个
+# 插件环节就会出现回退链，行为取决于插件加载顺序，没法讲清。
+PLUGIN_STAGE_RE = re.compile(r"^plugin:([a-z0-9-]+):([a-z0-9-]+)$")
+_PLUGIN_STAGE_MAX_LEN = 32  # ModelRoute/LLMUsage/LLMCallLog.stage 均为 String(32)
+
+
+@dataclass(slots=True, frozen=True)
+class PluginStageSpec:
+    """一个已注册插件环节的运行时声明。tier 决定耐心档（见 call_profile），
+    fallback 决定路由回退（见 resolve）。"""
+
+    name: str  # 完整命名空间串 plugin:<pack>:<stage>
+    tier: str  # "short" | "medium" | "long"
+    fallback: str | None  # 内置环节名或 None（None = 直接回退 default）
+
+
+_PLUGIN_STAGES: dict[str, PluginStageSpec] = {}
+
+
+def is_plugin_stage(stage: str) -> bool:
+    """名字是否为合法的插件命名空间串（只看形状，不看是否已注册）。"""
+    return bool(PLUGIN_STAGE_RE.match(stage)) and len(stage) <= _PLUGIN_STAGE_MAX_LEN
+
+
+def register_plugin_stage(
+    pack: str, stage: str, *, tier: str = "medium", fallback: str | None = None
+) -> str:
+    """注册一个插件环节，返回完整命名空间串。
+
+    重复注册：同名同配置幂等放过——抽取 schema 版本演进（同 id 覆盖注册）会把
+    同一环节再挂一次，这不该炸；同名**不同配置**拒绝——两个插件抢同一个名字，
+    或同一插件改了档位却没改版本，静默用先到的那份只会在线上表现成「配了没生效」。
+    """
+    name = f"plugin:{pack}:{stage}"
+    if not PLUGIN_STAGE_RE.match(name):
+        raise ValueError(
+            f"invalid plugin stage name: {name!r} (pack/stage segments must match [a-z0-9-]+)"
+        )
+    if len(name) > _PLUGIN_STAGE_MAX_LEN:
+        raise ValueError(
+            f"plugin stage name too long: {name!r} "
+            f"(max {_PLUGIN_STAGE_MAX_LEN} chars, the DB stage columns are String(32))"
+        )
+    if tier not in _TIER_PROFILES:
+        raise ValueError(f"unknown tier: {tier!r} (expected one of {sorted(_TIER_PROFILES)})")
+    if fallback is not None and fallback not in STAGES:
+        raise ValueError(f"fallback must be a built-in stage, got {fallback!r}")
+    spec = PluginStageSpec(name=name, tier=tier, fallback=fallback)
+    existing = _PLUGIN_STAGES.get(name)
+    if existing is not None:
+        if existing == spec:
+            return name
+        raise ValueError(f"plugin stage {name!r} already registered with a different config")
+    _PLUGIN_STAGES[name] = spec
+    return name
+
+
+def unregister_plugin_stage(name: str) -> bool:
+    """注销一个插件环节（插件卸载/测试清场用）；返回是否真的删了。"""
+    return _PLUGIN_STAGES.pop(name, None) is not None
+
+
+def plugin_stage_spec(stage: str) -> PluginStageSpec | None:
+    """已注册插件环节的声明；未注册返回 None。"""
+    return _PLUGIN_STAGES.get(stage)
+
+
+def known_stages() -> frozenset[str]:
+    """当前进程认识的全部环节：内置 STAGES + 已注册的插件环节。"""
+    return frozenset(STAGES) | _PLUGIN_STAGES.keys()
+
+
 _ROUTE_CACHE_TTL = 60.0
 
 # 能力型环节：需要专用模型（嵌入/重排），对话模型不具备该能力，
@@ -174,6 +261,9 @@ _SHORT_CALL = (60.0, 2)  # (timeout 秒, 最多尝试次数) → 最坏 60+3+60 
 _MEDIUM_CALL = (180.0, 2)
 _LONG_CALL = (300.0, 4)
 
+# 插件环节按注册时声明的 tier 取档（内置环节仍走下面三个集合的显式归类）
+_TIER_PROFILES = {"short": _SHORT_CALL, "medium": _MEDIUM_CALL, "long": _LONG_CALL}
+
 _SHORT_CALL_STAGES = frozenset(
     {
         "default",
@@ -240,6 +330,11 @@ def call_profile(stage: str) -> tuple[float, int]:
     短档 60s 对一个长生成环节是致命的（#386 就是这么把想法生成掐死的），
     而这种事从日志里看只是「provider 失败」。
     """
+    spec = _PLUGIN_STAGES.get(stage)
+    if spec is not None:
+        # 插件环节：档位在注册时声明（tier），不进上面三个内置集合——
+        # 那三个集合与 STAGES 元组有守卫测试互相对账，混入运行时注册项会把守卫搅浑
+        return _TIER_PROFILES[spec.tier]
     if stage in _MEDIUM_CALL_STAGES:
         return _MEDIUM_CALL
     if stage in _LONG_CALL_STAGES:
@@ -387,9 +482,17 @@ class LLMRouter:
         对话环节连 default 也没有时抛 LLMNotConfiguredError（503），不再
         静默回退演示用 fake provider；仅当显式开启
         ``settings.llm_fake_fallback``（测试套件 / 无 key 演示）才回退 fake。
+
+        插件命名空间环节（#736）的回退链是三级：精确路由（DB 里 stage 名 =
+        完整命名空间串）→ 注册时声明的内置 fallback 环节的路由 → default 路由。
+        耐心档不随回退变：始终按注册时声明的 tier（见 call_profile）。
         """
         routes = await self._get_routes()
         route = routes.get(stage)
+        if route is None:
+            spec = _PLUGIN_STAGES.get(stage)
+            if spec is not None and spec.fallback is not None:
+                route = routes.get(spec.fallback)
         if route is None:
             if stage in _CAPABILITY_STAGES:
                 if not routes and get_settings().llm_fake_fallback:

--- a/src/backend/app/services/extraction/schemas.py
+++ b/src/backend/app/services/extraction/schemas.py
@@ -55,8 +55,14 @@ class ExtractionSchema:
     fields: tuple[SchemaField, ...]
     # system prompt 模板，{fields_spec} 占位符由 field_spec_text() 填充
     prompt_template: str
-    # 该 schema 走哪个 LLM 环节（须在 core/llm/router.py 的 STAGES 里注册好路由与档位；
-    # 学科包挂新 schema 时要么复用已有环节，要么连同 STAGES/前端清单一起加）
+    # 该 schema 走哪个 LLM 环节。两种写法：
+    # - 内置环节名（如 extract_skeleton）：须在 core/llm/router.py 的 STAGES 里；
+    # - 插件命名空间串 plugin:<pack>:<stage>（#736）：register_schema 会自动把它注册进
+    #   router 的运行时环节表（tier=medium、fallback=extract_skeleton——与内置抽取
+    #   同为「整篇正文进、短 JSON 出」的负载形态），不必改 STAGES 或前端清单。
+    #   管理员想给它配专属模型，直接在路由表里为这个完整串加一行即可；没配时
+    #   按 extract_skeleton 的路由调用，再没有就跟随 default。
+    #   要自定 tier/fallback，先自行调用 router.register_plugin_stage 再 register_schema。
     stage: str = "extract_skeleton"
 
     def field_spec_text(self) -> str:
@@ -195,7 +201,19 @@ _REGISTRY: dict[str, ExtractionSchema] = {}
 
 
 def register_schema(schema: ExtractionSchema) -> None:
-    """挂载一个抽取 schema（学科包的接入点）。同 id 重复注册视为版本演进，直接覆盖。"""
+    """挂载一个抽取 schema（学科包的接入点）。同 id 重复注册视为版本演进，直接覆盖。
+
+    stage 是插件命名空间串且 router 还不认识它时，顺手注册进运行时环节表——
+    学科包作者只写一个 schema 就能走通全链，不用知道 router 的注册接口。
+    已注册过（学科包自己先按需调了 register_plugin_stage）就不动，尊重它声明的档位。
+    """
+    # 函数内 import：schemas 会在各服务模块 import 链的早期被拉起，顶层 import router
+    # 会把 config/db 一串东西提前加载，测试里改环境变量的窗口就没了
+    from app.core.llm.router import is_plugin_stage, known_stages, register_plugin_stage
+
+    if is_plugin_stage(schema.stage) and schema.stage not in known_stages():
+        _, pack, stage_name = schema.stage.split(":", 2)
+        register_plugin_stage(pack, stage_name, tier="medium", fallback="extract_skeleton")
     _REGISTRY[schema.id] = schema
 
 

--- a/src/backend/app/services/llm_admin.py
+++ b/src/backend/app/services/llm_admin.py
@@ -20,7 +20,7 @@ from app.core.llm.anthropic import AnthropicProvider
 from app.core.llm.base import LLMProvider, Message
 from app.core.llm.fake import FakeProvider
 from app.core.llm.openai_compat import OpenAICompatProvider
-from app.core.llm.router import STAGES, get_llm_router
+from app.core.llm.router import get_llm_router, is_plugin_stage, known_stages
 from app.core.security import decrypt_secret, encrypt_secret
 from app.models.base import utcnow
 from app.models.llm_config import LLMCallLog, LLMProviderConfig, LLMUsage, ModelRoute
@@ -145,8 +145,13 @@ async def list_routes(session: AsyncSession) -> Sequence[ModelRoute]:
 async def replace_routes(session: AsyncSession, items: Sequence[RouteItem]) -> Sequence[ModelRoute]:
     """整表覆盖平台路由。stage 必须合法且不重复，provider 必须是平台的。"""
     seen: set[str] = set()
+    valid_stages = known_stages()
     for item in items:
-        if item.stage not in STAGES:
+        # 内置环节必须精确命中；插件命名空间串（plugin:<pack>:<stage>）按形状放行，
+        # 即使对应插件此刻没加载——PUT 是整表覆盖，若插件卸载后就不认它的存量
+        # 路由行，管理员改任何一个环节都会 400，整张表从此存不进去（digest 的
+        # 事故换个马甲重演）。没人认领的插件路由行只是躺着不被用，无害。
+        if item.stage not in valid_stages and not is_plugin_stage(item.stage):
             raise InvalidRouteError(f"unknown stage: {item.stage}")
         if item.stage in seen:
             raise InvalidRouteError(f"duplicate stage: {item.stage}")

--- a/src/backend/tests/test_plugin_stages.py
+++ b/src/backend/tests/test_plugin_stages.py
@@ -1,0 +1,305 @@
+"""插件命名空间 LLM 环节（#736）：命名校验、注册缝、三级 resolve 链、
+路由表 PUT 放行、抽取 schema 自动注册与全链走通。"""
+
+import time
+import uuid
+
+import pytest
+
+from app.core.llm.router import (
+    _FALLBACK_ROUTE,
+    _LONG_CALL,
+    _MEDIUM_CALL,
+    _SHORT_CALL,
+    STAGES,
+    LLMRouter,
+    ResolvedRoute,
+    call_profile,
+    is_plugin_stage,
+    known_stages,
+    plugin_stage_spec,
+    register_plugin_stage,
+    unregister_plugin_stage,
+)
+
+
+@pytest.fixture
+def clean_registry():
+    """逐用例登记要清场的插件环节名——运行时注册表是进程级的，漏清会污染整个套件。"""
+    names: list[str] = []
+    yield names
+    for name in names:
+        unregister_plugin_stage(name)
+
+
+# ---- 1. 命名规则 ----
+
+
+def test_namespace_shape_is_three_segments_of_lowercase():
+    assert is_plugin_stage("plugin:pico-pack:extract-pico")
+    assert is_plugin_stage("plugin:a1:b2")
+    for bad in (
+        "plugin:pico",  # 少一段
+        "plugin:pico:extract:extra",  # 多一段
+        "plugin:PICO:extract",  # 大写
+        "plugin:pi_co:extract",  # 下划线
+        "plugin::extract",  # 空段
+        "extract_skeleton",  # 内置环节不算命名空间串
+        "pluginx:pico:extract",  # 前缀必须是 plugin:
+    ):
+        assert not is_plugin_stage(bad), bad
+
+
+def test_register_rejects_bad_segments_tier_and_fallback(clean_registry):
+    with pytest.raises(ValueError, match="invalid plugin stage name"):
+        register_plugin_stage("PICO", "extract")
+    with pytest.raises(ValueError, match="invalid plugin stage name"):
+        register_plugin_stage("pico", "ex_tract")
+    # 总长超 32：stage 列都是 String(32)，写进截断串比拒绝注册糟得多
+    with pytest.raises(ValueError, match="too long"):
+        register_plugin_stage("a-very-long-pack-name", "a-very-long-stage")
+    with pytest.raises(ValueError, match="unknown tier"):
+        register_plugin_stage("pico", "extract", tier="huge")
+    # fallback 只准指向内置环节：指向插件环节会形成回退链，行为取决于加载顺序
+    with pytest.raises(ValueError, match="built-in"):
+        register_plugin_stage("pico", "extract", fallback="plugin:other:stage")
+    with pytest.raises(ValueError, match="built-in"):
+        register_plugin_stage("pico", "extract", fallback="nope")
+
+
+# ---- 2. 注册缝 ----
+
+
+def test_register_adds_to_known_stages_and_is_idempotent(clean_registry):
+    name = register_plugin_stage("pico-pack", "extract-pico", fallback="extract_skeleton")
+    clean_registry.append(name)
+    assert name == "plugin:pico-pack:extract-pico"
+    assert name in known_stages()
+    assert set(STAGES) <= known_stages()
+    spec = plugin_stage_spec(name)
+    assert spec is not None and spec.tier == "medium" and spec.fallback == "extract_skeleton"
+
+    # 同名同配置幂等（schema 版本演进会重复挂同一环节）
+    assert register_plugin_stage("pico-pack", "extract-pico", fallback="extract_skeleton") == name
+    # 同名不同配置拒绝（两个插件抢名字 / 改档没改名，静默用先到的那份 = 配了没生效）
+    with pytest.raises(ValueError, match="different config"):
+        register_plugin_stage("pico-pack", "extract-pico", tier="long")
+
+    assert unregister_plugin_stage(name)
+    assert name not in known_stages()
+    assert not unregister_plugin_stage(name)  # 再删无事发生
+
+
+def test_call_profile_follows_the_declared_tier(clean_registry):
+    for tier, profile in (("short", _SHORT_CALL), ("medium", _MEDIUM_CALL), ("long", _LONG_CALL)):
+        name = register_plugin_stage("tier-pack", f"s-{tier}", tier=tier)
+        clean_registry.append(name)
+        assert call_profile(name) == profile
+    # 内置环节的档位不受注册表影响
+    assert call_profile("relevance") == _SHORT_CALL
+    assert call_profile("extract_skeleton") == _MEDIUM_CALL
+
+
+# ---- 3. resolve 三级链：精确 → fallback 环节路由 → default ----
+
+
+def _route(model: str) -> ResolvedRoute:
+    return ResolvedRoute(
+        provider_kind="fake",
+        base_url=None,
+        api_key="",
+        model=model,
+        temperature=0.0,
+        provider_name="fake",
+    )
+
+
+def _router_with(routes: dict[str, ResolvedRoute]) -> LLMRouter:
+    """路由表直接塞缓存（本测试测的是选路逻辑，不是 DB 加载）。"""
+    router = LLMRouter()
+    router._routes = routes
+    router._routes_loaded_at = time.monotonic()
+    return router
+
+
+async def test_resolve_prefers_the_exact_namespaced_route(clean_registry):
+    name = register_plugin_stage("pico-pack", "extract-pico", fallback="extract_skeleton")
+    clean_registry.append(name)
+    router = _router_with(
+        {
+            "default": _route("m-default"),
+            "extract_skeleton": _route("m-skeleton"),
+            name: _route("m-exact"),
+        }
+    )
+    _, route = await router.resolve(name)
+    assert route.model == "m-exact"
+
+
+async def test_resolve_falls_back_to_the_declared_builtin_stage(clean_registry):
+    name = register_plugin_stage("pico-pack", "extract-pico", fallback="extract_skeleton")
+    clean_registry.append(name)
+    router = _router_with(
+        {"default": _route("m-default"), "extract_skeleton": _route("m-skeleton")}
+    )
+    _, route = await router.resolve(name)
+    assert route.model == "m-skeleton"
+
+
+async def test_resolve_falls_back_to_default_last(clean_registry):
+    name = register_plugin_stage("pico-pack", "extract-pico", fallback="extract_skeleton")
+    clean_registry.append(name)
+    router = _router_with({"default": _route("m-default")})
+    _, route = await router.resolve(name)
+    assert route.model == "m-default"
+
+    # 没声明 fallback 的插件环节：跳过第二级，直接 default
+    bare = register_plugin_stage("pico-pack", "no-fallback")
+    clean_registry.append(bare)
+    _, route = await router.resolve(bare)
+    assert route.model == "m-default"
+
+
+async def test_resolve_empty_table_uses_the_fake_fallback(clean_registry):
+    """连 default 都没有：与内置环节同规则（测试套件开着 llm_fake_fallback）。"""
+    name = register_plugin_stage("pico-pack", "extract-pico", fallback="extract_skeleton")
+    clean_registry.append(name)
+    router = _router_with({})
+    _, route = await router.resolve(name)
+    assert route == _FALLBACK_ROUTE
+
+
+# ---- 4. 路由表 PUT：命名空间串放行 ----
+
+
+async def test_routes_put_accepts_namespaced_stages(client, clean_registry):
+    from tests.test_admin_llm import _admin_and_member
+
+    admin, _ = await _admin_and_member(client)
+    resp = await client.post(
+        "/api/admin/llm/providers", json={"name": "fake", "kind": "fake"}, headers=admin
+    )
+    provider_id = resp.json()["id"]
+
+    registered = register_plugin_stage("pico-pack", "extract-pico", fallback="extract_skeleton")
+    clean_registry.append(registered)
+    routes = [
+        {"stage": "default", "provider_id": provider_id, "model": "fake-cheap"},
+        {"stage": registered, "provider_id": provider_id, "model": "fake-pico"},
+        # 未注册但形状合法的串也放行：插件卸载后的存量路由行不能把整表变成存不进去
+        {"stage": "plugin:gone-pack:old-stage", "provider_id": provider_id, "model": "fake-old"},
+    ]
+    resp = await client.put("/api/admin/llm/routes", json=routes, headers=admin)
+    assert resp.status_code == 200, resp.text
+    assert {r["stage"] for r in resp.json()} == {
+        "default",
+        registered,
+        "plugin:gone-pack:old-stage",
+    }
+
+    # 形状不合法的串照旧 400（整表拒绝）
+    for bad in ("plugin:PICO:extract", "plugin:pico", "nope"):
+        resp = await client.put(
+            "/api/admin/llm/routes",
+            json=[{"stage": bad, "provider_id": provider_id, "model": "m"}],
+            headers=admin,
+        )
+        assert resp.status_code == 400, bad
+
+
+# ---- 5. 抽取 schema：命名空间 stage 自动注册 + 全链走通 ----
+
+
+PICO_PROMPT = (
+    "POLARIS_EXTRACT_PICO_DEMO\n"
+    "你是临床论文 PICO 抽取器。根据给定论文的标题与正文抽取：\n"
+    "{fields_spec}\n"
+    '只输出一个 JSON 对象，键为上述字段名，另加 "confidence"（0 到 1）。'
+)
+
+
+def _pico_schema():
+    from app.services.extraction.schemas import EntryKey, ExtractionSchema, SchemaField
+
+    return ExtractionSchema(
+        id="pico-demo",
+        version=1,
+        stage="plugin:pico-pack:extract-pico",
+        fields=(
+            SchemaField("population", "text", max_len=200),
+            SchemaField("outcomes", "list", max_len=120, max_items=4),
+            SchemaField(
+                "comparisons",
+                "entries",
+                max_len=0,
+                max_items=4,
+                entry_keys=(
+                    EntryKey("kind", max_len=32, choices=("drug", "placebo")),
+                    EntryKey("statement", max_len=200),
+                ),
+            ),
+        ),
+        prompt_template=PICO_PROMPT,
+    )
+
+
+def test_register_schema_auto_registers_the_namespaced_stage(clean_registry):
+    from app.services.extraction import schemas as schemas_mod
+
+    schema = _pico_schema()
+    clean_registry.append(schema.stage)
+    try:
+        schemas_mod.register_schema(schema)
+        spec = plugin_stage_spec(schema.stage)
+        assert spec is not None
+        # 学科 schema 与内置抽取同负载形态（整篇正文进、短 JSON 出）：中档 + 骨架回退
+        assert spec.tier == "medium" and spec.fallback == "extract_skeleton"
+        # 覆盖注册（版本演进）不炸：自动注册是幂等的
+        schemas_mod.register_schema(schema)
+    finally:
+        schemas_mod._REGISTRY.pop(schema.id, None)
+
+
+async def test_discipline_schema_extracts_end_to_end(client, tmp_path, clean_registry):
+    """学科包只写一个 schema 就走通全链：注册 → resolve（fake 兜底）→ 抽取落库。
+
+    fake provider 对不认识的抽取 marker 走通用兜底（按字段清单反推合法 JSON），
+    所以无 key 演示/测试里学科 schema 与内置 schema 同样能跑。
+    """
+    from app.core.db import get_sessionmaker
+    from app.services.extraction import schemas as schemas_mod
+    from app.services.extraction.runtime import extract_paper
+    from tests.conftest import add_paper, make_project_with_library, register_and_login
+    from tests.test_paper_extraction import _write_fulltext
+
+    schema = _pico_schema()
+    clean_registry.append(schema.stage)
+    try:
+        schemas_mod.register_schema(schema)
+
+        token = await register_and_login(client, email="pico@example.com")
+        headers = {"Authorization": f"Bearer {token}"}
+        project_id, _ = await make_project_with_library(client, headers, name="pico-proj")
+        async with get_sessionmaker()() as session:
+            paper = await add_paper(
+                session,
+                project_id=uuid.UUID(project_id),
+                title="PICO Discipline Probe",
+                abstract="A probe.",
+                full_text_path=_write_fulltext(tmp_path),
+            )
+            await session.commit()
+            outcome = await extract_paper(session, paper, schema_id="pico-demo")
+            assert outcome.status == "extracted", outcome.reason
+            row = outcome.row
+            assert row.schema_id == "pico-demo"
+            # 记账/产物上的 stage 是完整命名空间串
+            assert row.stage_meta["stage"] == "plugin:pico-pack:extract-pico"
+            # text 字段回显标题：断言 prompt 里带对了论文
+            assert "PICO Discipline Probe" in row.payload["population"]
+            assert row.payload["outcomes"]
+            # entries 的枚举键取了合法取值，整条过了归一化
+            assert row.payload["comparisons"][0]["kind"] == "drug"
+            assert row.confidence == 0.7
+    finally:
+        schemas_mod._REGISTRY.pop(schema.id, None)

--- a/src/frontend/src/features/settings/SettingsPage.tsx
+++ b/src/frontend/src/features/settings/SettingsPage.tsx
@@ -15,12 +15,13 @@ import { SysinfoPanel } from '../../components/ui/SysinfoPanel';
 import { McpToolsContent } from '../mcp/McpToolsPage';
 import { AcademicIdentitySection } from './AcademicIdentitySection';
 import { tr } from '../../lib/i18n';
-import { STAGE_LABELS } from '../../lib/stageLabels';
+import { stageLabel } from '../../lib/stageLabels';
 import { setTaskLogHistory, useTaskLogHistory } from '../../lib/prefs';
 import {
   ApiError,
   LLM_STAGES,
   api,
+  isPluginStage,
   type AffiliationMode,
   type ChatBotPlatform,
   type DailySyncScope,
@@ -1458,7 +1459,8 @@ function RoutesSection() {
   const saveMutation = useMutation({
     mutationFn: () => {
       const routes: LlmRoute[] = [];
-      for (const stage of LLM_STAGES) {
+      // PUT 是整表覆盖：插件环节的行也要一并提交，否则每次保存都会把它们静默删光
+      for (const stage of [...LLM_STAGES, ...pluginStages]) {
         const r = rows[stage];
         if (!r || !r.provider_id || !r.model.trim()) continue;
         const t = r.temperature.trim();
@@ -1478,6 +1480,17 @@ function RoutesSection() {
     },
     onError: (err) => toast(`${tr('保存失败', 'Save failed')}：${err instanceof Error ? err.message : String(err)}`, 'error'),
   });
+
+  // 插件命名空间环节（#736）：不在内置清单里，路由表里有记录才显示一行。
+  // 从 rows 派生而不是另存状态：清掉行（clearRow）它就消失，保存后路由随之删除，
+  // 该环节回到插件注册时声明的回退链（fallback 环节 → 默认）。
+  const pluginStages = useMemo(
+    () =>
+      Object.keys(rows)
+        .filter((s) => !(LLM_STAGES as readonly string[]).includes(s) && isPluginStage(s))
+        .sort(),
+    [rows],
+  );
 
   const defaultRow = rows['default'];
   const emptyDraftRow: RouteDraft = { provider_id: '', model: '', temperature: '', effort: '' };
@@ -1520,11 +1533,13 @@ function RoutesSection() {
     }
   };
 
-  // 常驻行固定在顶部；展开区只包含其余环节（embedding/rerank 不重复出现）。
-  const visibleStages: string[] =
-    showAll ? [...PRIMARY_STAGES, ...LLM_STAGES.filter((s) => !PRIMARY_STAGES.includes(s))] : PRIMARY_STAGES;
-  // 收起态下有显式设置的隐藏行数（提示用）
-  const hiddenExplicitCount = LLM_STAGES.filter((s) => !PRIMARY_STAGES.includes(s) && rows[s]).length;
+  // 常驻行固定在顶部；展开区包含其余内置环节 + 有路由记录的插件环节。
+  const visibleStages: string[] = showAll
+    ? [...PRIMARY_STAGES, ...LLM_STAGES.filter((s) => !PRIMARY_STAGES.includes(s)), ...pluginStages]
+    : PRIMARY_STAGES;
+  // 收起态下有显式设置的隐藏行数（提示用）；插件行必然是显式设置，全算上
+  const hiddenExplicitCount =
+    LLM_STAGES.filter((s) => !PRIMARY_STAGES.includes(s) && rows[s]).length + pluginStages.length;
 
   return (
     <div className="card card-pad">
@@ -1580,7 +1595,8 @@ function RoutesSection() {
               const unset = capability && !explicit; // 能力型环节未设置：不跟随默认，运行时降级
               // 展示值：显式行用自己的；跟随默认的行弱化展示 default 的 provider/模型
               const shown = rows[stage] ?? (follows ? defaultRow : undefined) ?? emptyDraftRow;
-              const label = STAGE_LABELS[stage];
+              const plugin = isPluginStage(stage);
+              const label = stageLabel(stage);
               const eff = effectiveOf(stage);
               const state: TestState = eff
                 ? tests.results[testKeyOf(eff.provider_id, eff.model.trim(), capabilityOf(stage))] ?? { status: 'idle' }
@@ -1590,7 +1606,16 @@ function RoutesSection() {
                 <tr key={stage}>
                   <td>
                     <div className="row gap6" style={{ alignItems: 'center' }}>
-                      <span style={{ fontSize: 12, fontWeight: 650 }}>{label ? tr(label.zh, label.en) : stage}</span>
+                      <span style={{ fontSize: 12, fontWeight: 650, ...(plugin ? { fontFamily: 'var(--mono, monospace)' } : {}) }}>{tr(label.zh, label.en)}</span>
+                      {plugin && (
+                        <span
+                          className="pill sm"
+                          style={{ background: 'var(--surface-3)', color: 'var(--text-3)' }}
+                          title={tr('插件注册的环节；清除这一行后按插件声明的回退环节调用', 'Registered by a plugin; clearing this row falls back to the stage it declared')}
+                        >
+                          {tr('插件', 'Plugin')}
+                        </span>
+                      )}
                       {follows && (
                         <span className="pill sm" style={{ background: 'var(--surface-3)', color: 'var(--text-3)' }}>
                           {tr('跟随默认', 'Follows default')}
@@ -1611,14 +1636,19 @@ function RoutesSection() {
                           style={{ width: 20, height: 20 }}
                           title={capability
                             ? tr('清除设置，恢复未设置', 'Clear — back to "Not set"')
-                            : tr('清除单独设置，恢复跟随默认', 'Clear this override and follow default again')}
+                            : plugin
+                              ? tr('清除这一行，按插件声明的回退环节调用', 'Clear this row and fall back to the stage the plugin declared')
+                              : tr('清除单独设置，恢复跟随默认', 'Clear this override and follow default again')}
                           onClick={() => clearRow(stage)}
                         >
                           <Icon name="x" size={11} />
                         </button>
                       )}
                     </div>
-                    <div className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)' }}>{stage}</div>
+                    {/* 插件行的标题就是原串本身，下面再排一遍纯属重复 */}
+                    {!plugin && (
+                      <div className="mono" style={{ fontSize: 10.5, color: 'var(--text-3)' }}>{stage}</div>
+                    )}
                   </td>
                   <td>
                     <SelectMenu

--- a/src/frontend/src/lib/__tests__/stageRegistry.test.ts
+++ b/src/frontend/src/lib/__tests__/stageRegistry.test.ts
@@ -2,8 +2,8 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
-import { LLM_STAGES } from '../api';
-import { STAGE_LABELS } from '../stageLabels';
+import { LLM_STAGES, PLUGIN_STAGE_RE, isPluginStage } from '../api';
+import { STAGE_LABELS, stageLabel } from '../stageLabels';
 
 /* ============================================================
    前端的 stage 清单必须和后端 router.py 的 STAGES 逐项一致。
@@ -20,6 +20,11 @@ import { STAGE_LABELS } from '../stageLabels';
 
    后端没有跑测试的 CI 工作流，前端有；而 vitest 跑在 node 里读得到后端源码。
    所以这条守卫放在这边。
+
+   插件命名空间环节（#736）是这条铁律的唯一豁免：plugin:<pack>:<stage> 由插件
+   运行时注册，天然不进两边的静态清单——守卫改为「内置精确对齐 + 命名空间
+   正则两边一致」。正则也要对账：前端拿它决定哪些串按插件行渲染/随保存提交，
+   后端拿它决定路由表 PUT 放不放行，两边漂了就是「界面画得出、保存 400」重演。
    ============================================================ */
 
 const routerSource = readFileSync(
@@ -34,18 +39,62 @@ const backendStages = (() => {
   return [...body.matchAll(/"([a-z_]+)"/g)].map((m) => m[1]!);
 })();
 
+/** 从 router.py 里抠出 PLUGIN_STAGE_RE 的正则字面量。 */
+const backendPluginRe = (() => {
+  const m = /^PLUGIN_STAGE_RE = re\.compile\(r"([^"]+)"\)/m.exec(routerSource);
+  if (!m) throw new Error('router.py 里找不到 PLUGIN_STAGE_RE——改了形状就同步改这里');
+  return m[1]!;
+})();
+
 describe('LLM stage 清单', () => {
   it('后端确实被解析到了（守卫本身不能空跑）', () => {
     expect(backendStages.length).toBeGreaterThan(10);
     expect(backendStages).toContain('default');
   });
 
-  it('前后端逐项一致', () => {
+  it('内置清单前后端逐项一致', () => {
     expect([...LLM_STAGES].sort()).toEqual([...backendStages].sort());
   });
 
-  it('每个环节都有大白话名字', () => {
+  it('每个内置环节都有大白话名字', () => {
     const missing = LLM_STAGES.filter((stage) => !STAGE_LABELS[stage]);
     expect(missing).toEqual([]);
+  });
+
+  it('内置清单里不许混入命名空间串（插件环节走运行时注册，不进静态清单）', () => {
+    expect(LLM_STAGES.filter((s) => isPluginStage(s))).toEqual([]);
+    expect(backendStages.filter((s) => s.startsWith('plugin:'))).toEqual([]);
+  });
+});
+
+describe('插件命名空间环节（#736）', () => {
+  it('命名正则与后端一字不差', () => {
+    // 后端正则带捕获组、前端不带——归一化掉括号再比（两边语义都是整串校验）
+    const normalize = (src: string) => src.replace(/[()]/g, '');
+    expect(normalize(PLUGIN_STAGE_RE.source)).toEqual(normalize(backendPluginRe));
+  });
+
+  it('三段式、段字符集限 [a-z0-9-]', () => {
+    expect(isPluginStage('plugin:pico-pack:extract-pico')).toBe(true);
+    expect(isPluginStage('plugin:a1:b2')).toBe(true);
+    for (const bad of [
+      'plugin:pico', // 少一段
+      'plugin:pico:extract:extra', // 多一段
+      'plugin:PICO:extract', // 大写
+      'plugin:pi_co:extract', // 下划线
+      'plugin::extract', // 空段
+      'extract_skeleton', // 内置环节不算
+      'pluginx:pico:extract', // 前缀必须是 plugin:
+    ]) {
+      expect(isPluginStage(bad), bad).toBe(false);
+    }
+  });
+
+  it('stageLabel 对插件串照排原串（badge 由渲染处补）', () => {
+    expect(stageLabel('plugin:pico-pack:extract-pico')).toEqual({
+      zh: 'plugin:pico-pack:extract-pico',
+      en: 'plugin:pico-pack:extract-pico',
+    });
+    expect(stageLabel('default')).toEqual(STAGE_LABELS['default']);
   });
 });

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -700,6 +700,19 @@ export const LLM_STAGES = [
   'hyp_compare',
 ] as const;
 
+/**
+ * 插件命名空间环节（#736）：`plugin:<pack>:<stage>` 三段式，段字符集限 [a-z0-9-]。
+ * 与后端 `app/core/llm/router.py` 的 PLUGIN_STAGE_RE 对齐（vitest 守卫盯着两边）。
+ * 这类环节不进 LLM_STAGES（那是内置清单，与后端 STAGES 逐项对齐）；它们由插件
+ * 在运行时注册，路由表里有记录才会出现在界面上。
+ */
+export const PLUGIN_STAGE_RE = /^plugin:[a-z0-9-]+:[a-z0-9-]+$/;
+
+/** stage 名是否为插件命名空间串（只看形状，不管对应插件是否加载）。 */
+export function isPluginStage(stage: string): boolean {
+  return PLUGIN_STAGE_RE.test(stage);
+}
+
 export interface LlmProviderRead {
   id: string;
   name: string;

--- a/src/frontend/src/lib/stageLabels.ts
+++ b/src/frontend/src/lib/stageLabels.ts
@@ -3,6 +3,9 @@
  * 一一对应（同一份 stage 标识符在设置页配路由、看用量分布）。
  *
  * 模块级常量只存 zh/en，渲染处再 tr()（见前端单语 + 中英切换约定）。
+ * 插件命名空间环节（plugin:<pack>:<stage>，#736）不在这张表里——它们由插件
+ * 运行时注册，前端不可能为每个插件备一份名字；渲染处统一走 stageLabel()，
+ * 拿到原串照排，旁边配「插件」badge 说明来路。
  */
 export const STAGE_LABELS: Record<string, { zh: string; en: string }> = {
   default: { zh: '默认', en: 'Default' },
@@ -41,3 +44,11 @@ export const STAGE_LABELS: Record<string, { zh: string; en: string }> = {
   hyp_feasibility: { zh: '假设·可行性论证', en: 'Hypothesis · feasibility' },
   hyp_compare: { zh: '假设·两两对比', en: 'Hypothesis · pairwise compare' },
 };
+
+/**
+ * 任意 stage 的展示名：内置环节用大白话名字；插件环节与未知环节照排原串
+ * （插件环节的「插件」badge 由渲染处按 isPluginStage 另行补上）。
+ */
+export function stageLabel(stage: string): { zh: string; en: string } {
+  return STAGE_LABELS[stage] ?? { zh: stage, en: stage };
+}


### PR DESCRIPTION
Closes #736. Part of #715 (audit item 17 / design report §19 — the 38-entry hardcoded STAGES tuple was the wall discipline packs would hit; the extraction registry already documented bumping into it).

- stage names accept `plugin:<pack>:<stage>` (charset-restricted, ≤32 chars to respect the three String(32) stage columns); the built-in tuple is untouched
- `register_plugin_stage(pack, stage, tier, fallback)`: idempotent on identical config (schema version evolution re-registers), rejected on conflicting config (two plugins can't fight over a name); fallback must be a built-in stage so the resolution chain never depends on plugin load order
- three-tier resolution: exact route → the declared built-in fallback's route → the default tier (same 503/fake rules as built-ins); call patience always follows the registered tier. The contrast with the digest-inherits-librarian lesson is documented: a plugin stage's fallback is an explicit, inspectable declaration, not a row that lies
- extraction schemas may declare namespaced stages and auto-register on `register_schema`; the fake provider gains a generic `POLARIS_EXTRACT_` responder that derives valid JSON from the field spec, so discipline schemas work keyless end to end (a PICO demo test proves it)
- route-table PUT deliberately admits well-formed but unregistered namespaced names — a full-replace endpoint that rejects rows for an uninstalled plugin would make the whole table unsaveable (the digest-outage shape); malformed names still 400
- frontend: parity guard learns the rule (built-ins exact, namespaced exempt, static lists must stay pure, the regex is cross-checked character-for-character against the backend source); namespaced stages render as mono text with a plugin badge when they have routes; and a real bug fixed — the save loop only iterated built-ins and would have silently deleted every plugin route on save

Verification: full suite 1742/1742 (two known load flakes green in isolation); two zero-conflict rebases (#738, #739) with targeted re-runs (67 backend + vitest 184 + build); new test file covers naming, registration semantics, all three resolution tiers, PUT admission, and the end-to-end discipline demo.