### PR TITLE
chore: schema hygiene, ghost-field retirement, and a golden re-record policy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BACKEND_PY   = src/backend/.venv/bin/python
 BACKEND_PIP  = src/backend/.venv/bin/pip
 
 .PHONY: dev up down logs backend-dev frontend-dev venv migrate test lint build texbase \
-        desktop-deps desktop-dev desktop-shell desktop-dist
+        desktop-deps desktop-dev desktop-shell desktop-dist golden-record
 
 ## ---- Docker ----
 texbase:        ## Build the shared TeX base image (api/worker FROM it; cached unless Dockerfile.texbase changed)
@@ -66,6 +66,16 @@ lint:
 	cd src/backend && .venv/bin/ruff check app worker tests
 	cd src/frontend && npx tsc --noEmit
 	cd src/desktop && npx tsc --noEmit
+
+golden-record:  ## Re-record golden transcripts (intentional wire changes only — read docs/golden-policy.md first)
+	# 一次性容器内录制（与 CI 同一套件形状；宿主机不需要 venv）。挂载可写：
+	# 录制直接改写 src/backend/tests/golden/data/ 下的文件，之后人工审查 diff。
+	docker run --rm \
+	  -v "$(CURDIR)/src/backend:/srv/backend" -w /srv/backend \
+	  -e POLARIS_GOLDEN=record \
+	  polaris-api:latest \
+	  sh -c "pip install -q -e '.[dev]' && python -m pytest tests/golden -q -p no:cacheprovider"
+	git diff --stat -- src/backend/tests/golden/data
 
 build: texbase  ## Build production images
 	$(COMPOSE) build

