### PR TITLE
chore: converge the skill systems, step one (#741)

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -91,15 +91,21 @@ On the **/skills** page (Library tab):
 
 ### The skill market
 
-The Market tab is deployment-internal sharing:
+The Market tab is local to this installation — the market lives on the device (or server) running
+Polaris, and nothing is distributed anywhere else. To share a skill across installations, use
+export/import (`polaris-skill@1` JSON packs).
 
-- **Publish to market** submits your skill's current version for review; an admin approves or
-  rejects it.
-- Approved listings can be **browsed, searched, and sorted** (newest or most-installed), **installed
-  to my skills** (installing copies the published version as your own editable skill), and **rated**
-  with a comment.
+- **Publish to market** lists your skill's current version immediately — there is no review step.
+  On a single-user desktop install, publishing freezes a version as an installable snapshot; on a
+  multi-account server, other accounts can install it too.
+- Listings can be **browsed, searched, and sorted** (newest or most-installed) and **installed to
+  my skills** (installing copies the published version as your own editable skill).
 - A listing always points at the exact version that was published — later edits to your skill do not
-  silently change what others install.
+  silently change what others install. The publisher can delist at any time.
+
+Note that plugins have a separate market of their own under **Settings → Plugins** — see
+[the convergence plan](#three-skill-systems-and-the-convergence-plan) below for how the two will
+eventually merge.
 
 ## Assistant skills (Buddy)
 
@@ -158,6 +164,32 @@ restriction never widens the existing DSH tool surface.
 
 See [Polaris for DeepSeek Harness](https://github.com/ZJU-REAL/Polaris/tree/main/integrations/deepseek-harness)
 for installation, token scopes, failure behavior, and configuration.
+
+## Three skill systems and the convergence plan
+
+Polaris currently carries three mechanisms that all answer "packaged agent behavior", accumulated
+in the order they were needed. This section states which is which and where they are going, so
+nobody has to reverse-engineer the plan from the code.
+
+| System | Storage | Status |
+| --- | --- | --- |
+| **v1 task skills** (this page's "Task skills": kinds, target stages, versions, the /skills market) | `skills` / `skill_versions` / `user_skills` / `skill_listings` | **Frozen.** Serves existing data and enablements only; no new feature writes these tables. |
+| **v2 assistant skills** (`SKILL.md`, progressive disclosure) | `agent_skills` / `agent_skill_files` | **Current main path** for new skill-shaped behavior. |
+| **Plugin market** (Settings → Plugins, desktop host) | installed plugin bundles + market index | **The destination.** Phase 4 of the plugin-market plan adds skills as a plugin `kind`, at which point market distribution converges here. |
+
+The convergence path, in order:
+
+1. **Stop new v1 writes** — done. The last feature still writing v1 rows (the interdisciplinary
+   research workflow's stage guidance) now lives in its own `guidance_documents` table; the v1
+   review-flow residue (`skill_listings.status/decided_by/comment`) is dropped, and a listing is
+   simply live until delisted.
+2. **v1 stays read-write for its own UI but frozen in scope** — the /skills library, market, and
+   enablements keep working for existing users; no new kinds, targets, or built-ins are added.
+3. **Skills become a plugin kind** (plugin-market plan, phase 4) — packaging, distribution, and
+   installation of skills move to the plugin market; the v2 `SKILL.md` shape is the payload format.
+4. **v1 retirement** is a separate, later project: migrate remaining v1 enablements onto their
+   successors, then drop the v1 tables. It will get its own migration plan and data move; nothing
+   in the current phase deletes user data.
 
 ## Tips and limits
 

--- a/src/backend/alembic/versions/a5b9c3d7e1f2_skill_system_convergence_step1.py
+++ b/src/backend/alembic/versions/a5b9c3d7e1f2_skill_system_convergence_step1.py
@@ -1,0 +1,143 @@
+"""技能三套并行收敛第一步（#741）：止血 + 删审核残列
+
+1. 新表 guidance_documents：跨学科工作流指引搬离已冻结的 v1 技能表。
+   存量搬运：v1 builtin 行 interdisciplinary-research-workflow 的**每个版本**
+   拷成一行（id 沿用 skill_versions.id，保留可追溯性），v1 行标记归档
+   （保守起见不删——downgrade 时解除归档即可整体还原）。
+2. skill_listings 删 status/decided_by/comment：#592 起发布即上架，审核状态机
+   已无写入口。「在架」改由 delisted_at 表达：为空 = 在架。存量映射：
+   status != 'approved' 的行（历史上的 pending/rejected/delisted）一律视为
+   已下架，delisted_at 取 updated_at（下架动作会刷新它，近似准确）。
+
+Revision ID: a5b9c3d7e1f2
+Revises: 351c324f4f6b
+Create Date: 2026-09-08
+"""
+
+import json
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "a5b9c3d7e1f2"
+down_revision: str | None = "351c324f4f6b"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+GUIDANCE_SLUG = "interdisciplinary-research-workflow"
+
+
+def _loads(value):  # sqlite 存 JSON 文本，pg JSON 列可能已是结构
+    if value is None or isinstance(value, (dict, list)):
+        return value or {}
+    return json.loads(value)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "guidance_documents",
+        sa.Column("slug", sa.String(length=64), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("body", sa.Text(), nullable=False),
+        sa.Column("targets", sa.JSON(), nullable=True),
+        sa.Column("steps", sa.JSON(), nullable=True),
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("slug", "version", name="uq_guidance_documents_slug_ver"),
+    )
+    op.create_index(
+        op.f("ix_guidance_documents_slug"), "guidance_documents", ["slug"], unique=False
+    )
+
+    conn = op.get_bind()
+    skill = conn.execute(
+        sa.text(
+            "SELECT id, name FROM skills WHERE slug = :slug AND scope = 'builtin'"
+        ),
+        {"slug": GUIDANCE_SLUG},
+    ).first()
+    if skill is not None:
+        versions = conn.execute(
+            sa.text(
+                "SELECT id, version, body, manifest, created_at, updated_at "
+                "FROM skill_versions WHERE skill_id = :sid ORDER BY version"
+            ),
+            {"sid": skill.id},
+        ).fetchall()
+        for row in versions:
+            manifest = _loads(row.manifest)
+            conn.execute(
+                sa.text(
+                    "INSERT INTO guidance_documents "
+                    "(id, slug, version, name, body, targets, steps, created_at, updated_at) "
+                    "VALUES (:id, :slug, :version, :name, :body, :targets, :steps, :ca, :ua)"
+                ),
+                {
+                    # id 沿用 skill_versions.id：存量 checkpoint 里的 skill_version_id
+                    # 仍能对回这行（str()：sqlite 存 32 位 hex 原样、pg 接受带横线串）
+                    "id": str(row.id),
+                    "slug": GUIDANCE_SLUG,
+                    "version": row.version,
+                    "name": skill.name,
+                    "body": row.body,
+                    "targets": json.dumps(manifest.get("targets") or [], ensure_ascii=False),
+                    "steps": json.dumps(manifest.get("steps") or [], ensure_ascii=False),
+                    "ca": row.created_at,
+                    "ua": row.updated_at,
+                },
+            )
+        # v1 行归档而非删除（保守；用户若在 user_skills 里手工挂过它也不至于悬空）
+        conn.execute(
+            sa.text("UPDATE skills SET is_archived = :yes WHERE id = :sid"),
+            {"yes": True, "sid": skill.id},
+        )
+
+    # 审核残列：先把「非在架」映射到 delisted_at，再删三列
+    op.add_column(
+        "skill_listings", sa.Column("delisted_at", sa.DateTime(timezone=True), nullable=True)
+    )
+    conn.execute(
+        sa.text(
+            "UPDATE skill_listings SET delisted_at = updated_at WHERE status != 'approved'"
+        )
+    )
+    with op.batch_alter_table("skill_listings") as batch:
+        batch.drop_index(op.f("ix_skill_listings_status"))
+        batch.drop_column("comment")
+        batch.drop_column("decided_by")
+        batch.drop_column("status")
+
+
+def downgrade() -> None:
+    # 状态机按 f5a6b7c8d9e0 的形状回来；decided_by/comment 数据不可恢复（落 NULL——
+    # 与「审核流从未真正用过」的现实一致）
+    with op.batch_alter_table("skill_listings") as batch:
+        batch.add_column(
+            sa.Column("status", sa.String(length=16), nullable=False, server_default="approved")
+        )
+        batch.add_column(sa.Column("decided_by", sa.Uuid(), nullable=True))
+        batch.add_column(sa.Column("comment", sa.Text(), nullable=True))
+    conn = op.get_bind()
+    conn.execute(
+        sa.text("UPDATE skill_listings SET status = 'delisted' WHERE delisted_at IS NOT NULL")
+    )
+    with op.batch_alter_table("skill_listings") as batch:
+        batch.drop_column("delisted_at")
+        batch.create_index(op.f("ix_skill_listings_status"), ["status"], unique=False)
+
+    # v1 行解除归档（内容从未离开 skills/skill_versions，直接还原）。
+    # 迁移后在 guidance_documents 里新增的版本（若有）不搬回 v1——builtin 技能在
+    # v1 本就只能由种子/迁移写入，回退丢弃新增版本是明确的取舍。
+    conn.execute(
+        sa.text(
+            "UPDATE skills SET is_archived = :no WHERE slug = :slug AND scope = 'builtin'"
+        ),
+        {"no": False, "slug": GUIDANCE_SLUG},
+    )
+    op.drop_index(op.f("ix_guidance_documents_slug"), table_name="guidance_documents")
+    op.drop_table("guidance_documents")

--- a/src/backend/app/api/market.py
+++ b/src/backend/app/api/market.py
@@ -1,7 +1,7 @@
 """技能市场路由（docs/task-system.md §7（原 skill-system.md §4.3））。
 
 - 发布：POST /skills/{id}/publish（技能主人）→ 直接上架
-- 浏览/详情/安装：登录即可；下架：发布者或管理员
+- 浏览/详情/安装：登录即可；下架：仅发布者本人
 """
 
 import uuid
@@ -67,8 +67,8 @@ async def list_market(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_active_user),
 ) -> list[SkillListingRead]:
-    """市场列表（仅已上架条目）。"""
-    listings = await market_service.list_market(session, status="approved", q=q, sort=sort)
+    """市场列表（仅在架条目）。"""
+    listings = await market_service.list_market(session, q=q, sort=sort)
     return [
         SkillListingRead(**d) for d in await market_service.annotate_listings(session, listings)
     ]
@@ -101,7 +101,7 @@ async def install_listing(
     try:
         skill = await market_service.install_listing(session, listing, user_id=user.id)
     except market_service.ListingStateError as e:
-        raise HTTPException(status.HTTP_409_CONFLICT, detail="LISTING_NOT_APPROVED") from e
+        raise HTTPException(status.HTTP_409_CONFLICT, detail="LISTING_DELISTED") from e
     version = await skills_service.latest_version(session, skill.id)
     from app.schemas.skill import SkillVersionRead
 

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -18,6 +18,7 @@ from app.mcp import mcp_router
 from app.services.builtin_agent_skills import ensure_builtin_agent_skills
 from app.services.crdt_rooms import reset_crdt_rooms
 from app.services.crdt_stream import get_crdt_stream_subscriber, stop_crdt_stream_subscriber
+from app.services.interdisciplinary_workflows import ensure_guidance_documents
 from app.services.skills import ensure_builtin_skills
 
 logger = logging.getLogger(__name__)
@@ -39,6 +40,7 @@ async def lifespan(app: FastAPI):
         async with get_sessionmaker()() as session:
             await ensure_builtin_skills(session)
             await ensure_builtin_agent_skills(session)
+            await ensure_guidance_documents(session)
     except Exception:  # noqa: BLE001
         logger.warning("builtin skill seeding failed (migrations pending?)", exc_info=True)
     # AI 起草流式镜像订阅（worker 发布 → 写活跃 CRDT 房间；连不上 redis 自动放弃）

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -12,6 +12,7 @@ from app.models.email_code import EmailVerificationCode
 from app.models.evidence import PaperEvidenceAnchor
 from app.models.experiment import Experiment, ExperimentRun
 from app.models.gate import Gate
+from app.models.guidance_document import GuidanceDocument
 from app.models.hypothesis import HypothesisNode
 from app.models.idea import Idea
 from app.models.integration_token import IntegrationToken
@@ -88,6 +89,7 @@ __all__ = [
     "Experiment",
     "ExperimentRun",
     "Gate",
+    "GuidanceDocument",
     "HypothesisNode",
     "Idea",
     "InterdisciplinaryResearchProfile",

--- a/src/backend/app/models/guidance_document.py
+++ b/src/backend/app/models/guidance_document.py
@@ -1,0 +1,36 @@
+"""平台内置指引文档（#741：技能三套并行收敛第一步）。
+
+跨学科工作流的指引原先寄存在 v1 技能表（skills/skill_versions 的 builtin 行）里——
+那是唯一一处**新功能代码仍在写 v1** 的地方。v1 已冻结（仅服务存量用户配置），
+而 v2 agent_skills 的形状也装不下它：v2 是「模型自己判断要不要加载」的渐进披露，
+这里需要的是「引擎在固定注入点无条件全文注入」——两者的消费模型南辕北辙，
+硬塞进 v2 只会让这份文档出现在 Buddy 的技能目录里（错误的地方）。
+
+所以给它一张自己的小表：按 (slug, version) 只增不改（同 v1 SkillVersion 的
+不可变语义），最新版本 = version 最大的一行。任务运行时把内容整体冻进
+checkpoint，断点恢复与回放不再依赖本表。
+"""
+
+from typing import Any
+
+from sqlalchemy import Integer, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.db import Base
+from app.models.base import JSONVariant, TimestampMixin, UUIDPrimaryKeyMixin
+
+
+class GuidanceDocument(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "guidance_documents"
+    __table_args__ = (
+        UniqueConstraint("slug", "version", name="uq_guidance_documents_slug_ver"),
+    )
+
+    slug: Mapped[str] = mapped_column(String(64), index=True, nullable=False)
+    version: Mapped[int] = mapped_column(Integer, nullable=False)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    body: Mapped[str] = mapped_column(Text, nullable=False)
+    #: 注入点列表（含 navigator.free_plan 的虚拟注入点）
+    targets: Mapped[list[str] | None] = mapped_column(JSONVariant)
+    #: workflow 步骤模板（navigator.free_plan 消费；纯 guidance 文档为 NULL）
+    steps: Mapped[list[dict[str, Any]] | None] = mapped_column(JSONVariant)

--- a/src/backend/app/models/skill.py
+++ b/src/backend/app/models/skill.py
@@ -1,17 +1,30 @@
-"""技能系统（docs/task-system.md §7（原 skill-system.md））：可版本化、可装配的判断性任务指令包。
+"""技能系统 v1（docs/task-system.md §7（原 skill-system.md））：可版本化、可装配的判断性任务指令包。
+
+**已冻结（#741）**：本套只服务存量数据与既有功能，新功能一律不再写这几张表
+（收敛计划见 docs/skills.md「三套系统与收敛计划」）。跨学科工作流的指引
+已迁至 guidance_documents。
 
 - Skill：技能主体（builtin 内置只读 / user 个人）
 - SkillVersion：不可变版本（manifest JSON + markdown body），只增不改；
   「当前版本」= 该技能 version 最大的一行，不另存指针
 - UserSkill：全局启用记录：用户 × 技能 × 注入点，可 pin 版本与配置
   （技能不绑定课题，启用后对该用户所有新任务生效）
-- SkillListing：技能市场条目（发布指向具体版本，管理员审核后可安装）
+- SkillListing：技能市场条目（发布即上架，指向具体版本）
 """
 
 import uuid
+from datetime import datetime
 from typing import Any
 
-from sqlalchemy import Boolean, ForeignKey, Integer, String, Text, UniqueConstraint
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.db import Base
@@ -101,16 +114,13 @@ class SkillListing(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     )
     summary: Mapped[str | None] = mapped_column(Text)
     tags: Mapped[list[str] | None] = mapped_column(JSONVariant)
-    # pending | approved | rejected | delisted（管理员审核）
-    status: Mapped[str] = mapped_column(String(16), default="pending", index=True, nullable=False)
     install_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     published_by: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("users.id", ondelete="SET NULL")
     )
-    decided_by: Mapped[uuid.UUID | None] = mapped_column(
-        ForeignKey("users.id", ondelete="SET NULL")
-    )
-    comment: Mapped[str | None] = mapped_column(Text)  # 审核意见
+    # 发布即上架（#592 起没有审核流）：在架 = delisted_at 为空；下架只记时间戳。
+    # 原 status/decided_by/comment 审核残列已删（#741）。
+    delisted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
     skill: Mapped[Skill] = relationship()
     version: Mapped[SkillVersion] = relationship()

--- a/src/backend/app/schemas/skill.py
+++ b/src/backend/app/schemas/skill.py
@@ -241,10 +241,10 @@ class SkillListingRead(BaseModel):
     skill_version_id: uuid.UUID
     summary: str | None
     tags: list[str] | None
-    status: str  # pending | approved | rejected | delisted
+    # 在架 = delisted_at 为空（发布即上架，#741 起没有审核状态机）
+    delisted_at: datetime | None
     install_count: int
     published_by: uuid.UUID | None
-    comment: str | None
     created_at: datetime
     # 联表补充（service 填充）
     skill: SkillRead | None = None

--- a/src/backend/app/services/builtin_skills.py
+++ b/src/backend/app/services/builtin_skills.py
@@ -3,6 +3,10 @@
 scope=builtin 只读，slug 全局唯一；用户可在技能库「复制为我的技能」后修改。
 启动时由 skills.ensure_builtin_skills() 按 slug 幂等插入（已存在则跳过，
 不覆盖——避免踩掉管理员手工修正；内容大改时应换新 slug 或出数据迁移）。
+
+v1 技能系统已冻结（#741，收敛计划见 docs/skills.md）：本清单只维护存量，
+不再新增条目。跨学科工作流的指引已迁去 guidance_documents
+（services/interdisciplinary_workflows.py），不在此列。
 """
 
 from typing import Any
@@ -310,88 +314,5 @@ BUILTIN_SKILLS: list[dict[str, Any]] = [
 - 数据处理与训练解耦：预处理产物落盘并带版本号，训练脚本只读产物。
 - 脚本必须支持 --smoke 模式：小数据/少步数跑通全流程后立即退出。
         - 失败要响亮：不吞异常，断言输入形状与数值范围。""",
-    },
-    {
-        "slug": "interdisciplinary-research-workflow",
-        "kind": "workflow",
-        "name": "跨学科研究工作流",
-        "name_en": "Interdisciplinary Research Workflow",
-        "description": "跨学科课题从范围确认、分学科检索到证据驱动的想法、实验、写作和评审",
-        "targets": [
-            "navigator.free_plan",
-            "wiki.score_relevance",
-            "forge.generate",
-            "experiment.plan",
-            "writing.section",
-            "writing.related_work",
-            "review.referees",
-            "present.outline",
-        ],
-        "steps": [
-            {
-                "title": "确认交叉研究范围",
-                "action": "llm.complete",
-                "params": {
-                    "stage": "planning",
-                    "prompt": (
-                        "读取课题已确认的主学科、关联学科、核心问题和证据边界。"
-                        "如果任一字段缺失，先提出最少的澄清问题，不要自行补全学科。"
-                    ),
-                },
-                "acceptance": "输出主学科、关联学科、核心问题和证据边界，并标明待确认项",
-                "requires_gate": None,
-            },
-            {
-                "title": "分学科检索并合并证据",
-                "action": "llm.complete",
-                "params": {
-                    "stage": "librarian",
-                    "prompt": (
-                        "先按主学科与各关联学科分别检索，再用统一 DOI/标题身份合并去重。"
-                        "每篇文献保留来源学科、贡献类型、相关性理由和句子级证据，"
-                        "不能把共享关键词当作跨学科关联。"
-                    ),
-                },
-                "acceptance": "输出分学科证据表，并有跨学科合并后的去重文献清单",
-                "requires_gate": None,
-            },
-            {
-                "title": "生成可证伪研究想法",
-                "action": "llm.complete",
-                "params": {
-                    "stage": "ideation",
-                    "prompt": (
-                        "基于已确认范围和分学科证据，生成有明确机制的交叉想法。"
-                        "每个想法必须说明主学科承担的核心问题、关联学科提供的不可替代方法、"
-                        "最小可行实验、风险和可证伪判据。"
-                    ),
-                },
-                "acceptance": "每个想法都有机制差异、最小实验和证据引用",
-                "requires_gate": None,
-            },
-            {
-                "title": "贯穿实验、写作和评审",
-                "action": "llm.complete",
-                "params": {
-                    "stage": "research",
-                    "prompt": (
-                        "后续实验计划、论文写作、PPT提纲和评审均携带同一交叉范围版本。"
-                        "所有引用采用文献编号+句子编号，找不到句子时退回段落或论文级，"
-                        "不得把某一学科的指标冒充另一学科的结论。"
-                    ),
-                },
-                "acceptance": "产物标注交叉研究上下文版本并保留可回溯引用",
-                "requires_gate": None,
-            },
-        ],
-        "body": (
-            "跨学科研究必须先确认范围资产，再进入后续流程。\n\n"
-            "- 主学科负责定义核心科学问题；关联学科必须提供不可替代的方法、数据或评价标准。\n"
-            "- 检索阶段按学科分桶以避免中文/英文术语和领域评价标准互相污染；合并阶段按 DOI、"
-            "外部标识和规范化标题去重。\n"
-            "- 任何 AI 结论都要携带交叉范围版本和证据锚点；句子级找不到时按既定规则回退，"
-            "不能静默改成无来源的摘要推断。\n"
-            "- 常规课题不注入本技能，不改变原有的单学科检索和写作流程。"
-        ),
     },
 ]

--- a/src/backend/app/services/interdisciplinary_workflows.py
+++ b/src/backend/app/services/interdisciplinary_workflows.py
@@ -6,9 +6,9 @@ from typing import Any
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.guidance_document import GuidanceDocument
 from app.models.interdisciplinary import InterdisciplinaryResearchProfileVersion
 from app.models.project import Project
-from app.models.skill import Skill, SkillVersion
 
 SKILL_SLUG = "interdisciplinary-research-workflow"
 
@@ -38,6 +38,117 @@ _PLACEHOLDERS = (
     "未确定",
     "未知",
 )
+
+# ---- 内置指引文档种子（#741：从 v1 BUILTIN_SKILLS 原文迁入，正文逐字节不动）----
+# 原先这份内容作为 v1 builtin 技能种子活在 skills/skill_versions 里——v1 已冻结，
+# 这里是唯一还在写它的新功能。现在它落在 guidance_documents（见模型 docstring
+# 里对「为什么不进 v2」的论证），注入行为不变。
+
+GUIDANCE_SEED: dict[str, Any] = {
+    "slug": SKILL_SLUG,
+    "name": "跨学科研究工作流",
+    "targets": [
+        "navigator.free_plan",
+        "wiki.score_relevance",
+        "forge.generate",
+        "experiment.plan",
+        "writing.section",
+        "writing.related_work",
+        "review.referees",
+        "present.outline",
+    ],
+    "steps": [
+        {
+            "title": "确认交叉研究范围",
+            "action": "llm.complete",
+            "params": {
+                "stage": "planning",
+                "prompt": (
+                    "读取课题已确认的主学科、关联学科、核心问题和证据边界。"
+                    "如果任一字段缺失，先提出最少的澄清问题，不要自行补全学科。"
+                ),
+            },
+            "acceptance": "输出主学科、关联学科、核心问题和证据边界，并标明待确认项",
+            "requires_gate": None,
+        },
+        {
+            "title": "分学科检索并合并证据",
+            "action": "llm.complete",
+            "params": {
+                "stage": "librarian",
+                "prompt": (
+                    "先按主学科与各关联学科分别检索，再用统一 DOI/标题身份合并去重。"
+                    "每篇文献保留来源学科、贡献类型、相关性理由和句子级证据，"
+                    "不能把共享关键词当作跨学科关联。"
+                ),
+            },
+            "acceptance": "输出分学科证据表，并有跨学科合并后的去重文献清单",
+            "requires_gate": None,
+        },
+        {
+            "title": "生成可证伪研究想法",
+            "action": "llm.complete",
+            "params": {
+                "stage": "ideation",
+                "prompt": (
+                    "基于已确认范围和分学科证据，生成有明确机制的交叉想法。"
+                    "每个想法必须说明主学科承担的核心问题、关联学科提供的不可替代方法、"
+                    "最小可行实验、风险和可证伪判据。"
+                ),
+            },
+            "acceptance": "每个想法都有机制差异、最小实验和证据引用",
+            "requires_gate": None,
+        },
+        {
+            "title": "贯穿实验、写作和评审",
+            "action": "llm.complete",
+            "params": {
+                "stage": "research",
+                "prompt": (
+                    "后续实验计划、论文写作、PPT提纲和评审均携带同一交叉范围版本。"
+                    "所有引用采用文献编号+句子编号，找不到句子时退回段落或论文级，"
+                    "不得把某一学科的指标冒充另一学科的结论。"
+                ),
+            },
+            "acceptance": "产物标注交叉研究上下文版本并保留可回溯引用",
+            "requires_gate": None,
+        },
+    ],
+    "body": (
+        "跨学科研究必须先确认范围资产，再进入后续流程。\n\n"
+        "- 主学科负责定义核心科学问题；关联学科必须提供不可替代的方法、数据或评价标准。\n"
+        "- 检索阶段按学科分桶以避免中文/英文术语和领域评价标准互相污染；合并阶段按 DOI、"
+        "外部标识和规范化标题去重。\n"
+        "- 任何 AI 结论都要携带交叉范围版本和证据锚点；句子级找不到时按既定规则回退，"
+        "不能静默改成无来源的摘要推断。\n"
+        "- 常规课题不注入本技能，不改变原有的单学科检索和写作流程。"
+    ),
+}
+
+
+async def ensure_guidance_documents(session: AsyncSession) -> int:
+    """按 slug 幂等插入内置指引文档 v1，返回新插入数量。已有任意版本则不动。
+
+    只在 slug 完全缺席时种入：存量部署由迁移把 v1 技能行搬过来（可能已有更高
+    版本），种子不能把它盖回 v1。
+    """
+    exists = await session.scalar(
+        select(GuidanceDocument.id).where(GuidanceDocument.slug == GUIDANCE_SEED["slug"]).limit(1)
+    )
+    if exists is not None:
+        return 0
+    session.add(
+        GuidanceDocument(
+            slug=GUIDANCE_SEED["slug"],
+            version=1,
+            name=GUIDANCE_SEED["name"],
+            body=GUIDANCE_SEED["body"],
+            targets=list(GUIDANCE_SEED["targets"]),
+            steps=[dict(step) for step in GUIDANCE_SEED["steps"]],
+        )
+    )
+    await session.commit()
+    return 1
 
 
 class InterdisciplinaryScopeInvalidError(ValueError):
@@ -69,29 +180,19 @@ async def _latest_confirmed_profile(
     )
 
 
-async def _builtin_skill_version(session: AsyncSession) -> tuple[Skill, SkillVersion] | None:
-    skill = await session.scalar(
-        select(Skill).where(
-            Skill.slug == SKILL_SLUG,
-            Skill.scope == "builtin",
-            Skill.is_archived.is_(False),
-        )
-    )
-    if skill is None:
-        return None
-    version = await session.scalar(
-        select(SkillVersion)
-        .where(SkillVersion.skill_id == skill.id)
-        .order_by(SkillVersion.version.desc())
+async def _latest_guidance_document(session: AsyncSession) -> GuidanceDocument | None:
+    return await session.scalar(
+        select(GuidanceDocument)
+        .where(GuidanceDocument.slug == SKILL_SLUG)
+        .order_by(GuidanceDocument.version.desc())
         .limit(1)
     )
-    return (skill, version) if version is not None else None
 
 
 async def snapshot_for_project(
     session: AsyncSession, project_id: uuid.UUID | None
 ) -> dict[str, Any] | None:
-    """Return the latest confirmed profile and current built-in Skill as one immutable payload."""
+    """Return the latest confirmed profile and guidance document as one immutable payload."""
 
     if project_id is None:
         return None
@@ -102,23 +203,27 @@ async def snapshot_for_project(
     if profile is None:
         return None
     validate_disciplines(profile.primary_domain, list(profile.related_domains or []))
-    skill_pair = await _builtin_skill_version(session)
-    if skill_pair is None:
+    document = await _latest_guidance_document(session)
+    if document is None:
         raise RuntimeError("INTERDISCIPLINARY_WORKFLOW_SKILL_MISSING")
-    skill, version = skill_pair
     return {
         "schema_version": 1,
         "project_id": str(project_id),
         "profile_id": str(profile.profile_id),
         "profile_version_id": str(profile.id),
         "profile_version": profile.version,
-        "skill_id": str(skill.id),
-        "skill_version_id": str(version.id),
-        "skill_version": version.version,
-        "skill_slug": skill.slug,
-        "skill_name": skill.name,
-        "skill_body": version.body,
-        "skill_manifest": dict(version.manifest or {}),
+        # 指引文档搬离 v1 后没有「技能/版本」两级——每个版本就是一行。两个键都指
+        # 同一行，键名保留是为了 checkpoint schema_version=1 不破（存量 run 回放）。
+        "skill_id": str(document.id),
+        "skill_version_id": str(document.id),
+        "skill_version": document.version,
+        "skill_slug": document.slug,
+        "skill_name": document.name,
+        "skill_body": document.body,
+        "skill_manifest": {
+            "targets": list(document.targets or []),
+            "steps": [dict(step) for step in document.steps or []],
+        },
         "research_scope": profile.research_scope,
         "core_questions": list(profile.core_questions or []),
         "primary_domain": profile.primary_domain,

--- a/src/backend/app/services/skill_market.py
+++ b/src/backend/app/services/skill_market.py
@@ -1,11 +1,15 @@
 """技能市场业务逻辑（docs/task-system.md §7（原 skill-system.md §4.3）；不 import fastapi）。
 
-部署内共享：发布即上架（approved）→ 浏览/安装。
+这是**本部署（这台设备或这台服务器）内**的市场：发布即上架 → 浏览/安装，没有审核流，
+也没有任何跨部署的分发（跨部署分享走技能导出/导入 JSON 包）。单用户桌面档位下，
+「发布」的意义是把某个版本定格成可安装的快照；多账号服务器档位下其他账号也能装。
+在架与否只看 delisted_at：为空 = 在架（#741 起不再有 status 状态机）。
 listing 永远指向发布时的具体 SkillVersion；安装 = 拷贝该版本为安装者的 user 技能。
 """
 
 import uuid
 from collections.abc import Sequence
+from datetime import UTC, datetime
 from typing import Any
 
 from sqlalchemy import select
@@ -16,15 +20,13 @@ from app.models.skill import Skill, SkillListing, SkillVersion
 from app.schemas.skill import SkillPublishRequest
 from app.services import skills as skills_service
 
-ACTIVE_STATUSES = ("approved",)
-
 
 class ListingConflictError(Exception):
-    """同一技能已有待审/在架条目。"""
+    """同一技能已有在架条目。"""
 
 
 class ListingStateError(Exception):
-    """条目状态不允许该操作（如安装非 approved 条目）。"""
+    """条目状态不允许该操作（如安装已下架条目）。"""
 
 
 class NotOwnerError(Exception):
@@ -41,14 +43,13 @@ async def publish_skill(
     if version is None:
         raise ListingStateError(f"{skill.slug} has no version")
     stmt = select(SkillListing.id).where(
-        SkillListing.skill_id == skill.id, SkillListing.status.in_(ACTIVE_STATUSES)
+        SkillListing.skill_id == skill.id, SkillListing.delisted_at.is_(None)
     )
     if (await session.execute(stmt)).first() is not None:
         raise ListingConflictError(skill.slug)
     listing = SkillListing(
         skill_id=skill.id,
         skill_version_id=version.id,
-        status="approved",
         summary=data.summary or skill.description,
         tags=data.tags or None,
         published_by=user_id,
@@ -70,10 +71,9 @@ def _base_read(listing: SkillListing) -> dict[str, Any]:
         skill_version_id=listing.skill_version_id,
         summary=listing.summary,
         tags=listing.tags,
-        status=listing.status,
+        delisted_at=listing.delisted_at,
         install_count=listing.install_count,
         published_by=listing.published_by,
-        comment=listing.comment,
         created_at=listing.created_at,
         skill=SkillRead.model_validate(listing.skill) if listing.skill is not None else None,
         version=listing.version.version if listing.version is not None else None,
@@ -97,11 +97,10 @@ def _listing_query():
 async def list_market(
     session: AsyncSession,
     *,
-    status: str = "approved",
     q: str | None = None,
     sort: str = "-created_at",
 ) -> Sequence[SkillListing]:
-    stmt = _listing_query().where(SkillListing.status == status)
+    stmt = _listing_query().where(SkillListing.delisted_at.is_(None))
     if q:
         pattern = f"%{q}%"
         stmt = stmt.join(Skill, SkillListing.skill_id == Skill.id).where(
@@ -125,7 +124,7 @@ async def delist(
     # admin 全局下架旁路已随 role 移除（#614）：只有发布者本人能下架
     if listing.published_by != user_id:
         raise NotOwnerError(str(listing.id))
-    listing.status = "delisted"
+    listing.delisted_at = datetime.now(UTC)
     await session.commit()
     await session.refresh(listing)
     return listing
@@ -135,8 +134,8 @@ async def install_listing(
     session: AsyncSession, listing: SkillListing, *, user_id: uuid.UUID
 ) -> Skill:
     """安装 = 拷贝发布版本为安装者的 user 技能（slug 冲突自动加后缀）。"""
-    if listing.status != "approved":
-        raise ListingStateError(listing.status)
+    if listing.delisted_at is not None:
+        raise ListingStateError("delisted")
     version = await session.get(SkillVersion, listing.skill_version_id)
     src_skill = listing.skill or await session.get(Skill, listing.skill_id)
     if version is None or src_skill is None:

--- a/src/backend/tests/fixtures/interdisciplinary_injection_golden.json
+++ b/src/backend/tests/fixtures/interdisciplinary_injection_golden.json
@@ -1,0 +1,187 @@
+{
+  "context_fixed": {
+    "core_questions": [
+      "Which visual observables preserve mechanical meaning?"
+    ],
+    "evidence_balance": {
+      "Computer vision": 0.25,
+      "Structural engineering": 0.5
+    },
+    "evidence_boundary": "Use only validated structural and visual evidence.",
+    "primary_domain": "Structural engineering",
+    "profile_id": "22222222-2222-2222-2222-222222222222",
+    "profile_version": 3,
+    "profile_version_id": "33333333-3333-3333-3333-333333333333",
+    "project_id": "11111111-1111-1111-1111-111111111111",
+    "query_matrix": [
+      {
+        "discipline": "Structural engineering",
+        "query": "impact response",
+        "role": "primary"
+      },
+      {
+        "discipline": "Computer vision",
+        "query": "video segmentation",
+        "role": "associated"
+      }
+    ],
+    "related_domains": [
+      "Computer vision",
+      "Data science"
+    ],
+    "research_scope": "Couple structural mechanics and visual measurement.",
+    "schema_version": 1,
+    "skill_body": "跨学科研究必须先确认范围资产，再进入后续流程。\n\n- 主学科负责定义核心科学问题；关联学科必须提供不可替代的方法、数据或评价标准。\n- 检索阶段按学科分桶以避免中文/英文术语和领域评价标准互相污染；合并阶段按 DOI、外部标识和规范化标题去重。\n- 任何 AI 结论都要携带交叉范围版本和证据锚点；句子级找不到时按既定规则回退，不能静默改成无来源的摘要推断。\n- 常规课题不注入本技能，不改变原有的单学科检索和写作流程。",
+    "skill_manifest": {
+      "config_schema": null,
+      "model_hint": null,
+      "output_contract": null,
+      "personas": [],
+      "steps": [
+        {
+          "acceptance": "输出主学科、关联学科、核心问题和证据边界，并标明待确认项",
+          "action": "llm.complete",
+          "params": {
+            "prompt": "读取课题已确认的主学科、关联学科、核心问题和证据边界。如果任一字段缺失，先提出最少的澄清问题，不要自行补全学科。",
+            "stage": "planning"
+          },
+          "requires_gate": null,
+          "title": "确认交叉研究范围"
+        },
+        {
+          "acceptance": "输出分学科证据表，并有跨学科合并后的去重文献清单",
+          "action": "llm.complete",
+          "params": {
+            "prompt": "先按主学科与各关联学科分别检索，再用统一 DOI/标题身份合并去重。每篇文献保留来源学科、贡献类型、相关性理由和句子级证据，不能把共享关键词当作跨学科关联。",
+            "stage": "librarian"
+          },
+          "requires_gate": null,
+          "title": "分学科检索并合并证据"
+        },
+        {
+          "acceptance": "每个想法都有机制差异、最小实验和证据引用",
+          "action": "llm.complete",
+          "params": {
+            "prompt": "基于已确认范围和分学科证据，生成有明确机制的交叉想法。每个想法必须说明主学科承担的核心问题、关联学科提供的不可替代方法、最小可行实验、风险和可证伪判据。",
+            "stage": "ideation"
+          },
+          "requires_gate": null,
+          "title": "生成可证伪研究想法"
+        },
+        {
+          "acceptance": "产物标注交叉研究上下文版本并保留可回溯引用",
+          "action": "llm.complete",
+          "params": {
+            "prompt": "后续实验计划、论文写作、PPT提纲和评审均携带同一交叉范围版本。所有引用采用文献编号+句子编号，找不到句子时退回段落或论文级，不得把某一学科的指标冒充另一学科的结论。",
+            "stage": "research"
+          },
+          "requires_gate": null,
+          "title": "贯穿实验、写作和评审"
+        }
+      ],
+      "targets": [
+        "navigator.free_plan",
+        "wiki.score_relevance",
+        "forge.generate",
+        "experiment.plan",
+        "writing.section",
+        "writing.related_work",
+        "review.referees",
+        "present.outline"
+      ],
+      "variables": []
+    },
+    "skill_name": "跨学科研究工作流",
+    "skill_slug": "interdisciplinary-research-workflow",
+    "skill_version": 1,
+    "validation_conditions": [
+      "Compare against independent impact experiments."
+    ]
+  },
+  "guidance_entries": [
+    {
+      "body": "Immutable interdisciplinary research context for this run:\n- Profile version: 3 (33333333-3333-3333-3333-333333333333)\n- Primary discipline: Structural engineering\n- Associated disciplines: Computer vision, Data science\n- Research scope: Couple structural mechanics and visual measurement.\n- Core bridge questions:\n- Which visual observables preserve mechanical meaning?\n- Evidence boundary: Use only validated structural and visual evidence.\n- Validation conditions:\n- Compare against independent impact experiments.\n- Evidence balance: Structural engineering: 0.5, Computer vision: 0.25\n\n- Discipline query channels and terms:\n- [primary] Structural engineering: impact response\n- [associated] Computer vision: video segmentation\n\nApply these constraints throughout the output. Keep the primary discipline responsible for the scientific question, identify the non-substitutable contribution of each associated discipline, preserve discipline-specific evidence standards, and state whether every bridge claim has balanced supporting evidence.\n\nPinned workflow Skill v1:\n跨学科研究必须先确认范围资产，再进入后续流程。\n\n- 主学科负责定义核心科学问题；关联学科必须提供不可替代的方法、数据或评价标准。\n- 检索阶段按学科分桶以避免中文/英文术语和领域评价标准互相污染；合并阶段按 DOI、外部标识和规范化标题去重。\n- 任何 AI 结论都要携带交叉范围版本和证据锚点；句子级找不到时按既定规则回退，不能静默改成无来源的摘要推断。\n- 常规课题不注入本技能，不改变原有的单学科检索和写作流程。",
+      "config": {
+        "profile_version_id": "33333333-3333-3333-3333-333333333333"
+      },
+      "kind": "guidance",
+      "name": "跨学科研究工作流",
+      "output_contract": null,
+      "personas": [],
+      "slug": "interdisciplinary-research-workflow",
+      "steps": [],
+      "version": 1
+    }
+  ],
+  "navigator_entries": [
+    {
+      "body": "跨学科研究必须先确认范围资产，再进入后续流程。\n\n- 主学科负责定义核心科学问题；关联学科必须提供不可替代的方法、数据或评价标准。\n- 检索阶段按学科分桶以避免中文/英文术语和领域评价标准互相污染；合并阶段按 DOI、外部标识和规范化标题去重。\n- 任何 AI 结论都要携带交叉范围版本和证据锚点；句子级找不到时按既定规则回退，不能静默改成无来源的摘要推断。\n- 常规课题不注入本技能，不改变原有的单学科检索和写作流程。",
+      "config": {
+        "profile_version_id": "33333333-3333-3333-3333-333333333333"
+      },
+      "kind": "workflow",
+      "name": "跨学科研究工作流",
+      "output_contract": null,
+      "personas": [],
+      "slug": "interdisciplinary-research-workflow",
+      "steps": [
+        {
+          "acceptance": "输出主学科、关联学科、核心问题和证据边界，并标明待确认项",
+          "action": "llm.complete",
+          "params": {
+            "prompt": "读取课题已确认的主学科、关联学科、核心问题和证据边界。如果任一字段缺失，先提出最少的澄清问题，不要自行补全学科。",
+            "stage": "planning"
+          },
+          "requires_gate": null,
+          "title": "确认交叉研究范围"
+        },
+        {
+          "acceptance": "输出分学科证据表，并有跨学科合并后的去重文献清单",
+          "action": "llm.complete",
+          "params": {
+            "prompt": "先按主学科与各关联学科分别检索，再用统一 DOI/标题身份合并去重。每篇文献保留来源学科、贡献类型、相关性理由和句子级证据，不能把共享关键词当作跨学科关联。",
+            "stage": "librarian"
+          },
+          "requires_gate": null,
+          "title": "分学科检索并合并证据"
+        },
+        {
+          "acceptance": "每个想法都有机制差异、最小实验和证据引用",
+          "action": "llm.complete",
+          "params": {
+            "prompt": "基于已确认范围和分学科证据，生成有明确机制的交叉想法。每个想法必须说明主学科承担的核心问题、关联学科提供的不可替代方法、最小可行实验、风险和可证伪判据。",
+            "stage": "ideation"
+          },
+          "requires_gate": null,
+          "title": "生成可证伪研究想法"
+        },
+        {
+          "acceptance": "产物标注交叉研究上下文版本并保留可回溯引用",
+          "action": "llm.complete",
+          "params": {
+            "prompt": "后续实验计划、论文写作、PPT提纲和评审均携带同一交叉范围版本。所有引用采用文献编号+句子编号，找不到句子时退回段落或论文级，不得把某一学科的指标冒充另一学科的结论。",
+            "stage": "research"
+          },
+          "requires_gate": null,
+          "title": "贯穿实验、写作和评审"
+        }
+      ],
+      "version": 1
+    }
+  ],
+  "rendered": {
+    "experiment.plan": "\n\n【项目技能指引】以下技能由用户启用，作为本环节的补充判断标准；它们不改变上文规定的输出格式：\n### 技能：跨学科研究工作流（interdisciplinary-research-workflow v1）\nImmutable interdisciplinary research context for this run:\n- Profile version: 3 (33333333-3333-3333-3333-333333333333)\n- Primary discipline: Structural engineering\n- Associated disciplines: Computer vision, Data science\n- Research scope: Couple structural mechanics and visual measurement.\n- Core bridge questions:\n- Which visual observables preserve mechanical meaning?\n- Evidence boundary: Use only validated structural and visual evidence.\n- Validation conditions:\n- Compare against independent impact experiments.\n- Evidence balance: Structural engineering: 0.5, Computer vision: 0.25\n\n- Discipline query channels and terms:\n- [primary] Structural engineering: impact response\n- [associated] Computer vision: video segmentation\n\nApply these constraints throughout the output. Keep the primary discipline responsible for the scientific question, identify the non-substitutable contribution of each associated discipline, preserve discipline-specific evidence standards, and state whether every bridge claim has balanced supporting evidence.\n\nPinned workflow Skill v1:\n跨学科研究必须先确认范围资产，再进入后续流程。\n\n- 主学科负责定义核心科学问题；关联学科必须提供不可替代的方法、数据或评价标准。\n- 检索阶段按学科分桶以避免中文/英文术语和领域评价标准互相污染；合并阶段按 DOI、外部标识和规范化标题去重。\n- 任何 AI 结论都要携带交叉范围版本和证据锚点；句子级找不到时按既定规则回退，不能静默改成无来源的摘要推断。\n- 常规课题不注入本技能，不改变原有的单学科检索和写作流程。\n（本项目配置：profile_version_id=33333333-3333-3333-3333-333333333333）",
+    "forge.gap_analysis": "\n\n【项目技能指引】以下技能由用户启用，作为本环节的补充判断标准；它们不改变上文规定的输出格式：\n### 技能：跨学科研究工作流（interdisciplinary-research-workflow v1）\nImmutable interdisciplinary research context for this run:\n- Profile version: 3 (33333333-3333-3333-3333-333333333333)\n- Primary discipline: Structural engineering\n- Associated disciplines: Computer vision, Data science\n- Research scope: Couple structural mechanics and visual measurement.\n- Core bridge questions:\n- Which visual observables preserve mechanical meaning?\n- Evidence boundary: Use only validated structural and visual evidence.\n- Validation conditions:\n- Compare against independent impact experiments.\n- Evidence balance: Structural engineering: 0.5, Computer vision: 0.25\n\n- Discipline query channels and terms:\n- [primary] Structural engineering: impact response\n- [associated] Computer vision: video segmentation\n\nApply these constraints throughout the output. Keep the primary discipline responsible for the scientific question, identify the non-substitutable contribution of each associated discipline, preserve discipline-specific evidence standards, and state whether every bridge claim has balanced supporting evidence.\n\nPinned workflow Skill v1:\n跨学科研究必须先确认范围资产，再进入后续流程。\n\n- 主学科负责定义核心科学问题；关联学科必须提供不可替代的方法、数据或评价标准。\n- 检索阶段按学科分桶以避免中文/英文术语和领域评价标准互相污染；合并阶段按 DOI、外部标识和规范化标题去重。\n- 任何 AI 结论都要携带交叉范围版本和证据锚点；句子级找不到时按既定规则回退，不能静默改成无来源的摘要推断。\n- 常规课题不注入本技能，不改变原有的单学科检索和写作流程。\n（本项目配置：profile_version_id=33333333-3333-3333-3333-333333333333）",
+    "forge.generate": "\n\n【项目技能指引】以下技能由用户启用，作为本环节的补充判断标准；它们不改变上文规定的输出格式：\n### 技能：跨学科研究工作流（interdisciplinary-research-workflow v1）\nImmutable interdisciplinary research context for this run:\n- Profile version: 3 (33333333-3333-3333-3333-333333333333)\n- Primary discipline: Structural engineering\n- Associated disciplines: Computer vision, Data science\n- Research scope: Couple structural mechanics and visual measurement.\n- Core bridge questions:\n- Which visual observables preserve mechanical meaning?\n- Evidence boundary: Use only validated structural and visual evidence.\n- Validation conditions:\n- Compare against independent impact experiments.\n- Evidence balance: Structural engineering: 0.5, Computer vision: 0.25\n\n- Discipline query channels and terms:\n- [primary] Structural engineering: impact response\n- [associated] Computer vision: video segmentation\n\nApply these constraints throughout the output. Keep the primary discipline responsible for the scientific question, identify the non-substitutable contribution of each associated discipline, preserve discipline-specific evidence standards, and state whether every bridge claim has balanced supporting evidence.\n\nPinned workflow Skill v1:\n跨学科研究必须先确认范围资产，再进入后续流程。\n\n- 主学科负责定义核心科学问题；关联学科必须提供不可替代的方法、数据或评价标准。\n- 检索阶段按学科分桶以避免中文/英文术语和领域评价标准互相污染；合并阶段按 DOI、外部标识和规范化标题去重。\n- 任何 AI 结论都要携带交叉范围版本和证据锚点；句子级找不到时按既定规则回退，不能静默改成无来源的摘要推断。\n- 常规课题不注入本技能，不改变原有的单学科检索和写作流程。\n（本项目配置：profile_version_id=33333333-3333-3333-3333-333333333333）",
+    "forge.score": "\n\n【项目技能指引】以下技能由用户启用，作为本环节的补充判断标准；它们不改变上文规定的输出格式：\n### 技能：跨学科研究工作流（interdisciplinary-research-workflow v1）\nImmutable interdisciplinary research context for this run:\n- Profile version: 3 (33333333-3333-3333-3333-333333333333)\n- Primary discipline: Structural engineering\n- Associated disciplines: Computer vision, Data science\n- Research scope: Couple structural mechanics and visual measurement.\n- Core bridge questions:\n- Which visual observables preserve mechanical meaning?\n- Evidence boundary: Use only validated structural and visual evidence.\n- Validation conditions:\n- Compare against independent impact experiments.\n- Evidence balance: Structural engineering: 0.5, Computer vision: 0.25\n\n- Discipline query channels and terms:\n- [primary] Structural engineering: impact response\n- [associated] Computer vision: video segmentation\n\nApply these constraints throughout the output. Keep the primary discipline responsible for the scientific question, identify the non-substitutable contribution of each associated discipline, preserve discipline-specific evidence standards, and state whether every bridge claim has balanced supporting evidence.\n\nPinned workflow Skill v1:\n跨学科研究必须先确认范围资产，再进入后续流程。\n\n- 主学科负责定义核心科学问题；关联学科必须提供不可替代的方法、数据或评价标准。\n- 检索阶段按学科分桶以避免中文/英文术语和领域评价标准互相污染；合并阶段按 DOI、外部标识和规范化标题去重。\n- 任何 AI 结论都要携带交叉范围版本和证据锚点；句子级找不到时按既定规则回退，不能静默改成无来源的摘要推断。\n- 常规课题不注入本技能，不改变原有的单学科检索和写作流程。\n（本项目配置：profile_version_id=33333333-3333-3333-3333-333333333333）",
+    "present.outline": "\n\n【项目技能指引】以下技能由用户启用，作为本环节的补充判断标准；它们不改变上文规定的输出格式：\n### 技能：跨学科研究工作流（interdisciplinary-research-workflow v1）\nImmutable interdisciplinary research context for this run:\n- Profile version: 3 (33333333-3333-3333-3333-333333333333)\n- Primary discipline: Structural engineering\n- Associated disciplines: Computer vision, Data science\n- Research scope: Couple structural mechanics and visual measurement.\n- Core bridge questions:\n- Which visual observables preserve mechanical meaning?\n- Evidence boundary: Use only validated structural and visual evidence.\n- Validation conditions:\n- Compare against independent impact experiments.\n- Evidence balance: Structural engineering: 0.5, Computer vision: 0.25\n\n- Discipline query channels and terms:\n- [primary] Structural engineering: impact response\n- [associated] Computer vision: video segmentation\n\nApply these constraints throughout the output. Keep the primary discipline responsible for the scientific question, identify the non-substitutable contribution of each associated discipline, preserve discipline-specific evidence standards, and state whether every bridge claim has balanced supporting evidence.\n\nPinned workflow Skill v1:\n跨学科研究必须先确认范围资产，再进入后续流程。\n\n- 主学科负责定义核心科学问题；关联学科必须提供不可替代的方法、数据或评价标准。\n- 检索阶段按学科分桶以避免中文/英文术语和领域评价标准互相污染；合并阶段按 DOI、外部标识和规范化标题去重。\n- 任何 AI 结论都要携带交叉范围版本和证据锚点；句子级找不到时按既定规则回退，不能静默改成无来源的摘要推断。\n- 常规课题不注入本技能，不改变原有的单学科检索和写作流程。\n（本项目配置：profile_version_id=33333333-3333-3333-3333-333333333333）",
+    "present.slides": "\n\n【项目技能指引】以下技能由用户启用，作为本环节的补充判断标准；它们不改变上文规定的输出格式：\n### 技能：跨学科研究工作流（interdisciplinary-research-workflow v1）\nImmutable interdisciplinary research context for this run:\n- Profile version: 3 (33333333-3333-3333-3333-333333333333)\n- Primary discipline: Structural engineering\n- Associated disciplines: Computer vision, Data science\n- Research scope: Couple structural mechanics and visual measurement.\n- Core bridge questions:\n- Which visual observables preserve mechanical meaning?\n- Evidence boundary: Use only validated structural and visual evidence.\n- Validation conditions:\n- Compare against independent impact experiments.\n- Evidence balance: Structural engineering: 0.5, Computer vision: 0.25\n\n- Discipline query channels and terms:\n- [primary] Structural engineering: impact response\n- [associated] Computer vision: video segmentation\n\nApply these constraints throughout the output. Keep the primary discipline responsible for the scientific question, identify the non-substitutable contribution of each associated discipline, preserve discipline-specific evidence standards, and state whether every bridge claim has balanced supporting evidence.\n\nPinned workflow Skill v1:\n跨学科研究必须先确认范围资产，再进入后续流程。\n\n- 主学科负责定义核心科学问题；关联学科必须提供不可替代的方法、数据或评价标准。\n- 检索阶段按学科分桶以避免中文/英文术语和领域评价标准互相污染；合并阶段按 DOI、外部标识和规范化标题去重。\n- 任何 AI 结论都要携带交叉范围版本和证据锚点；句子级找不到时按既定规则回退，不能静默改成无来源的摘要推断。\n- 常规课题不注入本技能，不改变原有的单学科检索和写作流程。\n（本项目配置：profile_version_id=33333333-3333-3333-3333-333333333333）",
+    "review.referees": "\n\n【项目技能指引】以下技能由用户启用，作为本环节的补充判断标准；它们不改变上文规定的输出格式：\n### 技能：跨学科研究工作流（interdisciplinary-research-workflow v1）\nImmutable interdisciplinary research context for this run:\n- Profile version: 3 (33333333-3333-3333-3333-333333333333)\n- Primary discipline: Structural engineering\n- Associated disciplines: Computer vision, Data science\n- Research scope: Couple structural mechanics and visual measurement.\n- Core bridge questions:\n- Which visual observables preserve mechanical meaning?\n- Evidence boundary: Use only validated structural and visual evidence.\n- Validation conditions:\n- Compare against independent impact experiments.\n- Evidence balance: Structural engineering: 0.5, Computer vision: 0.25\n\n- Discipline query channels and terms:\n- [primary] Structural engineering: impact response\n- [associated] Computer vision: video segmentation\n\nApply these constraints throughout the output. Keep the primary discipline responsible for the scientific question, identify the non-substitutable contribution of each associated discipline, preserve discipline-specific evidence standards, and state whether every bridge claim has balanced supporting evidence.\n\nPinned workflow Skill v1:\n跨学科研究必须先确认范围资产，再进入后续流程。\n\n- 主学科负责定义核心科学问题；关联学科必须提供不可替代的方法、数据或评价标准。\n- 检索阶段按学科分桶以避免中文/英文术语和领域评价标准互相污染；合并阶段按 DOI、外部标识和规范化标题去重。\n- 任何 AI 结论都要携带交叉范围版本和证据锚点；句子级找不到时按既定规则回退，不能静默改成无来源的摘要推断。\n- 常规课题不注入本技能，不改变原有的单学科检索和写作流程。\n（本项目配置：profile_version_id=33333333-3333-3333-3333-333333333333）",
+    "wiki.compile": "\n\n【项目技能指引】以下技能由用户启用，作为本环节的补充判断标准；它们不改变上文规定的输出格式：\n### 技能：跨学科研究工作流（interdisciplinary-research-workflow v1）\nImmutable interdisciplinary research context for this run:\n- Profile version: 3 (33333333-3333-3333-3333-333333333333)\n- Primary discipline: Structural engineering\n- Associated disciplines: Computer vision, Data science\n- Research scope: Couple structural mechanics and visual measurement.\n- Core bridge questions:\n- Which visual observables preserve mechanical meaning?\n- Evidence boundary: Use only validated structural and visual evidence.\n- Validation conditions:\n- Compare against independent impact experiments.\n- Evidence balance: Structural engineering: 0.5, Computer vision: 0.25\n\n- Discipline query channels and terms:\n- [primary] Structural engineering: impact response\n- [associated] Computer vision: video segmentation\n\nApply these constraints throughout the output. Keep the primary discipline responsible for the scientific question, identify the non-substitutable contribution of each associated discipline, preserve discipline-specific evidence standards, and state whether every bridge claim has balanced supporting evidence.\n\nPinned workflow Skill v1:\n跨学科研究必须先确认范围资产，再进入后续流程。\n\n- 主学科负责定义核心科学问题；关联学科必须提供不可替代的方法、数据或评价标准。\n- 检索阶段按学科分桶以避免中文/英文术语和领域评价标准互相污染；合并阶段按 DOI、外部标识和规范化标题去重。\n- 任何 AI 结论都要携带交叉范围版本和证据锚点；句子级找不到时按既定规则回退，不能静默改成无来源的摘要推断。\n- 常规课题不注入本技能，不改变原有的单学科检索和写作流程。\n（本项目配置：profile_version_id=33333333-3333-3333-3333-333333333333）",
+    "wiki.daily_digest": "\n\n【项目技能指引】以下技能由用户启用，作为本环节的补充判断标准；它们不改变上文规定的输出格式：\n### 技能：跨学科研究工作流（interdisciplinary-research-workflow v1）\nImmutable interdisciplinary research context for this run:\n- Profile version: 3 (33333333-3333-3333-3333-333333333333)\n- Primary discipline: Structural engineering\n- Associated disciplines: Computer vision, Data science\n- Research scope: Couple structural mechanics and visual measurement.\n- Core bridge questions:\n- Which visual observables preserve mechanical meaning?\n- Evidence boundary: Use only validated structural and visual evidence.\n- Validation conditions:\n- Compare against independent impact experiments.\n- Evidence balance: Structural engineering: 0.5, Computer vision: 0.25\n\n- Discipline query channels and terms:\n- [primary] Structural engineering: impact response\n- [associated] Computer vision: video segmentation\n\nApply these constraints throughout the output. Keep the primary discipline responsible for the scientific question, identify the non-substitutable contribution of each associated discipline, preserve discipline-specific evidence standards, and state whether every bridge claim has balanced supporting evidence.\n\nPinned workflow Skill v1:\n跨学科研究必须先确认范围资产，再进入后续流程。\n\n- 主学科负责定义核心科学问题；关联学科必须提供不可替代的方法、数据或评价标准。\n- 检索阶段按学科分桶以避免中文/英文术语和领域评价标准互相污染；合并阶段按 DOI、外部标识和规范化标题去重。\n- 任何 AI 结论都要携带交叉范围版本和证据锚点；句子级找不到时按既定规则回退，不能静默改成无来源的摘要推断。\n- 常规课题不注入本技能，不改变原有的单学科检索和写作流程。\n（本项目配置：profile_version_id=33333333-3333-3333-3333-333333333333）",
+    "wiki.score_relevance": "\n\n【项目技能指引】以下技能由用户启用，作为本环节的补充判断标准；它们不改变上文规定的输出格式：\n### 技能：跨学科研究工作流（interdisciplinary-research-workflow v1）\nImmutable interdisciplinary research context for this run:\n- Profile version: 3 (33333333-3333-3333-3333-333333333333)\n- Primary discipline: Structural engineering\n- Associated disciplines: Computer vision, Data science\n- Research scope: Couple structural mechanics and visual measurement.\n- Core bridge questions:\n- Which visual observables preserve mechanical meaning?\n- Evidence boundary: Use only validated structural and visual evidence.\n- Validation conditions:\n- Compare against independent impact experiments.\n- Evidence balance: Structural engineering: 0.5, Computer vision: 0.25\n\n- Discipline query channels and terms:\n- [primary] Structural engineering: impact response\n- [associated] Computer vision: video segmentation\n\nApply these constraints throughout the output. Keep the primary discipline responsible for the scientific question, identify the non-substitutable contribution of each associated discipline, preserve discipline-specific evidence standards, and state whether every bridge claim has balanced supporting evidence.\n\nPinned workflow Skill v1:\n跨学科研究必须先确认范围资产，再进入后续流程。\n\n- 主学科负责定义核心科学问题；关联学科必须提供不可替代的方法、数据或评价标准。\n- 检索阶段按学科分桶以避免中文/英文术语和领域评价标准互相污染；合并阶段按 DOI、外部标识和规范化标题去重。\n- 任何 AI 结论都要携带交叉范围版本和证据锚点；句子级找不到时按既定规则回退，不能静默改成无来源的摘要推断。\n- 常规课题不注入本技能，不改变原有的单学科检索和写作流程。\n（本项目配置：profile_version_id=33333333-3333-3333-3333-333333333333）",
+    "wiki.trend_synthesize": "\n\n【项目技能指引】以下技能由用户启用，作为本环节的补充判断标准；它们不改变上文规定的输出格式：\n### 技能：跨学科研究工作流（interdisciplinary-research-workflow v1）\nImmutable interdisciplinary research context for this run:\n- Profile version: 3 (33333333-3333-3333-3333-333333333333)\n- Primary discipline: Structural engineering\n- Associated disciplines: Computer vision, Data science\n- Research scope: Couple structural mechanics and visual measurement.\n- Core bridge questions:\n- Which visual observables preserve mechanical meaning?\n- Evidence boundary: Use only validated structural and visual evidence.\n- Validation conditions:\n- Compare against independent impact experiments.\n- Evidence balance: Structural engineering: 0.5, Computer vision: 0.25\n\n- Discipline query channels and terms:\n- [primary] Structural engineering: impact response\n- [associated] Computer vision: video segmentation\n\nApply these constraints throughout the output. Keep the primary discipline responsible for the scientific question, identify the non-substitutable contribution of each associated discipline, preserve discipline-specific evidence standards, and state whether every bridge claim has balanced supporting evidence.\n\nPinned workflow Skill v1:\n跨学科研究必须先确认范围资产，再进入后续流程。\n\n- 主学科负责定义核心科学问题；关联学科必须提供不可替代的方法、数据或评价标准。\n- 检索阶段按学科分桶以避免中文/英文术语和领域评价标准互相污染；合并阶段按 DOI、外部标识和规范化标题去重。\n- 任何 AI 结论都要携带交叉范围版本和证据锚点；句子级找不到时按既定规则回退，不能静默改成无来源的摘要推断。\n- 常规课题不注入本技能，不改变原有的单学科检索和写作流程。\n（本项目配置：profile_version_id=33333333-3333-3333-3333-333333333333）",
+    "writing.related_work": "\n\n【项目技能指引】以下技能由用户启用，作为本环节的补充判断标准；它们不改变上文规定的输出格式：\n### 技能：跨学科研究工作流（interdisciplinary-research-workflow v1）\nImmutable interdisciplinary research context for this run:\n- Profile version: 3 (33333333-3333-3333-3333-333333333333)\n- Primary discipline: Structural engineering\n- Associated disciplines: Computer vision, Data science\n- Research scope: Couple structural mechanics and visual measurement.\n- Core bridge questions:\n- Which visual observables preserve mechanical meaning?\n- Evidence boundary: Use only validated structural and visual evidence.\n- Validation conditions:\n- Compare against independent impact experiments.\n- Evidence balance: Structural engineering: 0.5, Computer vision: 0.25\n\n- Discipline query channels and terms:\n- [primary] Structural engineering: impact response\n- [associated] Computer vision: video segmentation\n\nApply these constraints throughout the output. Keep the primary discipline responsible for the scientific question, identify the non-substitutable contribution of each associated discipline, preserve discipline-specific evidence standards, and state whether every bridge claim has balanced supporting evidence.\n\nPinned workflow Skill v1:\n跨学科研究必须先确认范围资产，再进入后续流程。\n\n- 主学科负责定义核心科学问题；关联学科必须提供不可替代的方法、数据或评价标准。\n- 检索阶段按学科分桶以避免中文/英文术语和领域评价标准互相污染；合并阶段按 DOI、外部标识和规范化标题去重。\n- 任何 AI 结论都要携带交叉范围版本和证据锚点；句子级找不到时按既定规则回退，不能静默改成无来源的摘要推断。\n- 常规课题不注入本技能，不改变原有的单学科检索和写作流程。\n（本项目配置：profile_version_id=33333333-3333-3333-3333-333333333333）",
+    "writing.section": "\n\n【项目技能指引】以下技能由用户启用，作为本环节的补充判断标准；它们不改变上文规定的输出格式：\n### 技能：跨学科研究工作流（interdisciplinary-research-workflow v1）\nImmutable interdisciplinary research context for this run:\n- Profile version: 3 (33333333-3333-3333-3333-333333333333)\n- Primary discipline: Structural engineering\n- Associated disciplines: Computer vision, Data science\n- Research scope: Couple structural mechanics and visual measurement.\n- Core bridge questions:\n- Which visual observables preserve mechanical meaning?\n- Evidence boundary: Use only validated structural and visual evidence.\n- Validation conditions:\n- Compare against independent impact experiments.\n- Evidence balance: Structural engineering: 0.5, Computer vision: 0.25\n\n- Discipline query channels and terms:\n- [primary] Structural engineering: impact response\n- [associated] Computer vision: video segmentation\n\nApply these constraints throughout the output. Keep the primary discipline responsible for the scientific question, identify the non-substitutable contribution of each associated discipline, preserve discipline-specific evidence standards, and state whether every bridge claim has balanced supporting evidence.\n\nPinned workflow Skill v1:\n跨学科研究必须先确认范围资产，再进入后续流程。\n\n- 主学科负责定义核心科学问题；关联学科必须提供不可替代的方法、数据或评价标准。\n- 检索阶段按学科分桶以避免中文/英文术语和领域评价标准互相污染；合并阶段按 DOI、外部标识和规范化标题去重。\n- 任何 AI 结论都要携带交叉范围版本和证据锚点；句子级找不到时按既定规则回退，不能静默改成无来源的摘要推断。\n- 常规课题不注入本技能，不改变原有的单学科检索和写作流程。\n（本项目配置：profile_version_id=33333333-3333-3333-3333-333333333333）"
+  }
+}

--- a/src/backend/tests/test_interdisciplinary_injection_golden.py
+++ b/src/backend/tests/test_interdisciplinary_injection_golden.py
@@ -1,0 +1,60 @@
+"""#741 注入等价：指引搬离 v1 后，11+ 个注入点的产出与迁移前逐字节相同。
+
+fixture 是在改动**之前**的代码上录的（v1 builtin 种子 + 原 apply_to_skill_snapshot），
+固定 profile 字段与占位 UUID。这里用新存储的种子内容走同一条渲染管线，逐字节比对：
+- 13 个 guidance 注入点的 skill_guidance() 渲染文本；
+- navigator.free_plan 的 workflow 条目（steps/body 等，剔除随机 id 键）。
+比对通过 = 种子内容原文迁移无损 + 渲染行为未变。
+"""
+
+import json
+from pathlib import Path
+
+from app.agents.voyage.skillset import skill_guidance
+from app.services import interdisciplinary_workflows as iw
+
+FIXTURE = Path(__file__).parent / "fixtures" / "interdisciplinary_injection_golden.json"
+
+
+def _context_from_new_seed(fixed: dict) -> dict:
+    """按 snapshot_for_project 的新逻辑组 context，profile 字段与占位 id 取自 fixture。"""
+    seed = iw.GUIDANCE_SEED
+    return {
+        **fixed,
+        # fixture 落盘用了 sort_keys，dict 键序被排序过；渲染按插入序拼接，
+        # 这里按录制时的原始插入序还原
+        "evidence_balance": {"Structural engineering": 0.5, "Computer vision": 0.25},
+        # 迁移后两个键都指 guidance_documents 行；不参与渲染，随便给个占位
+        "skill_id": "44444444-4444-4444-4444-444444444444",
+        "skill_version_id": "55555555-5555-5555-5555-555555555555",
+        "skill_slug": seed["slug"],
+        "skill_name": seed["name"],
+        "skill_body": seed["body"],
+        "skill_manifest": {
+            "targets": list(seed["targets"]),
+            "steps": [dict(step) for step in seed["steps"]],
+        },
+    }
+
+
+def _strip_ids(entries: list[dict]) -> list[dict]:
+    return [
+        {k: v for k, v in entry.items() if k not in ("skill_id", "skill_version_id")}
+        for entry in entries
+    ]
+
+
+def test_injection_outputs_match_pre_migration_golden():
+    golden = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    context = _context_from_new_seed(golden["context_fixed"])
+
+    snapshot: dict = {}
+    iw.apply_to_skill_snapshot(snapshot, context)
+
+    rendered = {t: skill_guidance({"skills": snapshot}, t) for t in iw._GUIDANCE_TARGETS}
+    assert set(rendered) == set(golden["rendered"])
+    for target, text in golden["rendered"].items():
+        assert rendered[target] == text, f"{target} 注入文本与迁移前不一致"
+
+    assert _strip_ids(snapshot["navigator.free_plan"]) == golden["navigator_entries"]
+    assert _strip_ids(snapshot[iw._GUIDANCE_TARGETS[0]]) == golden["guidance_entries"]

--- a/src/backend/tests/test_interdisciplinary_workflows.py
+++ b/src/backend/tests/test_interdisciplinary_workflows.py
@@ -9,11 +9,10 @@ from app.agents.voyage.actions_experiment import _prompt_with_context
 from app.agents.voyage.engine import VoyageEngine
 from app.core.db import get_sessionmaker
 from app.core.llm.router import LLMRouter
+from app.models.guidance_document import GuidanceDocument
 from app.models.project import Project
-from app.models.skill import Skill, SkillVersion
 from app.models.voyage import VoyageRun
-from app.services.interdisciplinary_workflows import SKILL_SLUG
-from app.services.skills import ensure_builtin_skills
+from app.services.interdisciplinary_workflows import SKILL_SLUG, ensure_guidance_documents
 from tests.conftest import RecordingBus, register_and_login
 
 
@@ -59,7 +58,7 @@ async def _project_and_profile(client) -> tuple[dict[str, str], str]:
 
 async def _snapshot_run(project_id: str) -> VoyageRun:
     async with get_sessionmaker()() as session:
-        await ensure_builtin_skills(session)
+        await ensure_guidance_documents(session)
         project = await session.get(Project, uuid.UUID(project_id))
         run = VoyageRun(
             kind="idea_forge",
@@ -99,20 +98,22 @@ async def test_run_pins_confirmed_profile_and_builtin_skill_versions(client):
     assert "Structural engineering" in _prompt_with_context("BASE", ctx)
 
     async with get_sessionmaker()() as session:
-        skill = await session.scalar(select(Skill).where(Skill.slug == SKILL_SLUG))
-        first_skill_version = await session.scalar(
-            select(SkillVersion).where(
-                SkillVersion.skill_id == skill.id,
-                SkillVersion.version == first_context["skill_version"],
+        # 指引文档搬离 v1 后（#741）版本演进 = 追加一行（slug, version+1）
+        current = await session.scalar(
+            select(GuidanceDocument)
+            .where(
+                GuidanceDocument.slug == SKILL_SLUG,
+                GuidanceDocument.version == first_context["skill_version"],
             )
         )
         session.add(
-            SkillVersion(
-                skill_id=skill.id,
-                version=first_skill_version.version + 1,
-                manifest=dict(first_skill_version.manifest),
-                body=f"{first_skill_version.body}\n\nVersion two guidance.",
-                changelog="Test workflow version pinning.",
+            GuidanceDocument(
+                slug=SKILL_SLUG,
+                version=current.version + 1,
+                name=current.name,
+                body=f"{current.body}\n\nVersion two guidance.",
+                targets=list(current.targets or []),
+                steps=[dict(step) for step in current.steps or []],
             )
         )
         await session.commit()

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,7 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "351c324f4f6b"  # Schema hygiene: retired columns + owner merge (#734)
+HEAD_REVISION = "a5b9c3d7e1f2"  # Skill-system convergence step 1 (#741)
+HYGIENE_REVISION = "351c324f4f6b"  # Schema hygiene: retired columns + owner merge (#734)
 SETTINGS_REVISION = "b737c1a2d3e4"  # User-preference settings move to users.settings (#737)
 RESOURCES_REVISION = "d2dcfc8b899f"  # Resources, leases, polymorphic credentials (#677)
 METHOD_VECTORS_REVISION = "e867fcbae4ea"  # Method purpose/mechanism vectors (#663)
@@ -135,6 +136,8 @@ def _inspect_db(db_path: Path) -> tuple[str, dict[str, set[str]]]:
                     "agent_skills",
                     "agent_skill_files",
                     "skills",
+                    "skill_listings",
+                    "guidance_documents",
                     "buddy_memories",
                     "view_events",
                     "integration_tokens",
@@ -317,8 +320,16 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     assert {"skills", "skill_versions", "user_skills"} <= columns["_tables"]
     assert "project_skills" not in columns["_tables"]
     assert "project_id" not in columns["skills"]
-    # 技能市场 S4：skill_listings 表（skill_ratings 已在 P1 去实验室化中移除）
+    # 技能市场 S4：skill_listings 表（skill_ratings 已在 P1 去实验室化中移除）；
+    # #741 起审核残列已删，「在架」只看 delisted_at
     assert "skill_listings" in columns["_tables"]
+    assert "delisted_at" in columns["skill_listings"]
+    assert not {"status", "decided_by", "comment"} & columns["skill_listings"]
+    # #741：跨学科指引搬离 v1，落 guidance_documents
+    assert "guidance_documents" in columns["_tables"]
+    assert {"slug", "version", "name", "body", "targets", "steps"} <= columns[
+        "guidance_documents"
+    ]
     # 发表机构列（高级检索）
     assert "affiliations" in columns["papers"]
     # 用户系统 U1：治理列已在 head 删除，只剩头像列
@@ -612,7 +623,16 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     } <= columns["paper_extractions"]
     assert "ix_paper_extractions_paper_id" in _index_names(db_path, "paper_extractions")
 
-    # 先退掉列卫生（#734）：退役快照列与 created_by 按原形状回来（数据不可恢复，
+    # 先退掉技能收敛第一步（#741）：审核残列按原形状回来，指引文档表消失。
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == HYGIENE_REVISION
+    assert "guidance_documents" not in columns["_tables"]
+    assert {"status", "decided_by", "comment"} <= columns["skill_listings"]
+    assert "delisted_at" not in columns["skill_listings"]
+    assert "ix_skill_listings_status" in _index_names(db_path, "skill_listings")
+
+    # 再退掉列卫生（#734）：退役快照列与 created_by 按原形状回来（数据不可恢复，
     # created_by 从 submitted_by 回填——两列写入历史上恒等）。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
@@ -1233,3 +1253,89 @@ def test_schema_hygiene_migration_merges_owner_and_purges_private_llm_rows(tmp_p
     finally:
         engine.dispose()
 
+
+def test_skill_convergence_data_move_and_roundtrip(tmp_path):
+    """#741 数据迁移：指引版本逐行拷进 guidance_documents、v1 行归档、
+    listings 的审核状态映射成 delisted_at；downgrade 全部按原形状还原。"""
+    import json
+
+    db_path = tmp_path / "skills.db"
+    cfg = _make_config(db_path)
+    command.upgrade(cfg, SETTINGS_REVISION)
+
+    engine = create_engine(f"sqlite:///{db_path}")
+    skill_id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa01"
+    v1_id = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb01"
+    v2_id = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb02"
+    live_id = "cccccccccccccccccccccccccccccc01"
+    dead_id = "cccccccccccccccccccccccccccccc02"
+    manifest = {"targets": ["forge.generate"], "steps": [{"title": "s", "action": "llm.complete"}]}
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO skills (id, slug, kind, name, scope, is_archived, "
+                "created_at, updated_at) VALUES (:id, "
+                "'interdisciplinary-research-workflow', 'workflow', '跨学科研究工作流', "
+                "'builtin', 0, '2026-01-01 00:00:00', '2026-01-01 00:00:00')"
+            ),
+            {"id": skill_id},
+        )
+        for vid, ver, body in ((v1_id, 1, "body one"), (v2_id, 2, "body two")):
+            conn.execute(
+                text(
+                    "INSERT INTO skill_versions (id, skill_id, version, manifest, body, "
+                    "created_at, updated_at) VALUES (:id, :sid, :ver, :manifest, :body, "
+                    "'2026-01-01 00:00:00', '2026-01-01 00:00:00')"
+                ),
+                {"id": vid, "sid": skill_id, "ver": ver,
+                 "manifest": json.dumps(manifest), "body": body},
+            )
+        for lid, status in ((live_id, "approved"), (dead_id, "delisted")):
+            conn.execute(
+                text(
+                    "INSERT INTO skill_listings (id, skill_id, skill_version_id, status, "
+                    "install_count, created_at, updated_at) VALUES (:id, :sid, :vid, :status, "
+                    "0, '2026-01-01 00:00:00', '2026-02-02 00:00:00')"
+                ),
+                {"id": lid, "sid": skill_id, "vid": v1_id, "status": status},
+            )
+
+    command.upgrade(cfg, HEAD_REVISION)
+    with engine.connect() as conn:
+        docs = conn.execute(
+            text("SELECT id, version, name, body, targets, steps FROM guidance_documents "
+                 "ORDER BY version")
+        ).fetchall()
+        assert [(d.id, d.version, d.body) for d in docs] == [
+            (v1_id, 1, "body one"),  # id 沿用 skill_versions.id（存量 checkpoint 可对回）
+            (v2_id, 2, "body two"),
+        ]
+        assert json.loads(docs[0].targets) == ["forge.generate"]
+        assert json.loads(docs[0].steps) == manifest["steps"]
+        assert docs[0].name == "跨学科研究工作流"
+        # v1 行归档而非删除
+        archived = conn.execute(
+            text("SELECT is_archived FROM skills WHERE id = :id"), {"id": skill_id}
+        ).scalar_one()
+        assert archived == 1
+        rows = dict(
+            conn.execute(text("SELECT id, delisted_at FROM skill_listings")).fetchall()
+        )
+        assert rows[live_id] is None  # approved → 在架
+        assert rows[dead_id] is not None  # delisted → 下架时间取 updated_at
+
+    command.downgrade(cfg, "-1")
+    with engine.connect() as conn:
+        assert (
+            conn.execute(
+                text("SELECT name FROM sqlite_master WHERE name = 'guidance_documents'")
+            ).first()
+            is None
+        )
+        archived = conn.execute(
+            text("SELECT is_archived FROM skills WHERE id = :id"), {"id": skill_id}
+        ).scalar_one()
+        assert archived == 0  # 解除归档，v1 行整体还原
+        rows = dict(conn.execute(text("SELECT id, status FROM skill_listings")).fetchall())
+        assert rows == {live_id: "approved", dead_id: "delisted"}
+    engine.dispose()

--- a/src/backend/tests/test_skill_market.py
+++ b/src/backend/tests/test_skill_market.py
@@ -44,7 +44,7 @@ async def test_publish_lists_immediately(client):
     headers_b = await _login(client, email="bob@example.com")
     market = (await client.get("/api/market/skills", headers=headers_b)).json()
     assert [m["id"] for m in market] == [listing_id]
-    assert market[0]["status"] == "approved"
+    assert market[0]["delisted_at"] is None  # 发布即上架（#741 起没有审核状态机）
     assert market[0]["skill"]["slug"] == "market-rubric"
     assert market[0]["version"] == 1
 
@@ -77,7 +77,7 @@ async def test_install_and_delist(client):
 
     # 发布者下架 → 市场不可见、安装 409
     resp = await client.delete(f"/api/market/skills/{listing_id}", headers=headers_a)
-    assert resp.json()["status"] == "delisted"
+    assert resp.json()["delisted_at"] is not None
     assert (await client.get("/api/market/skills", headers=headers_b)).json() == []
     assert (
         await client.post(f"/api/market/skills/{listing_id}/install", headers=headers_b)

--- a/src/backend/tests/test_skills_api.py
+++ b/src/backend/tests/test_skills_api.py
@@ -117,9 +117,8 @@ async def test_builtin_seed_readonly_and_fork(client):
 
     builtin = (await client.get("/api/skills?scope=builtin", headers=headers)).json()
     assert len(builtin) == len(BUILTIN_SKILLS)
-    cross = next(s for s in builtin if s["slug"] == "interdisciplinary-research-workflow")
-    assert cross["kind"] == "workflow"
-    assert cross["name_en"] == "Interdisciplinary Research Workflow"
+    # 跨学科工作流指引已搬离 v1（#741）：不再作为 builtin 技能出现
+    assert all(s["slug"] != "interdisciplinary-research-workflow" for s in builtin)
     rubric = next(s for s in builtin if s["slug"] == "idea-scoring-rubric")
 
     # 内置只读：追加版本 / 归档均 403

--- a/src/frontend/src/features/settings/PluginsMarketSection.tsx
+++ b/src/frontend/src/features/settings/PluginsMarketSection.tsx
@@ -339,6 +339,10 @@ export function PluginsMarketSection() {
 
   return (
     <div>
+      {/* 两个市场互相指路（#741）：这里只管插件；AI 任务技能的市场在「技能」页 */}
+      <div style={{ fontSize: 11.5, color: 'var(--text-3)', marginBottom: 10 }}>
+        {tr('这里是插件市场；AI 任务技能有自己的市场，在「技能」页。', 'This is the plugin market; AI task skills have their own market on the Skills page.')}
+      </div>
       {/* —— 索引源设置：小输入框 + 保存/恢复默认 + 刷新 —— */}
       <div className="row gap8" style={{ alignItems: 'center', flexWrap: 'wrap', marginBottom: 6 }}>
         <span style={{ fontSize: 12, color: 'var(--text-2)', flexShrink: 0 }}>{tr('索引源', 'Source')}</span>

--- a/src/frontend/src/features/skills/SkillsPage.tsx
+++ b/src/frontend/src/features/skills/SkillsPage.tsx
@@ -670,6 +670,10 @@ function MarketView() {
 
   return (
     <div>
+      {/* 两个市场互相指路（#741）：这里只管任务技能；插件有自己的市场 */}
+      <div style={{ fontSize: 11.5, color: 'var(--text-3)', marginBottom: 10 }}>
+        {tr('这里是本机技能市场，存放你发布的任务技能；插件市场在 设置 → 插件。', 'This is the local skill market for the task skills you publish; the plugin market lives under Settings → Plugins.')}
+      </div>
       <div className="row gap10" style={{ marginBottom: 16 }}>
         <Segmented
           options={[
@@ -686,7 +690,7 @@ function MarketView() {
         {isError ? (
           <EmptyState icon="sparkle" title={tr('市场加载失败', 'Failed to load market')} desc={tr('后端服务未启动或版本过旧', 'Backend not running or too old')} />
         ) : isLoading ? null : (listings ?? []).length === 0 ? (
-          <EmptyState icon="sparkle" title={tr('市场还是空的', 'The market is empty')} desc={tr('在技能库把你的技能发布到市场，发布后大家就能安装', 'Publish your skills from the library so others can install them')} />
+          <EmptyState icon="sparkle" title={tr('市场还是空的', 'The market is empty')} desc={tr('在技能库把技能发布到市场，就会上架到这台设备（或服务器）的市场里，可随时安装回来', 'Publish a skill from the library to list it in the market on this device or server, ready to install')} />
         ) : (
           listings!.map((l) => <ListingCard key={l.id} l={l} onOpen={() => setOpenListing(l.id)} />)
         )}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -3068,10 +3068,10 @@ export interface SkillListingRead {
   skill_version_id: string;
   summary: string | null;
   tags: string[] | null;
-  status: 'pending' | 'approved' | 'rejected' | 'delisted';
+  /** 在架 = null（发布即上架，没有审核状态机） */
+  delisted_at: string | null;
   install_count: number;
   published_by: string | null;
-  comment: string | null;
   created_at: string;
   skill: SkillRead | null;
   version: number | null;


### PR DESCRIPTION
Closes #741. Part of #715 (audit item 12).

Three skill systems run in parallel — the frozen v1 `skills`/`skill_versions` tables, the v2 `SKILL.md` packs, and the plugin market — and new feature code was still writing into v1 while the removed review flow left columns behind. A full v1 retirement is a later project; this step stops the bleeding, removes the dead residue, and writes the convergence path down.

## Stop new v1 writes

The interdisciplinary workflow's stage guidance was the last feature storing itself as a builtin row in `skills`/`skill_versions`. It moves to a purpose-built `guidance_documents` table (`app/models/guidance_document.py`) with immutable `(slug, version)` rows carrying `targets`/`steps` JSON.

v2's `agent_skills` shape was the other candidate and was rejected on consumption model: v2 is progressive disclosure, where the model decides whether to load a pack, while this guidance is injected unconditionally and in full by the engine at fixed points. Forcing it into v2 would also have surfaced it in Buddy's skill catalogue, which is the wrong place for it. The new table keeps v1's immutable `(slug, version)` semantics — append-only, latest = highest version — and task runtimes freeze the content into the checkpoint, so resume and replay do not depend on the table.

The 83-line seed block leaves `services/builtin_skills.py` and reappears verbatim as `GUIDANCE_SEED` plus an idempotent `ensure_guidance_documents()` in `services/interdisciplinary_workflows.py`, wired into startup seeding in `app/main.py`; the snapshot lookup switches from `_builtin_skill_version` to `_latest_guidance_document`. All eleven injection points keep working, pinned by a new golden fixture test (`tests/test_interdisciplinary_injection_golden.py`) that records the injected text at every point.

Existing deployments are back-filled by the migration: one `guidance_documents` row per old skill version, reusing the version id so stored checkpoints still resolve, with the v1 skill row archived rather than dropped — downgrade un-archives it and restores the table.

## Review-flow residue dropped

`skill_listings.status/decided_by/comment` are removed in favour of a nullable `delisted_at` (empty = live). Publishing has been immediate since the review flow was removed in #592, so listing state is only live or delisted. Existing rows map by status: anything not `approved` becomes delisted with `delisted_at` taken from `updated_at`. The market service, the API detail code (`LISTING_NOT_APPROVED` → `LISTING_DELISTED`), the schemas and the frontend type follow, and the market service's "deployment-shared" wording is corrected to match the single-user form.

## The two markets acknowledge each other

The skills market view and the plugin market section each gain a one-line note pointing at the other, and the empty-state copy stops promising that "everyone" can install what you publish — publishing lists a skill on this device or server.

## The plan is written down

`docs/skills.md` gains a "three skill systems and the convergence plan" section stating what each system is for (v1 frozen, v2 current, plugin market the destination) and the path between them, closing the audit's "no migration plan exists" finding.

## Verification

Migration re-hung onto the current chain head `351c324f4f6b`; the chain stays single-headed. `tests/test_migrations.py` gains the new head revision, the `guidance_documents`/`skill_listings` schema assertions, an extra step in the downgrade walk, and `test_skill_convergence_data_move_and_roundtrip`, which seeds two skill versions plus a live and a delisted listing and asserts the data move and full downgrade restoration. Full backend suite green, `ruff check` clean on `app`, `alembic` and `tests`; the existing golden transcripts are untouched.
