### PR TITLE
ci: ruff joins python-ci (#746)

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,7 +1,10 @@
-# 后端全量 pytest 闸门（#728，堵住 #581「失败长期滞留 main」的口子）。
+# 后端全量 pytest 闸门（#728，堵住 #581「失败长期滞留 main」的口子）+ ruff 闸门（#746）。
 # 套件在 desktop 档位自足：conftest 自带 SQLite(aiosqlite) + fakeredis 与全部
 # POLARIS_* 环境变量，不需要 postgres/redis 服务容器。
 # docker_integration 用例（要真 docker + 镜像）由 pyproject 的 addopts 默认 deselect。
+#
+# ruff 单开一个 job 而不是塞进 pytest 的步骤里：lint 几秒出结果、套件二十多分钟，
+# 合在一起就意味着「格式问题要排队等全套跑完才报」，而且套件挂掉时 lint 结论会一起消失。
 name: python-ci
 
 on:
@@ -12,6 +15,28 @@ on:
   workflow_dispatch:
 
 jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: src/backend/pyproject.toml
+
+      - name: Install backend with dev extras
+        run: pip install -e "src/backend[dev]"
+
+      # 与 Makefile 的 lint 目标同范围（外加 alembic——pyproject 的 per-file-ignores
+      # 已经为 alembic/versions 写了规则，说明它本就在受检范围内）。本地与 CI 判定一致，
+      # 免得出现「本机 make lint 过了、CI 挂了」或者反过来。
+      - name: Run ruff
+        working-directory: src/backend
+        run: ruff check app worker tests alembic
+
   pytest:
     runs-on: ubuntu-latest
     # 本机容器全量约 25 分钟，CI 裸机估 15-30 分钟——45 兜底

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,8 @@ test:           ## Backend tests + frontend unit tests + frontend build
 	pnpm --dir src/frontend run build
 
 lint:
-	cd src/backend && .venv/bin/ruff check app worker tests
+	# 范围与 python-ci.yml 的 ruff job 保持一致（#746），本地和 CI 判定不分家
+	cd src/backend && .venv/bin/ruff check app worker tests alembic
 	cd src/frontend && npx tsc --noEmit
 	cd src/desktop && npx tsc --noEmit
 

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -49,7 +49,9 @@ dev = [
     "aiosqlite>=0.20",
     "fakeredis>=2.26",
     "respx>=0.22",
-    "ruff>=0.8",
+    # 上界不是洁癖：ruff 进 CI 闸门后（#746），1.0 前的小版本会加新规则，
+    # 不钉住就等于哪天 ruff 发版、所有不相干的 PR 一起变红。升版本是主动动作。
+    "ruff>=0.8,<0.17",
 ]
 
 [tool.setuptools.packages.find]

--- a/src/backend/tests/test_chat_plan.py
+++ b/src/backend/tests/test_chat_plan.py
@@ -235,7 +235,12 @@ def test_the_plan_frame_also_comes_from_submit_plan():
         ),
     )
     ev = ToolResultEvent(
-        id="t1", name="submit_plan", ok=True, summary="待审批的计划（1 步）", preview="", duration_ms=1
+        id="t1",
+        name="submit_plan",
+        ok=True,
+        summary="待审批的计划（1 步）",
+        preview="",
+        duration_ms=1,
     )
     steps = _plan_from(ev, result)
     assert steps is not None

--- a/src/backend/tests/test_paper_index_status.py
+++ b/src/backend/tests/test_paper_index_status.py
@@ -539,7 +539,11 @@ async def test_collecting_libraries_lists_only_admitted_and_visible(client):
         paper = new_paper(source="arxiv", arxiv_id="2607.77001", title="Collected", abstract="x")
         session.add(paper)
         await session.flush()
-        me = (await session.execute(_select(User).where(User.email == "collect-owner@example.com"))).scalar_one()
+        me = (
+            await session.execute(
+                _select(User).where(User.email == "collect-owner@example.com")
+            )
+        ).scalar_one()
         libs = {}
         for name, status, is_public, score in (
             ("已收录公共库", "compiled", True, 0.91),

--- a/src/backend/tests/test_tool_project_scope.py
+++ b/src/backend/tests/test_tool_project_scope.py
@@ -31,7 +31,9 @@ async def _seed(client) -> tuple[uuid.UUID, str, str]:
     token = await register_and_login(client, email="scope@example.com")
     headers = {"Authorization": f"Bearer {token}"}
     project = (
-        await client.post("/api/projects", json={"name": "Scope", "statement": "s"}, headers=headers)
+        await client.post(
+            "/api/projects", json={"name": "Scope", "statement": "s"}, headers=headers
+        )
     ).json()
     async with get_sessionmaker()() as session:
         user_id = (


### PR DESCRIPTION
Closes #746. Follow-up from #715.

#730 put the backend and frontend test suites into CI, closing the hole that let #581's failures survive on `main`. The lint half of `make lint` was never wired up the same way: the TypeScript checks happen to be enforced (they run inside the frontend build and the desktop lint step), but `grep -rn ruff .github/workflows/` returned nothing, so the Python lint verdict was advisory. `main` was already failing it with three `E501` violations that no pull request surfaced.

## What changes

- **`ruff` becomes its own job in `python-ci.yml`**, not a step inside `pytest`. Lint answers in seconds where the suite takes twenty-odd minutes; folding it in would mean a formatting problem queues behind the full run, and would make the lint verdict disappear whenever the suite fails.
- **Scope matches `make lint`, plus `alembic`** — `pyproject.toml` already carries a `per-file-ignores` entry for `alembic/versions`, so that tree was clearly meant to be linted. The Makefile target is widened to the same scope, so a local run and CI can never reach different verdicts.
- **The three existing violations are wrapped.** Pure line-wrapping in `test_chat_plan.py`, `test_paper_index_status.py` and `test_tool_project_scope.py`; no behavior change.
- **`ruff` gains an upper bound** (`>=0.8,<0.17`). Before 1.0, ruff adds rules in minor releases. That is harmless for an advisory tool and disruptive for a gate — without a cap, a ruff release turns every open pull request red at a moment nobody chose. Upgrading becomes a deliberate act.

`ruff format` is deliberately **not** added: the repository has never been formatted with it, and `ruff format --check` currently wants to reformat 268 of 671 files. That is a separate decision, not something to smuggle in behind a lint gate.

## Verification

`ruff check app worker tests alembic` passes in the exact CI scope; the three touched test files pass (33 passed). The new job runs on this pull request, so the gate proves itself here.