--- a/docs/development.md
+++ b/docs/development.md
@@ -66,6 +66,12 @@ make lint      # ruff check (backend) + tsc --noEmit (frontend and desktop)
 make build     # build production images
 ```
 
+Two backend test suites deserve a special mention: the **golden transcripts** under
+`src/backend/tests/golden/` replay two end-to-end chains and compare the responses byte for byte.
+If one fails on your branch, read [the golden policy](golden-policy.md) before touching anything —
+re-recording (`make golden-record`) is only legitimate for an intentional, human-reviewed wire
+change.
+
 ## Layering convention
 
 The backend follows one strict rule, and reviews enforce it:

--- a/docs/golden-policy.md
+++ b/docs/golden-policy.md
@@ -1,0 +1,72 @@
+# Golden transcript policy
+
+Polaris keeps two **golden transcripts** under `src/backend/tests/golden/data/`:
+
+- `import_wiki.json` — register → create library → create project → bibtex import →
+  wiki compile → index status (`tests/golden/test_golden_import_wiki.py`)
+- `discovery_run.json` — the full hypothesis-discovery chain: papers → library index →
+  discovery voyage → tree + disclosure artifacts (`tests/golden/test_golden_discovery.py`)
+
+Each test replays its chain deterministically (fake LLM provider + SQLite, zero network)
+and compares the normalized API responses **byte for byte** against the stored file.
+
+## Why so strict
+
+The goldens are a *behavior* gate, not a coverage gate. They pin the externally
+observable wire shape of two end-to-end chains, so that refactors, removals and
+"pure cleanup" PRs cannot silently change what the API says. A failing golden always
+means one of two things:
+
+1. **An accident** — you changed behavior you did not mean to change. Fix the code,
+   not the golden.
+2. **An intentional wire change** — then the golden must be re-recorded *in the same PR*,
+   with the diff reviewed by a human and explained in the PR description.
+
+The one thing that is never acceptable is re-recording to "make CI green" without
+reading the diff. A golden diff you cannot explain line by line is an accident by
+definition.
+
+## When a re-record is legitimate
+
+- The PR intentionally changes a response shape (adds/removes/renames a field on a
+  route the chains touch), and the golden diff contains **exactly** those keys and
+  nothing else.
+- The PR intentionally changes deterministic behavior the chains exercise (e.g. a
+  different plan template, a new pipeline step) and the diff matches the described
+  change.
+
+Not legitimate:
+
+- Re-recording inside a PR that claims to be a pure removal/refactor ("no behavior
+  change"). If the golden moved, the claim is false — investigate first.
+- Diffs containing timestamps, ids or ordering churn: that is a normalization bug in
+  `tests/golden/normalize.py`, not a behavior change. Fix the normalizer.
+
+## How to re-record
+
+From the repo root (runs in a one-shot container, same image as `polaris-api`):
+
+```sh
+make golden-record
+```
+
+This runs the golden tests with `POLARIS_GOLDEN=record`, which rewrites the files in
+`src/backend/tests/golden/data/` in place. Then:
+
+1. `git diff src/backend/tests/golden/data/` — read every hunk. Every changed key must
+   map to a change you intended and can name.
+2. Run the golden tests again *without* the flag (`pytest tests/golden -q`) — they must
+   pass twice in a row, proving the recording is stable, not flaky.
+3. Commit the golden files **together with** the code change, and paste a short diff
+   summary (which keys appeared/disappeared and why) into the PR description.
+
+CI only ever compares; it never records. The discipline is the reviewed diff.
+
+## Retiring compatibility-only fields
+
+Historically, dead fields were kept at constant values ("wire-shape compatibility")
+precisely because there was no documented re-record procedure — the goldens
+structurally kept ghost code alive (#715 item 14). That reason is gone: when a field
+is dead, remove it and re-record under the rules above (#734 did this for
+`UserRead.llm_self_managed` and `DirectionLibrarySummary.status/review_note`).
+A golden must pin behavior, not embalm it.

--- a/docs/task-system.md
+++ b/docs/task-system.md
@@ -141,7 +141,7 @@ answer) rather than declaring failure.
 | `paper_review` | pipeline | topic | `paper_review_plan()` (6 steps) | `POST /manuscripts/{id}/review` |
 | `presentation` | pipeline | topic | `presentation_plan()` (4 steps) | `POST /projects/{id}/presentations` |
 | `custom` | loop | topic | the workflow skill's own steps, written into `run.plan` at creation | `POST /skills/{id}/run` |
-| `demo` | loop | topic | `demo_plan()` (3 steps, one behind a `compute_budget` approval) | `POST /voyages` |
+| `demo` | loop | topic | `demo_plan()` (3 steps; pass `params.confirm_budget: true` to put the second behind a `compute_budget` approval — the same opt-in as experiments) | `POST /voyages` |
 
 Two things worth knowing:
 
@@ -503,19 +503,14 @@ optional embedding.
 3. If nothing has been completed at all, there is nothing honest to wrap up: the run goes to
    `paused_error`.
 
-**Library monthly budgets** fold into the same mechanism instead of adding a second one
-(`apply_library_budget` in `app/services/ingest.py`). When an ingest run is created:
-
-- `derive_budget(knobs)` gives a starting figure — `max_papers × 20 000` tokens, or `None` for
-  unlimited;
-- `monthly_library_usage()` sums this calendar month's (UTC) `llm_usage` rows for this `library_id`;
-- if `monthly_budget - used <= 0`, creation is refused with `LibraryBudgetExhaustedError`, which the
-  API returns as `409 LIBRARY_BUDGET_EXHAUSTED` — the run is never created;
-- otherwise `max_tokens` is tightened to `min(derived, remaining)`.
-
-So a library budget behaves as: refuse to start when it is already spent, and otherwise cap this run
-so it cannot overshoot the month. Once running, it is just an ordinary token budget and hits the
-wrap-up path above. The cap resets on the first of the month.
+**Ingest runs default to an unlimited budget** (#734). `derive_budget(knobs)` returns
+`{"max_tokens": None}` unless the caller explicitly opts into a finite budget via
+`knobs.max_tokens` — the old implicit `max_papers × 20 000` derivation silently paused large
+libraries halfway and is gone. The library's `monthly_budget` is **display-only** now: the usage
+panel (`GET /libraries/{id}/budget`) still aggregates this calendar month's (UTC) `llm_usage`
+rows via `monthly_library_usage()` and flags `exhausted` when usage passes the reference cap,
+but nothing is refused or tightened anymore — no run is ever blocked by it. An explicitly
+opted-in token budget is an ordinary run budget and hits the wrap-up path above.
 
 ### 4.6 Progress, events and logs
 
@@ -605,7 +600,7 @@ Library incremental sync (`daily_wiki_ingest`) is **not** on the cron anymore: i
 the daily feed run's final `daily.sync_libraries` step, once the pool is actually refreshed —
 scheduling it at a fixed later hour meant betting the fetch had finished, and losing that bet
 synced every library against a stale pool. It runs at most once per day, and each library is
-wrapped in its own exception handler so one library's exhausted monthly budget cannot stop the
+wrapped in its own exception handler so one library failing to start cannot stop the
 libraries queued after it.
 
 Two more operational details:
@@ -632,8 +627,8 @@ refreshed. `create_ingest_voyage()`:
 1. refuses with `IngestConflictError` → `409 INGEST_ALREADY_RUNNING` if a non-terminal
    `wiki_bootstrap`/`wiki_ingest` run already exists **for this library** (mutual exclusion is keyed
    on the library, not the topic, precisely because library runs do not carry a `project_id`);
-2. derives the token budget from the knobs and narrows it by the library's remaining monthly budget,
-   refusing outright if the month is spent;
+2. derives the token budget from the knobs (`None` — unlimited — unless the caller explicitly
+   passed `knobs.max_tokens`; the monthly budget is display-only and never blocks creation);
 3. writes a `VoyageRun` with `kind="wiki_ingest"`, `library_id` set, **`project_id` left null**, and
    `checkpoint["params"] = {mode, knobs}`;
 4. writes an `ingest.started` activity row against the library;
@@ -690,7 +685,7 @@ anything.
 | 2 | `daily.upsert` | Deduplicates into the content pool and creates/merges feed entries; records the touched paper ids in `checkpoint["daily_touched_papers"]` and drops `daily_entries`. |
 | 3 | `daily.cleanup` | Expires entries outside the rolling 7-day window and reclaims papers nobody collected. |
 | 4 | `daily.embed` | Only if the admin setting `daily_feed_embed_enabled` is on: builds paper-level vectors for the papers touched in step 2. Deliberately best-effort — a failure is reported as `embed_error`, *not* `error`, so it cannot fail the run. |
-| 5 | `daily.sync_libraries` | Enqueues the incremental `wiki_ingest` for each built library — the pool is refreshed, so the sync has something to sync. Skipped when the fetch brought in nothing new; at most once per day; one library's failure (e.g. an exhausted monthly budget) does not stop the rest. |
+| 5 | `daily.sync_libraries` | Enqueues the incremental `wiki_ingest` for each built library — the pool is refreshed, so the sync has something to sync. Skipped when the fetch brought in nothing new; at most once per day; one library's failure does not stop the rest. |
 
 Handing the fetched entries forward through the checkpoint rather than re-fetching in step 2 is not
 just an optimisation: re-querying arXiv could return a different result set, and step 2's dedup keys

--- a/src/backend/alembic/versions/351c324f4f6b_schema_hygiene_ghost_columns.py
+++ b/src/backend/alembic/versions/351c324f4f6b_schema_hygiene_ghost_columns.py
@@ -1,0 +1,100 @@
+"""列卫生（#734）：退役列删除 + 归属双列合一 + 自管轨存量行清理
+
+各表模型注释里挂了很久的「退役列（代码不再读写；删列待确认稳定后另做迁移）」
+在这里一次删掉——解读早已统一到 paper_wikis（a7d0c9e51b34，每篇论文一份），
+这些按库/按条目分身的快照列只剩「看起来还有一套并行解读存储」的误导：
+
+- library_papers.wiki_content / compiled_at / compiled_model
+- user_library_entries.wiki_content
+- daily_feed_entries.wiki_content / wiki_model
+- topic_papers.wiki_snapshot / snapshot_at
+
+归属双列合一：direction_libraries 自 P9b 起 submitted_by / created_by 两列并存、
+写入时恒等，读点全走 submitted_by。合并进 submitted_by（先回填 NULL 行）后删
+created_by；列名保留 submitted_by——30+ 读点与前端类型都在用，改名只有 churn。
+
+自管轨存量行清理（#621 收尾）：llm_providers / model_routes 里 owner_id 非 NULL
+的行是自管 LLM 轨时代的私有配置，入口早已拆除，运行时全靠 WHERE owner_id IS NULL
+过滤挡着（router / llm_admin）。存量行删除；WHERE 过滤保留为双保险。
+
+llm_usage.conversation_id 本次**不**删：从未有读点、写点也已不存在，列保留一期
+（防在途回滚），模型注释已标 deprecated，下一次列卫生迁移删除。
+
+downgrade：列按原形状加回（数据不可恢复，全落 NULL）；created_by 从 submitted_by
+回填（两列历史上写入恒等，无损）；被删的自管轨私有行不可恢复（本就无入口可用）。
+
+Revision ID: 351c324f4f6b
+Revises: b737c1a2d3e4
+Create Date: 2026-09-07
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "351c324f4f6b"
+# 与 #737（用户偏好搬家 b737c1a2d3e4）并行开发，出货时重挂到它后面成单链。
+down_revision: str | None = "b737c1a2d3e4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # 1) 归属双列合一：先把 created_by 有值而 submitted_by 空的行回填（防极老存量），
+    #    再删副本列。
+    op.execute(
+        "UPDATE direction_libraries SET submitted_by = created_by "
+        "WHERE submitted_by IS NULL AND created_by IS NOT NULL"
+    )
+    with op.batch_alter_table("direction_libraries") as batch:
+        batch.drop_column("created_by")
+
+    # 2) 退役快照列（sqlite 走 batch 重建表；pg 等价 DROP COLUMN）
+    with op.batch_alter_table("library_papers") as batch:
+        batch.drop_column("wiki_content")
+        batch.drop_column("compiled_at")
+        batch.drop_column("compiled_model")
+    with op.batch_alter_table("user_library_entries") as batch:
+        batch.drop_column("wiki_content")
+    with op.batch_alter_table("daily_feed_entries") as batch:
+        batch.drop_column("wiki_content")
+        batch.drop_column("wiki_model")
+    with op.batch_alter_table("topic_papers") as batch:
+        batch.drop_column("wiki_snapshot")
+        batch.drop_column("snapshot_at")
+
+    # 3) 自管轨存量行：先删路由（含挂在私有 provider 下的全局残路由，防悬挂 FK），
+    #    再删私有 provider。sqlite 不一定开启 FK 级联，显式两步。
+    op.execute(
+        "DELETE FROM model_routes WHERE owner_id IS NOT NULL OR provider_id IN "
+        "(SELECT id FROM llm_providers WHERE owner_id IS NOT NULL)"
+    )
+    op.execute("DELETE FROM llm_providers WHERE owner_id IS NOT NULL")
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("topic_papers") as batch:
+        batch.add_column(sa.Column("wiki_snapshot", sa.Text(), nullable=True))
+        batch.add_column(sa.Column("snapshot_at", sa.DateTime(timezone=True), nullable=True))
+    with op.batch_alter_table("daily_feed_entries") as batch:
+        batch.add_column(sa.Column("wiki_content", sa.Text(), nullable=True))
+        batch.add_column(sa.Column("wiki_model", sa.String(length=128), nullable=True))
+    with op.batch_alter_table("user_library_entries") as batch:
+        batch.add_column(sa.Column("wiki_content", sa.Text(), nullable=True))
+    with op.batch_alter_table("library_papers") as batch:
+        batch.add_column(sa.Column("wiki_content", sa.Text(), nullable=True))
+        batch.add_column(sa.Column("compiled_at", sa.DateTime(timezone=True), nullable=True))
+        batch.add_column(sa.Column("compiled_model", sa.String(length=255), nullable=True))
+    with op.batch_alter_table("direction_libraries") as batch:
+        batch.add_column(sa.Column("created_by", sa.Uuid(), nullable=True))
+        batch.create_foreign_key(
+            "fk_direction_libraries_created_by",
+            "users",
+            ["created_by"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+    # 两列写入历史上恒等：从 submitted_by 回填即无损还原
+    op.execute("UPDATE direction_libraries SET created_by = submitted_by")

--- a/src/backend/app/agents/voyage/navigator.py
+++ b/src/backend/app/agents/voyage/navigator.py
@@ -1,8 +1,9 @@
 """Navigator（领航 · planning）：把目标分解为步骤列表；执行失败时依据诊断重规划。
 
 - 输出严格 JSON（{"steps": [...]}），做 schema 校验，解析失败重试 2 次；
-- ``demo`` kind 用固定三步计划（不依赖 LLM 规划质量），第 2 步声明
-  ``requires_gate="compute_budget"`` 以演示人在环闸门。
+- ``demo`` kind 用固定三步计划（不依赖 LLM 规划质量）；显式传
+  ``params.confirm_budget=True`` 时第 2 步声明 ``requires_gate="compute_budget"``
+  以演示人在环闸门（与 experiment 同款 opt-in，#626/#734）。
 """
 
 import json
@@ -553,7 +554,14 @@ def discovery_plan(run: VoyageRun) -> list[dict[str, Any]]:
 
 
 def demo_plan(run: VoyageRun) -> list[dict[str, Any]]:
-    """demo 航程固定三步：分析目标 → 生成产物（过闸门）→ 总结。"""
+    """demo 航程固定三步：分析目标 → 生成产物 → 总结。
+
+    预算闸门默认不拦（#626 的漏网处，#734 补齐）：与 experiment_plan 同款，
+    创建时显式传 params.confirm_budget=True 才在「生成产物」前停下等审批；
+    机制（Gate 模型 + engine 断点）原样保留，闸门链路的测试靠 opt-in 演示。
+    """
+    checkpoint = (run.checkpoint if run is not None else None) or {}
+    confirm_budget = bool((checkpoint.get("params") or {}).get("confirm_budget"))
     return [
         {
             "title": "分析目标",
@@ -573,7 +581,7 @@ def demo_plan(run: VoyageRun) -> list[dict[str, Any]]:
                 "content": "# Demo 任务产物\n\n目标：{goal}\n\n（由演示任务生成）\n",
             },
             "acceptance": "产物已写入 checkpoint",
-            "requires_gate": "compute_budget",
+            "requires_gate": "compute_budget" if confirm_budget else None,
         },
         {
             "title": "总结",

--- a/src/backend/app/api/ingest.py
+++ b/src/backend/app/api/ingest.py
@@ -48,9 +48,6 @@ async def start_ingest(
         )
     except ingest_service.IngestConflictError as e:
         raise HTTPException(status.HTTP_409_CONFLICT, detail="INGEST_ALREADY_RUNNING") from e
-    except ingest_service.LibraryBudgetExhaustedError as e:
-        # 本月预算已用尽：拒绝启动（下月自动恢复，或管理员调高预算）
-        raise HTTPException(status.HTTP_409_CONFLICT, detail="LIBRARY_BUDGET_EXHAUSTED") from e
     await queue.enqueue("run_voyage", str(run.id))
     return VoyageRead.model_validate(run)
 

--- a/src/backend/app/api/libraries.py
+++ b/src/backend/app/api/libraries.py
@@ -295,8 +295,6 @@ async def generate_library_digest(
         )
     except ingest_service.IngestConflictError as e:
         raise HTTPException(status.HTTP_409_CONFLICT, detail="INGEST_ALREADY_RUNNING") from e
-    except ingest_service.LibraryBudgetExhaustedError as e:
-        raise HTTPException(status.HTTP_409_CONFLICT, detail="LIBRARY_BUDGET_EXHAUSTED") from e
     await queue.enqueue("run_voyage", str(run.id))
     return DigestGenerateRead(
         voyage_id=run.id,
@@ -370,7 +368,11 @@ async def get_library_budget(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> LibraryBudgetRead:
-    """本月预算消耗（可管理者）：库侧 LLM 调用（打分/编译/概念定义/向量化）的聚合。"""
+    """本月用量（可管理者）：库侧 LLM 调用（打分/编译/概念定义/向量化）的聚合。
+
+    #734 起纯展示：monthly_budget 只是参考上限，exhausted 也只是「用量超过了
+    参考上限」的提示——不再有任何任务因此被拒绝或暂停。
+    """
     library = await _get_managed_library(session, library_id, user)
     usage = await ingest_service.monthly_library_usage(session, library.id)
     budget = library.monthly_budget
@@ -401,7 +403,7 @@ async def start_library_ingest(
     """对某个方向库直接触发抓取（P9a）：可管理者（创建者 ∪ 无主库）皆可。
 
     独立建的库（project_id 为空）由此入口驱动 ingest；起源课题的隐式库同时
-    带上 project 以兼容活动流/鉴权。互斥以库为准，超预算 409 拒绝。
+    带上 project 以兼容活动流/鉴权。互斥以库为准。
     """
     library = await _get_managed_library(session, library_id, user)
     project = (
@@ -420,8 +422,6 @@ async def start_library_ingest(
         )
     except ingest_service.IngestConflictError as e:
         raise HTTPException(status.HTTP_409_CONFLICT, detail="INGEST_ALREADY_RUNNING") from e
-    except ingest_service.LibraryBudgetExhaustedError as e:
-        raise HTTPException(status.HTTP_409_CONFLICT, detail="LIBRARY_BUDGET_EXHAUSTED") from e
     await queue.enqueue("run_voyage", str(run.id))
     return VoyageRead.model_validate(run)
 

--- a/src/backend/app/models/daily_feed.py
+++ b/src/backend/app/models/daily_feed.py
@@ -11,7 +11,7 @@ import datetime as dt
 import uuid
 from typing import Any
 
-from sqlalchemy import Date, ForeignKey, String, Text, UniqueConstraint
+from sqlalchemy import Date, ForeignKey, String, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.db import Base
@@ -44,10 +44,6 @@ class DailyFeedEntry(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     categories: Mapped[Any] = mapped_column(JSONVariant, nullable=False, default=list)
     # arxiv 公告类型：new（新提交）| cross（转投/交叉列表）
     announce_type: Mapped[str] = mapped_column(String(16), nullable=False, default="new")
-    # 退役列（解读已统一到 papers.wiki / paper_wikis，每篇一份）：只留存量数据，
-    # 代码不再读写；删列待确认稳定后另做迁移。
-    wiki_content: Mapped[str | None] = mapped_column(Text)
-    wiki_model: Mapped[str | None] = mapped_column(String(128))
 
     paper: Mapped[Paper] = relationship()
 

--- a/src/backend/app/models/library.py
+++ b/src/backend/app/models/library.py
@@ -37,9 +37,6 @@ class UserLibraryEntry(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     abstract: Mapped[str | None] = mapped_column(Text)
     url: Mapped[str | None] = mapped_column(String(1024))
     tldr: Mapped[str | None] = mapped_column(Text)
-    # 退役列（解读已统一到 paper_wikis，条目详情按 last_paper_id 现查）：只留存量
-    # 数据，代码不再读写；删列待确认稳定后另做迁移。
-    wiki_content: Mapped[str | None] = mapped_column(Text)
     saved: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     saved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     # 回收站：取消收藏 / 删除条目 = 软删（trashed_at 置位），可召回、可彻底删除、可清空。

--- a/src/backend/app/models/library_direction.py
+++ b/src/backend/app/models/library_direction.py
@@ -71,11 +71,11 @@ class DirectionLibrary(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     is_public: Mapped[bool] = mapped_column(
         Boolean, default=False, server_default="false", nullable=False
     )
-    # 库创建者（P9b 用户建库）：个人库仅创建者 + admin 可见/可管理。
+    # 库归属人（创建者）：个人库仅归属人可见/可管理；NULL = 无主库（存量/系统建）。
+    # 曾与 created_by 双列并存、写入时恒等（P9b 遗留），#734 合一：全部读写走这一列，
+    # 列名保留 submitted_by——30+ 读点、前端类型与 golden wire 形状都在用它，改名收益
+    # 只有「更好听」，代价是全链路 churn。
     submitted_by: Mapped[uuid.UUID | None] = mapped_column(
-        ForeignKey("users.id", ondelete="SET NULL")
-    )
-    created_by: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("users.id", ondelete="SET NULL")
     )
     # 起源课题溯源（历史 1:1 库回指；SET NULL——删课题不再级联删库，孤儿库保留）。
@@ -104,9 +104,6 @@ class LibraryPaper(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     relevance_score: Mapped[float | None]  # LLM 对照方向 rubric 的打分
     relevance_reason: Mapped[str | None] = mapped_column(Text)  # 本次收录/排除的方向化理由
     tldr_note: Mapped[str | None] = mapped_column(Text)  # 库视角一句话概括（可选）
-    # 退役列（解读已统一到 paper_wikis，每篇论文一份、不再按库分版本）：只留存量
-    # 数据，代码不再读写；删列待确认稳定后另做迁移。
-    wiki_content: Mapped[str | None] = mapped_column(Text)
     # 状态流转同 PAPER_STATUSES：candidate → scored|excluded → fetched → compiled；included 人工纳入
     status: Mapped[str] = mapped_column(String(32), default="candidate", nullable=False)
     # 进回收站的原因（status=excluded 时有值）：irrelevant 相关性不足自动淘汰 | manual 手动删除
@@ -118,9 +115,6 @@ class LibraryPaper(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     scored_run_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("voyage_runs.id", ondelete="SET NULL"), index=True
     )
-    # 退役列（编译时间/模型随解读走 paper_wikis）：同上，只留存量数据。
-    compiled_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
-    compiled_model: Mapped[str | None] = mapped_column(String(255))
 
     paper: Mapped[Paper] = relationship()
 

--- a/src/backend/app/models/llm_config.py
+++ b/src/backend/app/models/llm_config.py
@@ -95,11 +95,13 @@ class ModelRoute(UUIDPrimaryKeyMixin, TimestampMixin, Base):
 
 class LLMUsage(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     __tablename__ = "llm_usage"
-    # 用量面板按天/周窗口聚合（/lab/usage、排行榜），没这个索引就是全表扫
+    # 按时间窗聚合的现实消费者（lab 用量面板/排行榜已随去实验室化移除）：
+    # 库月度用量 services/ingest.monthly_library_usage（治理页用量条）与管理端
+    # usage_report 都按 created_at 过滤，没这个索引就是全表扫。
     __table_args__ = (Index("ix_llm_usage_created_at", "created_at"),)
 
-    #: index=True：配额检查按用户过滤，而这一列此前**没有索引**（project_id/library_id
-    #: 都有），agent 循环里每轮查一次配额就是一次全表扫。
+    #: index=True：个人用量汇总（services/users.usage_summary，设置页展示）按用户
+    #: 过滤；配额检查已随治理机制移除（#614），索引留给展示查询。
     user_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("users.id", ondelete="SET NULL"), index=True
     )
@@ -110,7 +112,9 @@ class LLMUsage(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     library_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("direction_libraries.id", ondelete="SET NULL"), index=True
     )
-    #: 这一行属于哪场对话（voyage_id 的对偶）。让"这场对话花了多少 token"可回答。
+    #: deprecated（#734）：设想中的「这场对话花了多少 token」从未有读点，写点也已
+    #: 移除——router 记账（_record_usage）不带它，恒 NULL。列保留一期防在途回滚，
+    #: 下一次列卫生迁移删除。
     conversation_id: Mapped[uuid.UUID | None] = mapped_column(nullable=True, index=True)
     voyage_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("voyage_runs.id", ondelete="SET NULL")

--- a/src/backend/app/models/topic_shelf.py
+++ b/src/backend/app/models/topic_shelf.py
@@ -19,7 +19,7 @@ from app.models.paper import Paper
 
 
 class TopicPaper(UUIDPrimaryKeyMixin, TimestampMixin, Base):
-    """课题-论文书架行：引用内容池论文 + 入架时的 wiki 快照 + 课题语境备注。"""
+    """课题-论文书架行：引用内容池论文 + 课题语境备注（解读经 paper_wikis 现查）。"""
 
     __tablename__ = "topic_papers"
     __table_args__ = (
@@ -39,10 +39,6 @@ class TopicPaper(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     source_library_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("direction_libraries.id", ondelete="SET NULL")
     )
-    # 退役列（解读已统一到 paper_wikis，每篇一份、书架直接引用）：只留存量数据，
-    # 代码不再读写；删列待确认稳定后另做迁移。
-    wiki_snapshot: Mapped[str | None] = mapped_column(Text)
-    snapshot_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     # 课题语境的「为什么相关」备注
     note: Mapped[str | None] = mapped_column(Text)
     added_by: Mapped[uuid.UUID | None] = mapped_column(

--- a/src/backend/app/models/user.py
+++ b/src/backend/app/models/user.py
@@ -27,7 +27,7 @@ class User(SQLAlchemyBaseUserTableUUID, TimestampMixin, Base):
     avatar_path: Mapped[str | None] = mapped_column(String(1024))
     # 用户个人设置：{key: value}。None/缺键 = 未设置。
     # managed_command_unanswered_minutes 存远端命令等待用户答复的个人偏好；管理员全局
-    # 上限仍优先。历史 chat_fulltext_index 已废除，存量值保留但不再读取。
+    # 上限仍优先。
     # #737 配置分层起，原 system_settings 里的用户偏好也存在这里（命名空间键，
     # 落在 owner 用户头上）：daily.categories / daily.sync_time / daily.retention_days /
     # daily.sync_scope / tts.admin / affiliations.extraction_mode，读写统一走

--- a/src/backend/app/schemas/ingest.py
+++ b/src/backend/app/schemas/ingest.py
@@ -20,8 +20,13 @@ class IngestKnobs(BaseModel):
     snowball_depth: int = Field(default=1, ge=0, le=3)
     compile_top_n: int = Field(default=50, ge=1, le=200)  # 打分后精读编译前 N 篇
     # 最大化模式：True 时检索/打分/抽取/编译不设篇数上限（max_papers/compile_top_n 被忽略，
-    # 仅保留极高安全哨兵防失控），token 预算也不设限。默认 False，向后兼容。
+    # 仅保留极高安全哨兵防失控）。默认 False，向后兼容。
     unlimited: bool = False
+    # 本次运行的 token 预算上限（引擎步间检查，超限走既有预算暂停语义）。
+    # #734 暂缓机制收口：默认 None = 不设预算——以前按 max_papers 派生一个隐式
+    # 上限，量一大任务就静默暂停在半路，界面上只见「卡住了」。有限预算改为
+    # 显式 opt-in：真想设限的调用方自己传数。
+    max_tokens: int | None = Field(default=None, ge=1)
 
 
 class IngestRequest(BaseModel):

--- a/src/backend/app/schemas/libraries.py
+++ b/src/backend/app/schemas/libraries.py
@@ -20,10 +20,8 @@ class DirectionLibrarySummary(BaseModel):
     statement: str | None
     # 过渡期隐式库回指的课题；未来共享库可为 None
     project_id: uuid.UUID | None
-    # 审批流残留（#619 删列）：恒为 "active" / None。语义已死，但仍随响应下发——
-    # golden transcript 逐字节比对响应形状，纯移除改动不动 wire 形状。
-    status: str = "active"
-    review_note: str | None = None
+    # 审批流残留的恒值字段 status/review_note（#619 删列后只剩 wire 形状兼容）
+    # 已随 #734 的有意重录 golden 移除。
     # 共享开关：false = 仅创建者可见的个人库 | true = 对本部署所有用户可见
     is_public: bool = False
     # 库创建者（个人库仅创建者 + admin 可见）
@@ -47,7 +45,8 @@ class DirectionLibrarySummary(BaseModel):
 
 class DirectionLibraryDetail(DirectionLibrarySummary):
     cadence: str | None
-    # 每月 ingest 预算（token 数；None = 不限）
+    # deprecated（#734 暂缓机制收口）：月度预算不再拦截任何任务，列保留只作
+    # 「参考上限」展示（治理页用量条）；值仍可读写以兼容存量配置。
     monthly_budget: int | None = None
     # 收录配置全量（P8a 权威源）：statement/goals/in_scope/out_of_scope/questions/
     # rubric/anchor_papers/keywords(含 arxiv_categories)/cadence，供「收录设置」编辑
@@ -70,6 +69,7 @@ class LibraryCreate(BaseModel):
     # 那才是能真正问出「研究问题/对象/子问题/方法类型」的东西。
     statement: str = Field(min_length=1, max_length=4000)
     cadence: str | None = Field(default=None, max_length=32)
+    # deprecated（#734）：参考上限，仅展示；界面已不提供输入，字段保留兼容存量调用
     monthly_budget: int | None = Field(default=None, ge=0)
     rubric: Any | None = None
     anchors: list[Any] | None = None
@@ -94,6 +94,7 @@ class DirectionLibraryUpdate(BaseModel):
     name: str | None = Field(default=None, min_length=1, max_length=255)
     statement: str | None = None
     cadence: str | None = Field(default=None, max_length=32)
+    # deprecated（#734）：参考上限，仅展示；界面已不提供输入，字段保留兼容存量调用
     monthly_budget: int | None = Field(default=None, ge=0)
     rubric: Any | None = None
     anchors: list[Any] | None = None
@@ -140,15 +141,18 @@ class PaperMergeResult(BaseModel):
 
 
 class LibraryBudgetRead(BaseModel):
-    """库预算面板（P6）：本月消耗（UTC 自然月，token 口径与 LLMUsage 记账一致）。"""
+    """库用量面板：本月消耗（UTC 自然月，token 口径与 LLMUsage 记账一致）。
+
+    #734 起纯展示：monthly_budget 只是参考上限，超过不再拦截任何任务。
+    """
 
     month: str  # 如 "2026-07"
-    monthly_budget: int | None  # None = 不限
+    monthly_budget: int | None  # 参考上限（deprecated 列）；None = 未设
     prompt_tokens: int
     completion_tokens: int
     used_tokens: int
-    remaining_tokens: int | None  # 不限时为 None；用超时为 0
-    exhausted: bool  # True = 本月预算已用尽（ingest 会被拒绝启动）
+    remaining_tokens: int | None  # 未设上限时为 None；用超时为 0
+    exhausted: bool  # True = 本月用量已超参考上限（仅展示，不再拒绝启动任何任务）
 
 
 class LibraryDigestSummary(BaseModel):

--- a/src/backend/app/schemas/user.py
+++ b/src/backend/app/schemas/user.py
@@ -13,12 +13,12 @@ class UserRead(schemas.BaseUser[uuid.UUID]):
     display_name: str
     username: str | None = None
     username_locked: bool = False
-    # 历史遗留：自管 LLM 轨已并入平台配置（#621），users 表里没有这一列了。
-    # 字段保留并恒为 False，只为不动 API 形状（golden transcript 逐字节比对着它）；
-    # 下次允许重录 golden 时一并移除。
-    llm_self_managed: bool = False
     has_avatar: bool = False
     settings: dict[str, Any] | None = None
+    # 单人产品没有「超管」概念（治理列已随 #614 删除）：fastapi-users 基类自带的
+    # is_superuser 不再随 API 下发（exclude 只影响响应序列化；DB 列与内部逻辑不动）。
+    # 恒 False 的幽灵字段 llm_self_managed（#621 遗留）已随 #734 重录 golden 移除。
+    is_superuser: bool = Field(default=False, exclude=True)
 
 
 class UserCreate(schemas.BaseUserCreate):

--- a/src/backend/app/services/ingest.py
+++ b/src/backend/app/services/ingest.py
@@ -18,10 +18,6 @@ from app.models.voyage import TERMINAL_STATUSES, VoyageRun
 from app.schemas.ingest import IngestKnobs
 from app.services.libraries import get_library_for_project
 
-# 预算从 knobs 派生：每篇编译预留的 token 额度（打分+编译+概念定义+验证）
-_TOKENS_PER_PAPER = 20_000
-
-
 #: 三种收集模式。search/snowball 是人主动发起的两条补充路径，incremental 是每天自动
 #: 从每日论文池挑。``bootstrap`` 是 ``search`` 的旧名，只做入口兼容，不再往下传。
 MODE_LABELS: dict[str, str] = {
@@ -40,10 +36,6 @@ def normalize_mode(mode: str) -> str:
 
 class IngestConflictError(Exception):
     """同一项目已有 ingest voyage 在跑。"""
-
-
-class LibraryBudgetExhaustedError(Exception):
-    """方向库本月预算已用尽（P6）：拒绝启动新的 ingest。"""
 
 
 async def monthly_library_usage(session: AsyncSession, library_id: uuid.UUID) -> dict[str, Any]:
@@ -69,37 +61,20 @@ async def monthly_library_usage(session: AsyncSession, library_id: uuid.UUID) ->
     }
 
 
-async def apply_library_budget(
-    session: AsyncSession,
-    *,
-    library_id: uuid.UUID,
-    monthly_budget: int | None,
-    budget: dict[str, Any],
-) -> dict[str, Any]:
-    """把库的月度预算折算进 run.budget（复用 Voyage 预算暂停语义，不另造状态机）。
-
-    - 本月已用 ≥ 上限 → 抛 LibraryBudgetExhaustedError（拒绝启动）；
-    - 否则 run.budget.max_tokens 收紧为 min(原值, 本月剩余)——运行中一旦累计
-      到剩余额度，引擎按既有预算机制收尾/暂停。
-    """
-    if not monthly_budget:
-        return budget
-    usage = await monthly_library_usage(session, library_id)
-    remaining = int(monthly_budget) - int(usage["total_tokens"])
-    if remaining <= 0:
-        raise LibraryBudgetExhaustedError(str(library_id))
-    max_tokens = budget.get("max_tokens")
-    budget = dict(budget)
-    budget["max_tokens"] = remaining if not max_tokens else min(int(max_tokens), remaining)
-    return budget
-
-
 def derive_budget(knobs: IngestKnobs) -> dict[str, Any]:
-    # 最大化模式不设 token 预算：引擎 _budget_exceeded 对 falsy 的 max_tokens（None/缺失）
-    # 直接跳过预算检查（engine.py），任务不会因预算暂停/降级收尾。
-    if knobs.unlimited:
+    """knobs → run.budget。#734 暂缓机制收口：**默认不设 token 预算**。
+
+    以前按 max_papers 派生一个隐式上限（每篇 2 万 token），库一大任务就静默
+    暂停在半路；月度预算（monthly_budget）还会把上限进一步收紧、甚至直接拒绝
+    启动——这些「治理机制」在单人产品里只剩误伤。现在有限预算是显式 opt-in
+    （knobs.max_tokens），monthly_budget 只作展示（见 api/libraries.get_library_budget）。
+
+    引擎 _budget_exceeded 对 falsy 的 max_tokens（None/缺失）直接跳过预算检查
+    （engine.py），任务不会因预算暂停/降级收尾。
+    """
+    if knobs.unlimited or knobs.max_tokens is None:
         return {"max_tokens": None}
-    return {"max_tokens": int(knobs.max_papers) * _TOKENS_PER_PAPER}
+    return {"max_tokens": int(knobs.max_tokens)}
 
 
 async def find_running_ingest_for_library(
@@ -130,7 +105,7 @@ async def create_ingest_voyage(
     query_terms: list[str] | None = None,
     time_range: str | None = None,
 ) -> VoyageRun:
-    """建 ingest voyage（互斥检查 + 库预算检查 + Activity 落记录），由调用方入队 run_voyage。
+    """建 ingest voyage（互斥检查 + Activity 落记录），由调用方入队 run_voyage。
 
     任务只挂 ``library``：建库 / 增量更新是文献库自己的事，课题只是关联库来用
     语料。``project`` 仅用来取展示名（有起源课题时用课题名更好认），不写进
@@ -139,12 +114,7 @@ async def create_ingest_voyage(
     """
     if await find_running_ingest_for_library(session, library.id) is not None:
         raise IngestConflictError(str(library.id))
-    budget = await apply_library_budget(
-        session,
-        library_id=library.id,
-        monthly_budget=library.monthly_budget,
-        budget=derive_budget(knobs),
-    )
+    budget = derive_budget(knobs)
     mode = normalize_mode(mode)
     # 手动的两种模式（search/snowball）沿用 wiki_bootstrap 这个 kind：它们都是"人主动去
     # 拉一批"，与自动的每日同步区分开即可；kind 是存量数据的形状，不为了新名字去迁移。
@@ -231,12 +201,7 @@ async def create_digest_voyage(
         return run, "incremental", 0
 
     actual_knobs = knobs or IngestKnobs()
-    budget = await apply_library_budget(
-        session,
-        library_id=library.id,
-        monthly_budget=library.monthly_budget,
-        budget=derive_budget(actual_knobs),
-    )
+    budget = derive_budget(actual_knobs)
     paper_ids = list(dict.fromkeys(row.paper_id for row in rows))
     latest_published_at = max(
         (row.published_at for row in rows if row.published_at is not None), default=None

--- a/src/backend/app/services/libraries.py
+++ b/src/backend/app/services/libraries.py
@@ -553,8 +553,7 @@ async def create_library(
         cadence=cadence,
         definition=definition or None,  # P8a：独立库同样以 definition 为收录配置权威源
         monthly_budget=monthly_budget,
-        created_by=created_by,
-        submitted_by=created_by,
+        submitted_by=created_by,  # 归属人单列（#734 起 created_by 副本列已删）
         project_id=None,
     )
     session.add(library)

--- a/src/backend/app/services/paper_merge.py
+++ b/src/backend/app/services/paper_merge.py
@@ -192,7 +192,7 @@ async def merge_papers(
         set_committed_value(drop, "wiki", None)
     report["wiki_moved"] = wiki_moved
 
-    # ---- 2. topic_papers：同课题冲突保留 keep 行（缺快照/备注则补），否则 repoint ----
+    # ---- 2. topic_papers：同课题冲突保留 keep 行（缺备注则补），否则 repoint ----
     keep_shelf = {
         t.topic_id: t
         for t in (
@@ -208,9 +208,7 @@ async def merge_papers(
             row.paper_id = keep_id
             shelf_repointed += 1
             continue
-        if existing.wiki_snapshot is None and row.wiki_snapshot is not None:
-            existing.wiki_snapshot = row.wiki_snapshot
-            existing.snapshot_at = row.snapshot_at
+        # wiki 快照列已退役删除（#734）：解读统一走 paper_wikis，无需搬运
         if not existing.note and row.note:
             existing.note = row.note
         # 一边在架一边在回收站 → 合并后在架（别让合并把还在书架上的条目变没）

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -155,7 +155,6 @@ async def ensure_project_library(session, project_id):
         name=project.name if project else "test-lib",
         project_id=pid,
         is_public=True,  # 课题起源库=共享库（P10：全实验室可读）
-        created_by=None,
         # 起源库记课题主人为创建者：库级写权限 = admin ∪ 创建者（策展人已随 #593 移除）
         submitted_by=project.owner_id if project else None,
     )
@@ -323,7 +322,6 @@ async def make_project_with_library(
             definition=definition,
             project_id=project_id,
             is_public=True,  # 课题起源库=共享库（P10：全实验室可读）
-            created_by=None,
             submitted_by=owner_id,
         )
         if definition:

--- a/src/backend/tests/golden/data/discovery_run.json
+++ b/src/backend/tests/golden/data/discovery_run.json
@@ -115,9 +115,7 @@
     "owner_name": "Discovery Golden",
     "paper_count": 0,
     "project_id": null,
-    "review_note": null,
     "statement": "Deterministic golden-transcript library for the hypothesis pipeline.",
-    "status": "active",
     "submitted_by": "<uuid-1>",
     "updated_at": "<ts>"
   },
@@ -458,9 +456,7 @@
     "has_avatar": false,
     "id": "<uuid-1>",
     "is_active": true,
-    "is_superuser": false,
     "is_verified": false,
-    "llm_self_managed": false,
     "settings": null,
     "username": "discoverygolden",
     "username_locked": false

--- a/src/backend/tests/golden/data/import_wiki.json
+++ b/src/backend/tests/golden/data/import_wiki.json
@@ -63,9 +63,7 @@
     "owner_name": "Golden Probe",
     "paper_count": 0,
     "project_id": null,
-    "review_note": null,
     "statement": "Deterministic golden-transcript library covering reproducible plumbing.",
-    "status": "active",
     "submitted_by": "<uuid-1>",
     "updated_at": "<ts>"
   },
@@ -169,9 +167,7 @@
     "has_avatar": false,
     "id": "<uuid-1>",
     "is_active": true,
-    "is_superuser": false,
     "is_verified": false,
-    "llm_self_managed": false,
     "settings": null,
     "username": "goldenprobe",
     "username_locked": false

--- a/src/backend/tests/golden/test_golden_discovery.py
+++ b/src/backend/tests/golden/test_golden_discovery.py
@@ -10,9 +10,9 @@ novelty_report / feasibility / score、步骤观测与 token 记账，归一化�
 引擎驱动（VoyageEngine.run）不是 HTTP 步骤，不进 transcript；transcript 只收
 API 面上的可观测结果——golden 钉的是对外行为，不是内部实现。
 
-更新方式（仅限本地，CI 只比对）::
+更新方式（仅限本地，CI 只比对；何时允许重录、diff 怎么审见 docs/golden-policy.md）::
 
-    POLARIS_GOLDEN=record python -m pytest tests/golden -q
+    make golden-record   # 或：POLARIS_GOLDEN=record python -m pytest tests/golden -q
 """
 
 import json
@@ -189,6 +189,6 @@ async def test_discovery_chain_matches_golden(client, queue_stub):
     )
     expected = GOLDEN_PATH.read_text(encoding="utf-8")
     assert rendered == expected, (
-        "golden transcript 变了。若这是有意的行为变更：本地 POLARIS_GOLDEN=record 重录，"
-        "人工审查 diff 后随代码一起提交。"
+        "golden transcript 变了。若这是有意的行为变更：本地 make golden-record 重录，"
+        "人工审查 diff 后随代码一起提交（规则见 docs/golden-policy.md）。"
     )

--- a/src/backend/tests/golden/test_golden_import_wiki.py
+++ b/src/backend/tests/golden/test_golden_import_wiki.py
@@ -6,9 +6,9 @@
 这是 B 轨（去实验室化移除）的回归闸门：**纯移除 PR 必须保持 golden 不变**。
 golden 变了 = 行为变了，需要人工审查 diff 并说明理由。
 
-更新方式（仅限本地，CI 只比对，纪律来自 DSH 的 snapshot 流程）::
+更新方式（仅限本地，CI 只比对；何时允许重录、diff 怎么审见 docs/golden-policy.md）::
 
-    POLARIS_GOLDEN=record python -m pytest tests/golden -q
+    make golden-record   # 或：POLARIS_GOLDEN=record python -m pytest tests/golden -q
 """
 
 import json
@@ -125,6 +125,7 @@ async def test_import_wiki_chain_matches_golden(client):
     )
     expected = GOLDEN_PATH.read_text(encoding="utf-8")
     assert rendered == expected, (
-        "golden transcript 变了。若这是有意的行为变更：本地 POLARIS_GOLDEN=record 重录，"
-        "人工审查 diff 后随代码一起提交；纯移除 PR 不允许改 golden。"
+        "golden transcript 变了。若这是有意的行为变更：本地 make golden-record 重录，"
+        "人工审查 diff 后随代码一起提交（规则见 docs/golden-policy.md）；"
+        "自称『纯移除/无行为变更』的 PR 不允许动 golden。"
     )

--- a/src/backend/tests/test_concept_fuels.py
+++ b/src/backend/tests/test_concept_fuels.py
@@ -218,7 +218,7 @@ async def test_concept_pairs_personal_library_hidden(client):
             await session.execute(select(User).where(User.email == "owner@example.com"))
         ).scalar_one()
         library = DirectionLibrary(
-            name="private-lib", is_public=False, submitted_by=owner.id, created_by=owner.id
+            name="private-lib", is_public=False, submitted_by=owner.id
         )
         session.add(library)
         await session.commit()

--- a/src/backend/tests/test_download_batch_protocol.py
+++ b/src/backend/tests/test_download_batch_protocol.py
@@ -35,7 +35,6 @@ async def _target(email: str, *, name: str = "batch library", papers: int = 1):
             name=name,
             is_public=False,
             submitted_by=owner.id,
-            created_by=owner.id,
         )
         session.add(library)
         await session.flush()

--- a/src/backend/tests/test_library_budget.py
+++ b/src/backend/tests/test_library_budget.py
@@ -1,4 +1,10 @@
-"""P6 库预算（任务 2）：用量按库归因、月度聚合、超限拒绝启动与剩余额度收紧。"""
+"""库用量与预算语义（#734 暂缓机制收口后）：
+
+- 用量按库归因、月度聚合（展示面保留）；
+- ingest 预算**默认无限**：不再从 max_papers 派生隐式 token 上限；
+- 有限预算 = 显式 opt-in（knobs.max_tokens）；
+- monthly_budget 只是参考上限：用超也照样启动任务，面板 exhausted 仅展示。
+"""
 
 import uuid
 from datetime import UTC, datetime, timedelta
@@ -11,6 +17,7 @@ from app.core.llm.router import get_llm_router
 from app.models.library_direction import DirectionLibrary
 from app.models.llm_config import LLMUsage
 from app.models.voyage import VoyageRun
+from app.schemas.ingest import IngestKnobs
 from app.services import ingest as ingest_service
 from tests.conftest import make_project_with_library, register_and_login
 
@@ -18,7 +25,7 @@ from tests.conftest import make_project_with_library, register_and_login
 async def _setup_project(client, email="budget-owner@example.com"):
     token = await register_and_login(client, email=email)
     headers = {"Authorization": f"Bearer {token}"}
-    # P9c：课题不再自动建库——显式配一条 active 起源库（project_id 回指）。
+    # P9c：课题不再自动建库——显式配一条起源库（project_id 回指）。
     project_id, library_id = await make_project_with_library(
         client, headers, name="预算方向"
     )
@@ -67,17 +74,35 @@ async def test_monthly_usage_aggregation(client):
         assert empty["total_tokens"] == 0
 
 
-async def test_ingest_rejected_when_budget_exhausted(client, queue_stub):
+def test_derive_budget_defaults_to_unlimited():
+    """#734：默认不设 token 预算——隐式的 max_papers×2 万派生上限已移除。"""
+    assert ingest_service.derive_budget(IngestKnobs()) == {"max_tokens": None}
+    # max_papers 再大也不再影响预算
+    assert ingest_service.derive_budget(IngestKnobs(max_papers=500)) == {"max_tokens": None}
+    # 有限预算 = 显式 opt-in
+    assert ingest_service.derive_budget(IngestKnobs(max_tokens=70_000)) == {"max_tokens": 70_000}
+    # 最大化模式下即便显式给了上限也不设（unlimited 语义优先）
+    assert ingest_service.derive_budget(IngestKnobs(unlimited=True, max_tokens=1)) == {
+        "max_tokens": None
+    }
+
+
+async def test_over_budget_library_still_starts_ingest(client, queue_stub):
+    """monthly_budget 用超只是展示：ingest 照常启动、照常入队（硬限额已移除）。"""
     headers, project_id, library_id = await _setup_project(client, email="budget-a@example.com")
     await _set_budget(library_id, 1000)
     await _add_usage(library_id, prompt=800, completion=300)  # 1100 ≥ 1000
     resp = await client.post(
         f"/api/projects/{project_id}/ingest", json={"mode": "bootstrap"}, headers=headers
     )
-    assert resp.status_code == 409, resp.text
-    assert resp.json()["detail"] == "LIBRARY_BUDGET_EXHAUSTED"
-    assert queue_stub.jobs == []  # 没有入队任何任务
-    # 预算面板显示已用尽
+    assert resp.status_code == 201, resp.text
+    voyage_id = resp.json()["id"]
+    assert ("run_voyage", (voyage_id,), {}) in queue_stub.jobs
+    async with get_sessionmaker()() as session:
+        run = await session.get(VoyageRun, uuid.UUID(voyage_id))
+        # 月度上限不再折进 run.budget
+        assert run.budget == {"max_tokens": None}
+    # 面板仍然如实展示「已超参考上限」——但那只是信息，不是闸门
     resp = await client.get(f"/api/libraries/{library_id}/budget", headers=headers)
     assert resp.status_code == 200
     body = resp.json()
@@ -86,25 +111,25 @@ async def test_ingest_rejected_when_budget_exhausted(client, queue_stub):
     assert body["remaining_tokens"] == 0
 
 
-async def test_ingest_budget_capped_to_monthly_remaining(client, queue_stub):
+async def test_ingest_budget_not_capped_by_monthly_budget(client, queue_stub):
+    """月度预算不再收紧 run.budget；显式 opt-in 的 max_tokens 原样生效。"""
     headers, project_id, library_id = await _setup_project(client, email="budget-b@example.com")
     await _set_budget(library_id, 100_000)
-    await _add_usage(library_id, prompt=20_000, completion=10_000)  # 已用 30k → 剩 70k
+    await _add_usage(library_id, prompt=20_000, completion=10_000)
     resp = await client.post(
         f"/api/projects/{project_id}/ingest",
-        json={"mode": "bootstrap", "knobs": {"max_papers": 10}},  # 派生预算 200k > 剩余
+        json={"mode": "bootstrap", "knobs": {"max_papers": 10}},
         headers=headers,
     )
     assert resp.status_code == 201, resp.text
-    voyage_id = resp.json()["id"]
     async with get_sessionmaker()() as session:
-        run = await session.get(VoyageRun, uuid.UUID(voyage_id))
-        assert run.budget["max_tokens"] == 70_000
-    # 无预算库不受影响：max_tokens 用 knobs 派生值
+        run = await session.get(VoyageRun, uuid.UUID(resp.json()["id"]))
+        assert run.budget == {"max_tokens": None}  # 既无隐式派生，也无月度收紧
+    # 显式 opt-in：传 max_tokens 才有有限预算
     headers2, project_id2, _library_id2 = await _setup_project(client, email="budget-c@example.com")
     resp = await client.post(
         f"/api/projects/{project_id2}/ingest",
-        json={"mode": "bootstrap", "knobs": {"max_papers": 10}},
+        json={"mode": "bootstrap", "knobs": {"max_papers": 10, "max_tokens": 200_000}},
         headers=headers2,
     )
     assert resp.status_code == 201, resp.text
@@ -149,3 +174,5 @@ async def test_router_records_library_attribution(client):
         assert len(rows) == 1
         assert rows[0].stage == "relevance"
         assert rows[0].prompt_tokens > 0
+        # #734 停写核证：对话归因列不再被任何写点填充
+        assert rows[0].conversation_id is None

--- a/src/backend/tests/test_library_lifecycle.py
+++ b/src/backend/tests/test_library_lifecycle.py
@@ -56,7 +56,7 @@ async def test_create_project_can_link_existing_libraries(client):
     """P9c：建课题入参可关联已有库；语料 = 关联库并集。"""
     admin = await _register(client, "p7-link@example.com")
     async with get_sessionmaker()() as session:
-        lib = DirectionLibrary(name="已有库", created_by=None, project_id=None)
+        lib = DirectionLibrary(name="已有库", project_id=None)
         session.add(lib)
         await session.commit()
         lib_id = lib.id
@@ -177,7 +177,7 @@ async def test_delete_library_without_topics_needs_no_force(client):
     """独立库（无课题关联）删除不受 force 影响；无主库（submitted_by 空）谁都能删（#614）。"""
     admin = await _register(client, "p7-admin5@example.com")
     async with get_sessionmaker()() as session:
-        library = DirectionLibrary(name="孤儿库", created_by=None, project_id=None)
+        library = DirectionLibrary(name="孤儿库", project_id=None)
         session.add(library)
         await session.commit()
         library_id = library.id
@@ -193,7 +193,7 @@ async def test_get_source_libraries_returns_multiple_associations(client):
     project_id = uuid.UUID(project_id_str)
 
     async with get_sessionmaker()() as session:
-        extra = DirectionLibrary(name="额外方向库", created_by=None, project_id=None)
+        extra = DirectionLibrary(name="额外方向库", project_id=None)
         session.add(extra)
         await session.flush()
         await libraries_service.set_source_libraries(

--- a/src/backend/tests/test_library_paper_management.py
+++ b/src/backend/tests/test_library_paper_management.py
@@ -11,7 +11,7 @@ from sqlalchemy import select
 
 from app.core.db import get_sessionmaker
 from app.models.library_direction import LibraryPaper
-from app.models.paper import Concept, Paper, paper_concepts
+from app.models.paper import Concept, Paper, PaperWiki, paper_concepts
 from tests.conftest import register_and_login
 
 BIBTEX_ENTRY = """@inproceedings{smith2025bench,
@@ -90,9 +90,11 @@ async def _seed_paper(
                 paper_id=paper.id,
                 status=status,
                 relevance_score=relevance,
-                wiki_content=wiki,
             )
         )
+        if wiki is not None:
+            # 解读全平台一份（paper_wikis）；成员行的 wiki 快照列已随 #734 退役删除
+            session.add(PaperWiki(paper_id=paper.id, content=wiki, model="fake"))
         await session.commit()
         return str(paper.id)
 

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,7 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "b737c1a2d3e4"  # User-preference settings move to users.settings (#737)
+HEAD_REVISION = "351c324f4f6b"  # Schema hygiene: retired columns + owner merge (#734)
+SETTINGS_REVISION = "b737c1a2d3e4"  # User-preference settings move to users.settings (#737)
 RESOURCES_REVISION = "d2dcfc8b899f"  # Resources, leases, polymorphic credentials (#677)
 METHOD_VECTORS_REVISION = "e867fcbae4ea"  # Method purpose/mechanism vectors (#663)
 EXTRACTIONS_REVISION = "58b0bc2d809d"  # Paper skeleton extractions (#661)
@@ -183,6 +184,13 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     command.upgrade(cfg, "head")
     version, columns = _inspect_db(db_path)
     assert version == HEAD_REVISION
+    # 列卫生（#734）：退役快照列与归属副本列在 head 已删
+    assert not {"wiki_content", "compiled_at", "compiled_model"} & columns["library_papers"]
+    assert "wiki_content" not in columns["user_library_entries"]
+    assert not {"wiki_content", "wiki_model"} & columns["daily_feed_entries"]
+    assert not {"wiki_snapshot", "snapshot_at"} & columns["topic_papers"]
+    assert "created_by" not in columns["direction_libraries"]
+    assert "submitted_by" in columns["direction_libraries"]
     # 治理列已随个人化定位删除（#614）
     assert not {"role", "read_only", "llm_access", "token_quota", "features"} & columns[
         "users"
@@ -212,7 +220,7 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     assert {"slug", "description", "body", "allowed_tools", "invocation"} <= columns["agent_skills"]
     assert {"scope_kind", "scope_id", "usage", "active_stream_id"} <= columns["conversations"]
     assert {"blocks", "text", "seq", "status", "sources"} <= columns["conversation_messages"]
-    # 这场对话花了多少 token（voyage_id 的对偶）
+    # deprecated（#734 停写）：列保留一期防在途回滚，下一次列卫生迁移删除
     assert "conversation_id" in columns["llm_usage"]
     assert "venue_metric_snapshot" in columns["literature_search_hits"]
     assert {"provider", "identity_key", "metrics", "expires_at"} <= columns[
@@ -401,8 +409,8 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     assert "owner_id" in columns["model_routes"]
     # 自管轨并入平台配置（#621）：接管开关列已删，providers/routes 的 owner_id 保留
     assert "llm_self_managed" not in columns["users"]
-    # 个人库 wiki 快照列（上一版）
-    assert "wiki_content" in columns["user_library_entries"]
+    # 个人库 wiki 快照列已随列卫生退役（#734）
+    assert "wiki_content" not in columns["user_library_entries"]
     # 方向文献库两表 + papers.dedup_key（策展人表已在 P1 去实验室化中移除）
     assert {
         "direction_libraries",
@@ -415,8 +423,6 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
         "topic_id",
         "paper_id",
         "source_library_id",
-        "wiki_snapshot",
-        "snapshot_at",
         "note",
         "added_by",
     } <= columns["topic_papers"]
@@ -439,9 +445,6 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     # 本分支新增：论文级唯一解读表（原列一律保留，只是不再读写）
     assert "paper_wikis" in columns["_tables"]
     assert {"paper_id", "content", "model", "compiled_by"} <= columns["paper_wikis"]
-    assert "wiki_content" in columns["library_papers"]  # 存量列保留，可回滚
-    assert "wiki_content" in columns["daily_feed_entries"]
-    assert "wiki_snapshot" in columns["topic_papers"]
     # 本分支新增：概念统一到论文级（去 library_id，slug 全局唯一）+ 两张回滚留档表
     assert "library_id" not in columns["concepts"]
     assert {"concepts_pre_unify", "paper_concepts_pre_unify"} <= columns["_tables"]
@@ -609,7 +612,19 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     } <= columns["paper_extractions"]
     assert "ix_paper_extractions_paper_id" in _index_names(db_path, "paper_extractions")
 
-    # 先退掉用户偏好搬家（#737）：纯数据迁移，schema 原样。
+    # 先退掉列卫生（#734）：退役快照列与 created_by 按原形状回来（数据不可恢复，
+    # created_by 从 submitted_by 回填——两列写入历史上恒等）。
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == SETTINGS_REVISION
+    assert {"wiki_content", "compiled_at", "compiled_model"} <= columns["library_papers"]
+    assert "wiki_content" in columns["user_library_entries"]
+    assert {"wiki_content", "wiki_model"} <= columns["daily_feed_entries"]
+    assert {"wiki_snapshot", "snapshot_at"} <= columns["topic_papers"]
+    assert "created_by" in columns["direction_libraries"]
+    assert "resources" in columns["_tables"]  # 只退一步：资源/租约仍在
+
+    # 再退掉用户偏好搬家（#737）：纯数据迁移，schema 原样。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == RESOURCES_REVISION
@@ -1035,6 +1050,12 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     assert "models" in columns["llm_providers"]
     assert "owner_id" in columns["llm_providers"]
     assert "llm_self_managed" not in columns["users"]  # head 已删（#621）
+    # 列卫生在重新 upgrade 后回归（#734）
+    assert not {"wiki_content", "compiled_at", "compiled_model"} & columns["library_papers"]
+    assert "wiki_content" not in columns["user_library_entries"]
+    assert not {"wiki_content", "wiki_model"} & columns["daily_feed_entries"]
+    assert not {"wiki_snapshot", "snapshot_at"} & columns["topic_papers"]
+    assert "created_by" not in columns["direction_libraries"]
     assert "project_members" not in columns["_tables"]  # head 已删（#625）
     assert "hypothesis_nodes" in columns["_tables"]  # 假设树表回归（#637）
     assert not {"feedback", "feedback_images"} & columns["_tables"]  # head 已删（#617）
@@ -1101,7 +1122,9 @@ def test_user_preference_settings_copy_to_owner_and_roundtrip(tmp_path):
                 {"k": key, "v": json.dumps(value)},
             )
 
-    command.upgrade(cfg, HEAD_REVISION)
+    # 精确升到 #737 本身（不再用 HEAD：#734 已排在它后面，
+    # 用 HEAD 会让下面的 downgrade -1 退错一层）
+    command.upgrade(cfg, SETTINGS_REVISION)
     with engine.connect() as conn:
         rows = dict(conn.execute(text("SELECT id, settings FROM users")).fetchall())
         owner = json.loads(rows["00000000-0000-0000-0000-000000000001"])
@@ -1138,3 +1161,75 @@ def test_user_preference_migration_skips_empty_deployment(tmp_path):
     command.upgrade(cfg, "head")
     version, _ = _inspect_db(db_path)
     assert version == HEAD_REVISION
+
+
+def test_schema_hygiene_migration_merges_owner_and_purges_private_llm_rows(tmp_path):
+    """#734 的数据面：created_by 并入 submitted_by；自管轨私有 provider/route 行删除。
+
+    在上一版（RESOURCES_REVISION）落一批存量行再升 head：
+    - submitted_by 为空但 created_by 有值的库 → 归属回填，不丢归属人；
+    - llm_providers / model_routes 的 owner_id 非 NULL 行（#621 只拆了入口没清数据，
+      全靠 WHERE owner_id IS NULL 挡着）→ 物理删除；全局行（owner NULL）原样保留。
+    """
+    db_path = tmp_path / "hygiene.db"
+    cfg = _make_config(db_path)
+    command.upgrade(cfg, RESOURCES_REVISION)
+
+    owner = "11111111-1111-1111-1111-111111111111"
+    engine = create_engine(f"sqlite:///{db_path}")
+    now = "2026-09-07 00:00:00"
+    with engine.begin() as conn:
+        # 归属双列：一行只有 created_by（极老存量），一行两列齐（P9b 后的常态）
+        conn.execute(
+            text(
+                "INSERT INTO direction_libraries "
+                "(id, name, library_kind, is_public, created_by, submitted_by, "
+                " created_at, updated_at) VALUES "
+                "('lib-legacy', '老库', 'standard', 0, :owner, NULL, :now, :now), "
+                "('lib-normal', '常态库', 'standard', 0, :owner, :owner, :now, :now)"
+            ),
+            {"owner": owner, "now": now},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO llm_providers "
+                "(id, owner_id, name, kind, enabled, created_at, updated_at) VALUES "
+                "('prov-global', NULL, 'platform', 'openai_compat', 1, :now, :now), "
+                "('prov-private', :owner, 'mine', 'openai_compat', 1, :now, :now)"
+            ),
+            {"owner": owner, "now": now},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO model_routes "
+                "(id, owner_id, stage, provider_id, model, created_at, updated_at) VALUES "
+                "('route-global', NULL, 'default', 'prov-global', 'gpt-x', :now, :now), "
+                "('route-private', :owner, 'default', 'prov-global', 'gpt-x', :now, :now), "
+                "('route-dangling', NULL, 'librarian', 'prov-private', 'gpt-x', :now, :now)"
+            ),
+            {"owner": owner, "now": now},
+        )
+    engine.dispose()
+
+    command.upgrade(cfg, "head")
+
+    engine = create_engine(f"sqlite:///{db_path}")
+    try:
+        with engine.connect() as conn:
+            merged = dict(
+                conn.execute(
+                    text("SELECT id, submitted_by FROM direction_libraries")
+                ).fetchall()
+            )
+            # 老存量的归属人回填；常态行不动
+            assert merged == {"lib-legacy": owner, "lib-normal": owner}
+            providers = {
+                r[0] for r in conn.execute(text("SELECT id FROM llm_providers")).fetchall()
+            }
+            assert providers == {"prov-global"}  # 私有 provider 已清
+            routes = {r[0] for r in conn.execute(text("SELECT id FROM model_routes")).fetchall()}
+            # 私有路由与挂在私有 provider 下的残路由都清掉，全局行保留
+            assert routes == {"route-global"}
+    finally:
+        engine.dispose()
+

--- a/src/backend/tests/test_paper_assets.py
+++ b/src/backend/tests/test_paper_assets.py
@@ -43,7 +43,6 @@ async def _library(session, *, user_id: uuid.UUID, public: bool = False) -> Dire
         statement="PDF asset test",
         is_public=public,
         submitted_by=user_id,
-        created_by=user_id,
     )
     session.add(library)
     await session.flush()

--- a/src/backend/tests/test_paper_content.py
+++ b/src/backend/tests/test_paper_content.py
@@ -42,7 +42,6 @@ async def _setup(client):
             name=f"content-{uuid.uuid4().hex[:8]}",
             statement="content test",
             submitted_by=user_id,
-            created_by=user_id,
         )
         paper = new_paper(title="Content paper", doi="10.1234/content")
         session.add_all([library, paper])

--- a/src/backend/tests/test_paper_merge.py
+++ b/src/backend/tests/test_paper_merge.py
@@ -106,11 +106,9 @@ async def test_merge_papers_full_repoint_with_conflicts(client):
         )
         # 另一用户只有 drop 行 → repoint
         session.add(PaperUserMeta(paper_id=drop.id, user_id=other_id, starred=True))
-        # 书架冲突：同课题两行（keep 行无快照）
+        # 书架冲突：同课题两行（keep 行无备注）
         session.add(TopicPaper(topic_id=pid, paper_id=keep.id))
-        session.add(
-            TopicPaper(topic_id=pid, paper_id=drop.id, wiki_snapshot="snap", note="why")
-        )
+        session.add(TopicPaper(topic_id=pid, paper_id=drop.id, note="why"))
         session.add(TopicPaper(topic_id=pid_b, paper_id=drop.id))  # 仅 drop → repoint
         # 软引用
         session.add(
@@ -202,7 +200,7 @@ async def test_merge_papers_full_repoint_with_conflicts(client):
             ).all()
         )
         assert chunk_count == 2
-        # 书架：keep 行补了快照与备注
+        # 书架：keep 行补了备注（wiki 快照列已退役删除，解读统一走 paper_wikis）
         shelf = (
             await session.execute(
                 select(TopicPaper).where(TopicPaper.paper_id == keep_id)
@@ -210,7 +208,6 @@ async def test_merge_papers_full_repoint_with_conflicts(client):
         ).scalars().all()
         assert len(shelf) == 2
         merged_row = next(t for t in shelf if t.topic_id == uuid.UUID(project_id))
-        assert merged_row.wiki_snapshot == "snap"
         assert merged_row.note == "why"
         # 软引用 repoint
         entry = (

--- a/src/backend/tests/test_scoped_paper_detail.py
+++ b/src/backend/tests/test_scoped_paper_detail.py
@@ -52,7 +52,7 @@ async def _new_paper(title="Shared paper") -> str:
         return str(paper.id)
 
 
-async def _add_membership(lib_id, paper_id, *, status, relevance, wiki=None) -> None:
+async def _add_membership(lib_id, paper_id, *, status, relevance) -> None:
     async with get_sessionmaker()() as session:
         session.add(
             LibraryPaper(
@@ -60,7 +60,6 @@ async def _add_membership(lib_id, paper_id, *, status, relevance, wiki=None) -> 
                 paper_id=uuid.UUID(str(paper_id)),
                 status=status,
                 relevance_score=relevance,
-                wiki_content=wiki,
             )
         )
         await session.commit()

--- a/src/backend/tests/test_source_libraries.py
+++ b/src/backend/tests/test_source_libraries.py
@@ -21,8 +21,8 @@ async def _hdr(client, email):
 
 
 async def _extra_library_with_paper(session, *, name, title, score=0.5):
-    """独立库 + 一篇库内论文（compiled + wiki），返回 (library, paper)。"""
-    lib = DirectionLibrary(name=name, created_by=None, project_id=None)
+    """独立库 + 一篇库内论文（compiled），返回 (library, paper)。"""
+    lib = DirectionLibrary(name=name, project_id=None)
     session.add(lib)
     await session.flush()
     paper = Paper(title=title)
@@ -34,7 +34,6 @@ async def _extra_library_with_paper(session, *, name, title, score=0.5):
             paper_id=paper.id,
             status="compiled",
             relevance_score=score,
-            wiki_content="# 解读",
         )
     )
     await session.flush()
@@ -86,17 +85,17 @@ async def test_list_papers_union_dedupes_shared_paper(client):
             relevance_score=0.6,
         )
         origin = await libraries_service.get_library_for_project(session, project_id)
-        extra = DirectionLibrary(name="第二库", created_by=None, project_id=None)
+        extra = DirectionLibrary(name="第二库", project_id=None)
         session.add(extra)
         await session.flush()
-        # 同一篇论文在第二个库也有成员行（且带 wiki，视角应优先它）
+        # 同一篇论文在第二个库也有成员行（各库独立打分；解读全平台一份，
+        # 不再随成员行走——wiki 快照列已随 #734 退役删除）
         session.add(
             LibraryPaper(
                 library_id=extra.id,
                 paper_id=paper.id,
                 status="compiled",
                 relevance_score=0.95,
-                wiki_content="# 更好的解读",
             )
         )
         await libraries_service.set_source_libraries(
@@ -110,7 +109,6 @@ async def test_list_papers_union_dedupes_shared_paper(client):
 
     assert total == 1
     assert items[0].paper.title == "Shared Paper"
-    assert items[0].membership.wiki_content == "# 更好的解读"  # 有 wiki 的视角优先
 
 
 async def test_empty_source_libraries_yields_empty_corpus(client):

--- a/src/backend/tests/test_voyage_engine.py
+++ b/src/backend/tests/test_voyage_engine.py
@@ -14,13 +14,21 @@ from tests.conftest import RecordingBus, register_and_login
 
 
 async def _setup_demo_voyage(client, goal="研究 LLM 推理加速的关键路径"):
+    """demo 任务 + 显式预算闸门 opt-in（#734 起 demo 的闸门与 experiment 同款：
+    默认直行，params.confirm_budget=True 才在第 2 步停下）。本文件的闸门链路
+    用例靠这个 opt-in 演示 Gate + engine 断点机制。"""
     token = await register_and_login(client)
     headers = {"Authorization": f"Bearer {token}"}
     resp = await client.post("/api/projects", json={"name": "voyage-proj"}, headers=headers)
     project_id = resp.json()["id"]
     resp = await client.post(
         "/api/voyages",
-        json={"kind": "demo", "project_id": project_id, "goal": goal},
+        json={
+            "kind": "demo",
+            "project_id": project_id,
+            "goal": goal,
+            "params": {"confirm_budget": True},
+        },
         headers=headers,
     )
     assert resp.status_code == 201, resp.text
@@ -100,6 +108,31 @@ async def test_demo_voyage_full_loop(client, queue_stub, bus_recorder):
         )
         assert usage_rows  # llm.complete + sextant 均记账
         assert {r.stage for r in usage_rows} <= {"navigator", "sextant", "default"}
+
+
+async def test_demo_voyage_default_runs_gateless(client, queue_stub, bus_recorder):
+    """预算闸门默认不拦（#626 的漏网处，#734 补齐）：不传 confirm_budget 的 demo
+    任务一口气跑到 done，全程不建任何 Gate。"""
+    token = await register_and_login(client, email="gateless@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = await client.post("/api/projects", json={"name": "gateless-proj"}, headers=headers)
+    project_id = resp.json()["id"]
+    resp = await client.post(
+        "/api/voyages",
+        json={"kind": "demo", "project_id": project_id, "goal": "默认直行"},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    run_id = resp.json()["id"]
+
+    engine, _bus = _make_engine()
+    await engine.run(uuid.UUID(run_id))
+
+    detail = (await client.get(f"/api/voyages/{run_id}", headers=headers)).json()
+    assert detail["status"] == "done"
+    assert [s["status"] for s in detail["steps"]] == ["passed", "passed", "passed"]
+    gates = (await client.get(f"/api/gates?project_id={project_id}", headers=headers)).json()
+    assert gates == []
 
 
 async def test_gate_reject_fails_voyage(client, queue_stub, bus_recorder):

--- a/src/backend/tests/test_wiki_ingest.py
+++ b/src/backend/tests/test_wiki_ingest.py
@@ -285,7 +285,7 @@ async def test_bootstrap_full_pipeline(client, queue_stub, wiki_mocks):
     assert resp.status_code == 201, resp.text
     voyage = resp.json()
     assert voyage["kind"] == "wiki_bootstrap"
-    assert voyage["budget"]["max_tokens"] == 10 * 20_000  # 预算从 knobs 派生
+    assert voyage["budget"]["max_tokens"] is None  # 预算默认无限（#734，有限=显式 opt-in）
     run_id = voyage["id"]
     assert ("run_voyage", (run_id,), {}) in queue_stub.jobs
 
@@ -877,10 +877,11 @@ def test_unlimited_knobs_and_budget_semantics():
     knobs = IngestKnobs(unlimited=True, max_papers=10, compile_top_n=5)
     assert knobs.unlimited is True and knobs.max_papers == 10 and knobs.compile_top_n == 5
 
-    # 预算：unlimited → max_tokens=None；默认模式派生公式不变
+    # 预算：unlimited → max_tokens=None；默认模式同样无预算（#734，隐式派生已移除）
     assert ingest_service.derive_budget(knobs) == {"max_tokens": None}
-    # 预算按「最大检索篇数」派生（上限而非开销；真正花钱的是编译那部分）
-    assert ingest_service.derive_budget(IngestKnobs()) == {"max_tokens": 150 * 20_000}
+    assert ingest_service.derive_budget(IngestKnobs()) == {"max_tokens": None}
+    # 有限预算是显式 opt-in
+    assert ingest_service.derive_budget(IngestKnobs(max_tokens=42)) == {"max_tokens": 42}
 
     # 引擎语义：max_tokens 为 None（falsy）不触发预算暂停，用量再大也不算超限
     run = VoyageRun(
@@ -1166,8 +1167,8 @@ async def test_manual_digest_falls_back_to_incremental_when_no_today_updates(cli
         assert run.checkpoint["params"].get("digest_only") is None
 
 
-async def test_standalone_library_ingest_budget_gate(client, queue_stub):
-    """独立库触发同样受库预算门约束：本月用尽 → 409 且不入队。"""
+async def test_standalone_library_ingest_ignores_monthly_budget(client, queue_stub):
+    """月度预算硬限额已移除（#734）：本月用超也照样启动、照常入队（上限仅展示）。"""
     token = await register_and_login(client, email="lib-budget@example.com")
     headers = {"Authorization": f"Bearer {token}"}
     library_id = await _create_standalone_library(
@@ -1190,9 +1191,9 @@ async def test_standalone_library_ingest_budget_gate(client, queue_stub):
         json={"mode": "bootstrap"},
         headers=headers,
     )
-    assert resp.status_code == 409, resp.text
-    assert resp.json()["detail"] == "LIBRARY_BUDGET_EXHAUSTED"
-    assert queue_stub.jobs == []
+    assert resp.status_code == 201, resp.text
+    voyage_id = resp.json()["id"]
+    assert ("run_voyage", (voyage_id,), {}) in queue_stub.jobs
 
 
 async def test_standalone_library_ingest_forbidden_for_stranger(client, queue_stub):
@@ -1431,11 +1432,12 @@ async def test_recent_paused_run_is_left_alone(client, queue_stub, wiki_mocks):
         assert await ingest_service.reclaim_stale_paused_ingests(session) == []
 
 
-async def test_over_budget_library_does_not_stop_the_others(client, queue_stub, wiki_mocks):
-    """一个库超预算不能拖垮当天其余的库。
+async def test_over_budget_library_still_syncs_daily(client, queue_stub, wiki_mocks):
+    """月度预算硬限额移除后（#734），超预算的库不再被每日扇出跳过。
 
-    老写法只捕获 IngestConflictError，LibraryBudgetExhaustedError 会穿透整个循环，
-    排在后面的库当天全都不同步，而且只在 arq 日志里留个异常，界面上完全无感。
+    历史坑（留档）：老写法里超预算抛 LibraryBudgetExhaustedError，一度会穿透整个
+    循环把排在后面的库当天全部拖停；后来改为逐库跳过；现在预算只作展示，两个库
+    都照常入队。
     """
     from worker.tasks import daily_wiki_ingest
 
@@ -1471,7 +1473,7 @@ async def test_over_budget_library_does_not_stop_the_others(client, queue_stub, 
     redis = _Redis()
     enqueued = await daily_wiki_ingest({"redis": redis})
 
-    # 超预算的那个被跳过，正常的那个照常入队
+    # 超「参考上限」的那个与正常的那个都照常入队（预算不再是闸门）
     async with get_sessionmaker()() as session:
         runs = {
             str(r.library_id): r
@@ -1484,8 +1486,8 @@ async def test_over_budget_library_does_not_stop_the_others(client, queue_stub, 
             .all()
         }
     assert healthy_id in runs, "正常的库必须仍被入队"
-    assert broke_id not in runs
-    assert len(redis.jobs) == len(enqueued) == 1
+    assert broke_id in runs, "超参考上限的库同样入队（#734 硬限额已移除）"
+    assert len(redis.jobs) == len(enqueued) == 2
 
 
 async def test_truncated_run_does_not_advance_the_watermark(client, queue_stub, wiki_mocks):

--- a/src/backend/tests/test_wire_ghost_fields.py
+++ b/src/backend/tests/test_wire_ghost_fields.py
@@ -1,0 +1,70 @@
+"""幽灵 wire 字段退役核证（#734）。
+
+这些字段曾因「golden transcript 逐字节比对，纯移除 PR 不许动 wire 形状」而以
+恒值苟活；本次随 golden 政策落地（docs/golden-policy.md）做了一次**有意重录**，
+从响应面上彻底移除。这里钉住「确实没了」，防止哪个序列化路径把它们带回来。
+"""
+
+from tests.conftest import INVITE_CODE
+
+
+async def test_user_responses_have_no_ghost_fields(client):
+    resp = await client.post(
+        "/api/auth/register",
+        json={
+            "email": "ghost-probe@example.com",
+            "password": "str0ng-password",
+            "display_name": "Ghost Probe",
+            "username": "ghostprobe",
+            "invite_code": INVITE_CODE,
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    # 恒 False 的自管轨残留（#621 删列后只剩 wire 兼容）
+    assert "llm_self_managed" not in body
+    # 单人产品没有「超管」概念：fastapi-users 基类字段不再随响应下发
+    assert "is_superuser" not in body
+
+    login = await client.post(
+        "/api/auth/jwt/login",
+        data={"username": "ghost-probe@example.com", "password": "str0ng-password"},
+    )
+    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    me = (await client.get("/api/users/me", headers=headers)).json()
+    assert "llm_self_managed" not in me
+    assert "is_superuser" not in me
+
+
+async def test_library_responses_have_no_ghost_fields(client):
+    resp = await client.post(
+        "/api/auth/register",
+        json={
+            "email": "ghost-lib@example.com",
+            "password": "str0ng-password",
+            "display_name": "Ghost Lib",
+            "username": "ghostlib",
+            "invite_code": INVITE_CODE,
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    login = await client.post(
+        "/api/auth/jwt/login",
+        data={"username": "ghost-lib@example.com", "password": "str0ng-password"},
+    )
+    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    created = await client.post(
+        "/api/libraries",
+        json={"name": "Ghost Library", "statement": "ghost-field retirement probe"},
+        headers=headers,
+    )
+    assert created.status_code == 201, created.text
+    detail = created.json()
+    # 审批流残留的恒值字段（#619 删列后只剩 wire 兼容）
+    assert "status" not in detail
+    assert "review_note" not in detail
+
+    listed = (await client.get("/api/libraries", headers=headers)).json()
+    mine = next(row for row in listed if row["id"] == detail["id"])
+    assert "status" not in mine
+    assert "review_note" not in mine

--- a/src/backend/worker/tasks.py
+++ b/src/backend/worker/tasks.py
@@ -204,9 +204,9 @@ async def daily_wiki_ingest(ctx: dict[str, Any]) -> list[str]:
 
     按库选而不是按课题选：独立库（project_id 为空）在按课题遍历的老写法里一个都进不来。
 
-    每个库单独兜异常。以前只捕获 IngestConflictError，于是一个库超月度预算抛
-    LibraryBudgetExhaustedError 就会打断整个循环，**排在它后面的库当天全都不同步**，
-    而且只在 arq 日志里留个异常，界面上完全无感。
+    每个库单独兜异常：一个库启动失败不能打断整个循环，否则排在它后面的库当天
+    全都不同步，而且只在 arq 日志里留个异常，界面上完全无感（月度预算硬限额
+    时代实测发生过；硬限额已随 #734 移除，这条纪律保留防其他异常复现同样的坑）。
 
     返回本次入队的 voyage id 列表（arq 结果可查）。
     """
@@ -238,9 +238,6 @@ async def daily_wiki_ingest(ctx: dict[str, Any]) -> list[str]:
                 )
             except ingest_service.IngestConflictError:
                 continue  # 并发保护：查表与建 run 之间有人手动触发
-            except ingest_service.LibraryBudgetExhaustedError:
-                logger.warning("daily ingest skipped, budget exhausted: %s", library.id)
-                continue
             except Exception:  # noqa: BLE001 — 单个库出问题不能拖垮当天其余的库
                 logger.exception("daily ingest failed to start for library %s", library.id)
                 await session.rollback()

--- a/src/frontend/src/features/wiki/GovernanceTab.tsx
+++ b/src/frontend/src/features/wiki/GovernanceTab.tsx
@@ -19,9 +19,10 @@ function fromDefinition(def: ProjectDefinition | null): InclusionValue {
 }
 
 /* ============================================================
-   文献库治理页签（P6）：
-   - 库信息与预算编辑（可管理者）；
-   - 本月 AI 用量进度（超限后同步任务暂停到下月）；
+   文献库治理页签：
+   - 库信息编辑（可管理者）；
+   - 本月 AI 用量展示（#734 起纯展示：预算硬限额已移除，不再暂停任务，
+     旧的「每月预算」输入随之撤下——参考上限仅在用量条上呈现）；
    - 重复论文候选与合并（不可撤销）。
    ============================================================ */
 
@@ -188,7 +189,7 @@ function DuplicatesCard({ libraryId }: { libraryId: string }) {
   );
 }
 
-/* —— 本月用量进度 —— */
+/* —— 本月用量展示（原「预算进度」；上限只是参考，不再是闸门） —— */
 
 function BudgetCard({ libraryId }: { libraryId: string }) {
   const { data: budget, isError } = useQuery({
@@ -226,8 +227,8 @@ function BudgetCard({ libraryId }: { libraryId: string }) {
             </span>
             <span className="muted" style={{ fontSize: 12 }}>
               {limited
-                ? `${tr('上限 ', 'Cap ')}${budget.monthly_budget!.toLocaleString()}`
-                : tr('未设上限', 'No cap')}
+                ? `${tr('参考上限 ', 'Reference cap ')}${budget.monthly_budget!.toLocaleString()}`
+                : tr('未设参考上限', 'No reference cap')}
             </span>
           </div>
           {limited && (
@@ -244,10 +245,10 @@ function BudgetCard({ libraryId }: { libraryId: string }) {
             </div>
           )}
           {budget.exhausted && (
-            <div style={{ color: 'var(--danger-tx)', fontSize: 13 }}>
+            <div style={{ color: 'var(--warn)', fontSize: 13 }}>
               {tr(
-                '本月预算已用尽：同步任务已暂停，下月自动恢复，或调高上限后再试。',
-                'Monthly budget used up: syncing is paused until next month, or raise the cap and retry.',
+                '本月用量已超过参考上限（仅提示，任务照常运行）。',
+                'Usage has passed the reference cap this month (informational only — tasks keep running).',
               )}
             </div>
           )}
@@ -257,7 +258,7 @@ function BudgetCard({ libraryId }: { libraryId: string }) {
   );
 }
 
-/* —— 库信息与预算 —— */
+/* —— 库信息 —— */
 
 function LibraryInfoCard({
   lib,
@@ -269,29 +270,26 @@ function LibraryInfoCard({
   const queryClient = useQueryClient();
   const [name, setName] = useState(lib.name);
   const [statement, setStatement] = useState(lib.statement ?? '');
-  const [budget, setBudget] = useState(lib.monthly_budget == null ? '' : String(lib.monthly_budget));
   const [isPublic, setIsPublic] = useState(lib.is_public);
 
   // 库切换 / 保存后回填
   useEffect(() => {
     setName(lib.name);
     setStatement(lib.statement ?? '');
-    setBudget(lib.monthly_budget == null ? '' : String(lib.monthly_budget));
     setIsPublic(lib.is_public);
   }, [lib]);
 
   const dirty =
     name !== lib.name ||
     statement !== (lib.statement ?? '') ||
-    isPublic !== lib.is_public ||
-    budget !== (lib.monthly_budget == null ? '' : String(lib.monthly_budget));
+    isPublic !== lib.is_public;
 
+  // 「每月预算」输入已撤（#734）：硬限额移除后它什么都不控制，留着只会误导。
   const save = useMutation({
     mutationFn: () =>
       api.updateLibrary(lib.id, {
         name: name.trim() || lib.name,
         statement: statement.trim() || null,
-        monthly_budget: budget.trim() === '' ? null : Math.max(0, Math.floor(Number(budget))),
         is_public: isPublic,
       }),
     onSuccess: () => {
@@ -303,8 +301,6 @@ function LibraryInfoCard({
     onError: () => toast(tr('保存失败，请重试', 'Save failed, please retry'), 'error'),
   });
 
-  const budgetInvalid = budget.trim() !== '' && (!Number.isFinite(Number(budget)) || Number(budget) < 0);
-
   return (
     <section className="card" style={{ padding: 18 }}>
       <div className="row" style={{ justifyContent: 'space-between', marginBottom: 12 }}>
@@ -312,7 +308,7 @@ function LibraryInfoCard({
         {!readOnly && (
           <button
             className="btn btn-primary sm"
-            disabled={!dirty || budgetInvalid || save.isPending || !name.trim()}
+            disabled={!dirty || save.isPending || !name.trim()}
             onClick={() => save.mutate()}
           >
             {save.isPending ? tr('保存中…', 'Saving…') : tr('保存', 'Save')}
@@ -353,27 +349,6 @@ function LibraryInfoCard({
               {tr('开启后本部署的所有用户都能浏览这个库', 'Everyone on this deployment can browse this library')}
             </span>
           </label>
-        )}
-        {!readOnly && (
-        <div className="row gap12" style={{ flexWrap: 'wrap' }}>
-          <label className="col gap6" style={{ minWidth: 220 }}>
-            <span className="muted" style={{ fontSize: 12 }}>
-              {tr('每月 AI 预算（token 数，留空 = 不限）', 'Monthly AI budget (tokens, empty = unlimited)')}
-            </span>
-            <input
-              className="input"
-              inputMode="numeric"
-              value={budget}
-              onChange={(e) => setBudget(e.target.value)}
-              placeholder={tr('如 2000000', 'e.g. 2000000')}
-            />
-          </label>
-        </div>
-        )}
-        {!readOnly && budgetInvalid && (
-          <div style={{ color: 'var(--danger-tx)', fontSize: 12 }}>
-            {tr('预算需为不小于 0 的数字', 'Budget must be a number ≥ 0')}
-          </div>
         )}
       </div>
     </section>

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -159,7 +159,6 @@ export interface UserRead {
   id: string;
   email: string;
   is_active: boolean;
-  is_superuser: boolean;
   is_verified: boolean;
   /** Polaris 扩展字段（后端可能暂未返回，均可选） */
   display_name?: string | null;
@@ -1411,7 +1410,7 @@ export interface DirectionLibrarySummary {
 
 export interface DirectionLibraryDetail extends DirectionLibrarySummary {
   cadence: string | null;
-  /** 每月 AI 预算（token 数；null = 不限） */
+  /** @deprecated 参考上限（#734 起硬限额已移除，仅治理页用量条展示；null = 未设） */
   monthly_budget: number | null;
   /** 收录配置全量（P8：库为权威源），供「收录设置」编辑 */
   definition: ProjectDefinition | null;
@@ -1619,17 +1618,18 @@ export interface PaperMergeResult {
   details: Record<string, unknown>;
 }
 
-/** 库预算面板：本月 AI 用量（token）与上限。 */
+/** 库用量面板：本月 AI 用量（token）。#734 起纯展示——上限只是参考，不再拦任务。 */
 export interface LibraryBudgetRead {
   /** 如 "2026-07" */
   month: string;
+  /** @deprecated 参考上限；null = 未设 */
   monthly_budget: number | null;
   prompt_tokens: number;
   completion_tokens: number;
   used_tokens: number;
-  /** 不限时为 null */
+  /** 未设参考上限时为 null */
   remaining_tokens: number | null;
-  /** true = 本月预算已用尽（同步任务会被拒绝启动） */
+  /** true = 本月用量已超参考上限（仅展示，任务照常运行） */
   exhausted: boolean;
 }
 
@@ -4197,12 +4197,13 @@ export const api = {
     rubric?: RubricDimension[];
     anchors?: AnchorPaper[];
     cadence?: string | null;
+    /** @deprecated 参考上限（#734 起不再拦任务），界面已不提供输入 */
     monthly_budget?: number | null;
     keywords?: KeywordSpec | null;
   }): Promise<DirectionLibraryDetail> {
     return requestJson<DirectionLibraryDetail>('/libraries', 'POST', input);
   },
-  /** 对某个方向库直接触发抓取（P9a；仅 status=active 且预算内，可管理者）。 */
+  /** 对某个方向库直接触发抓取（P9a；可管理者。#734 起预算不再拦截）。 */
   startLibraryIngest(id: string, input: IngestStart): Promise<VoyageRead> {
     return requestJson<VoyageRead>(`/libraries/${id}/ingest/run`, 'POST', input);
   },
@@ -4225,6 +4226,7 @@ export const api = {
       name?: string;
       statement?: string | null;
       cadence?: string | null;
+      /** @deprecated 参考上限（#734 起不再拦任务），界面已不提供输入 */
       monthly_budget?: number | null;
       rubric?: RubricDimension[] | null;
       anchors?: AnchorPaper[] | null;


### PR DESCRIPTION
Closes #734. Part of #715 (audit items 14+16 — ghost columns, leaked deferred mechanisms, and the missing golden re-record procedure that kept them alive).

**Golden policy, finally written down**: `docs/golden-policy.md` states when a re-record is legitimate (intentional wire change, human-reviewed diff) and how; `make golden-record` wraps the container recording. This PR performs the first sanctioned re-record — the diff, reviewed line by line, is exactly eight key deletions across the two chains (`is_superuser`/`llm_self_managed` from register, `status`/`review_note` from create_library) and nothing else; replay verified stable twice.

**Deferred-mechanism leaks closed**: ingest budgets default to unlimited (the implicit per-paper token derivation is gone; a finite budget is an explicit new knob), the library `monthly_budget` hard stop is removed entirely (the endpoint becomes display-only usage; the frontend drops the budget input and the "tasks will pause" claim), and `demo_plan`'s hardcoded compute-budget gate becomes `confirm_budget`-gated like everything else — the last defaults-on interception found by the audit.

**Column hygiene** (migration `351c324f4f6b` on `b737c1a2d3e4`, full downgrade + roundtrip + a seeded-data test): `created_by` merges into `submitted_by` (kept name — identical write history, 30+ read sites, golden wire) and is dropped; the self-described retired wiki-snapshot columns across four tables are dropped; legacy self-managed rows in the LLM tables are purged (the runtime WHERE guard stays as belt-and-braces); `llm_usage.conversation_id` is marked deprecated for next-cycle removal; `is_superuser` leaves the API response face; stale index comments now name their real consumers.

Verification: full suite **1736 passed, 0 failed**; survived three main advances (#738/#739/#740) with re-verified intersections each time; frontend tsc/build/vitest 180 green; ruff at baseline.