### PR TITLE
fix: desktop e2e engine mode is idempotent across runs (#687)

### DIFF
--- a/src/desktop/e2e/e2e.ts
+++ b/src/desktop/e2e/e2e.ts
@@ -84,6 +84,10 @@ function launchEnv(overrides: Record<string, string>): Record<string, string> {
   // fake LLM 回退是严格显式 opt-in（#717）：基线环境必须干净，需要它的组
   // （组 A）在 overrides 里显式声明，其余组证明「不设就没有」。
   delete env.POLARIS_LLM_FAKE_FALLBACK;
+  // 同理（#687）：开发者机器上可能设了 POLARIS_DATABASE_URL 指向自己的库，
+  // 泄进来会让组 A 用错库、也会让其他组的引擎行为不可预期。基线清干净，
+  // 需要的组在 overrides 里显式声明。
+  delete env.POLARIS_DATABASE_URL;
   // 内部分发机器可能设了默认服务器：会让「未配置服务器」的断言失真
   delete env.POLARIS_DEFAULT_SERVER_URL;
   return { ...env, ...overrides };
@@ -150,9 +154,16 @@ async function groupEngine(): Promise<void> {
 
   // 容器名/端口随机化：默认名 polaris-desktop-engine 若被并行任务占着，
   // docker run 会直接撞名失败，回收时还可能误删别人的容器。
-  const container = `polaris-desktop-engine-e2e-${Math.random().toString(36).slice(2, 8)}`;
+  const runId = Math.random().toString(36).slice(2, 8);
+  const container = `polaris-desktop-engine-e2e-${runId}`;
   const port = 18100 + Math.floor(Math.random() * 1800);
   const userData = mkdtempSync(join(tmpdir(), 'polaris-e2e-a-'));
+  // 每轮一个独立数据库（#687）：docker 模式的引擎默认写挂载目录里的
+  // ./polaris_dev.db，跨轮留存——上一轮建的课题会让「全新库落到 /start」
+  // 的断言在第二轮直接失真。不能改成「跑前删 polaris_dev.db」：那是开发者
+  // 自己的本地库。库文件仍落在挂载目录里（容器只看得见这一处），但名字带
+  // 本轮 id，收尾时按名删除，互不干扰也不留垃圾。
+  const dbFile = `polaris-e2e-${runId}.db`;
   let app: ElectronApplication | null = null;
 
   try {
@@ -165,6 +176,9 @@ async function groupEngine(): Promise<void> {
         // 显式 opt-in：插件不再代设 fake 回退（#717），引擎容器经 docker 的
         // 无值 -e 透传拿到它——测试确定性由这里声明，而不是产品替我们开
         POLARIS_LLM_FAKE_FALLBACK: '1',
+        // 本轮专属库（#687），同样走无值 -e 透传。相对路径的基准是容器里的
+        // 工作目录 /srv/backend，也就是宿主的 BACKEND_DIR。
+        POLARIS_DATABASE_URL: `sqlite+aiosqlite:///./${dbFile}`,
       }),
     );
     app = r.app;
@@ -236,6 +250,11 @@ async function groupEngine(): Promise<void> {
       }
     }
     rmSync(userData, { recursive: true, force: true });
+    // 本轮的库连同 sqlite 的 -wal/-shm 边车一起清掉（#687）：不清就等于把
+    // 「跨轮留存」从一个文件名换成一堆文件名，仓库里还会攒垃圾。
+    for (const suffix of ['', '-wal', '-shm']) {
+      rmSync(join(BACKEND_DIR, `${dbFile}${suffix}`), { force: true });
+    }
   }
 }
 

--- a/src/kernel/src/plugins/legacy-engine.ts
+++ b/src/kernel/src/plugins/legacy-engine.ts
@@ -104,6 +104,11 @@ export function buildEngineArgv(config: LegacyEngineConfig, port: number): strin
     // POLARIS_LLM_FAKE_FALLBACK（冒烟/E2E 的显式 opt-in）docker 才带进容器，
     // 没设则容器内同样不存在——与 command 模式继承宿主 env 的行为对齐。
     '-e', 'POLARIS_LLM_FAKE_FALLBACK',
+    // 数据库地址同样只做无值透传（#687）。docker 模式不设它时，后端用默认的
+    // ./polaris_dev.db——也就是挂载进来的后端源码目录里那一个，跨次运行留存。
+    // command 模式早就把库钉在 userData 下（engine-bootstrap 的启动器，#718），
+    // 这里补上同一个口子：宿主显式指定就用宿主的，不指定则维持原状不变。
+    '-e', 'POLARIS_DATABASE_URL',
     config.image,
     'sh', '-lc',
     // 先迁移后起服务：desktop 档位没有独立 worker 抢跑迁移的问题，串行即可

--- a/src/kernel/tests/legacy-engine.test.ts
+++ b/src/kernel/tests/legacy-engine.test.ts
@@ -122,6 +122,14 @@ describe('legacy-engine buildEngineArgv (docker mode)', () => {
     expect(argv.join(' ')).not.toContain('POLARIS_LLM_FAKE_FALLBACK=')
   })
 
+  it('passes the database URL through without a value so the host can redirect it (#687)', () => {
+    const argv = buildEngineArgv(base, 18080)
+    // 不指定时后端仍用默认的 ./polaris_dev.db（挂载目录里那一个）；宿主
+    // （E2E、引导流程）显式设了才改道——插件不替任何人决定库放在哪
+    expect(argv).toContain('POLARIS_DATABASE_URL')
+    expect(argv.join(' ')).not.toContain('POLARIS_DATABASE_URL=')
+  })
+
   it('honors a custom containerName so parallel instances do not collide', () => {
     const argv = buildEngineArgv({ ...base, containerName: 'polaris-engine-e2e-x' }, 19000)
     expect(argv.slice(3, 5)).toEqual(['--name', 'polaris-engine-e2e-x'])


### PR DESCRIPTION
Closes #687.

Running the e2e engine group twice in a row failed on the second run. Under docker mode the engine uses the backend's default database URL, `sqlite+aiosqlite:///./polaris_dev.db`, and its working directory is the mounted backend source tree — so the database persisted between runs, the topic created by the first run was still there, and the "a fresh database lands on /start" assertion diverged.

## Why the fix is where it is

Command mode has pinned the database under `userData` since #718 (`buildEngineCommand` in `engine-bootstrap.ts` sets `POLARIS_DATABASE_URL` in the launcher). Docker mode never got the equivalent, so a host had no way to say where the database should go.

`legacy-engine` now passes `POLARIS_DATABASE_URL` into the container **without a value**, the same shape already used for the fake-LLM opt-in added by #717: if the host has not set it, the variable does not exist in the container and behavior is unchanged; if the host sets it, the host decides. The plugin still never picks a database location on anyone's behalf.

The e2e then gives each run a database named after the run id it already generates for the container name, and removes it — plus the sqlite `-wal`/`-shm` sidecars — in the same `finally` block that already reclaims the container and the temp `userData`.

**Deleting `polaris_dev.db` in setup was considered and rejected.** That file is the developer's own local database; a test suite that removes it would trade an idempotency bug for data loss on every developer machine that runs the suite.

`launchEnv` also drops an inherited `POLARIS_DATABASE_URL` from the baseline environment, matching how it already scrubs `POLARIS_LLM_FAKE_FALLBACK` and `POLARIS_DEFAULT_SERVER_URL`: a value set on a developer's machine must not silently steer any group.

## Verification

The full e2e suite was run twice back to back on a machine with `polaris-api-test:local`, so the engine group actually executed rather than skipping:

- **Run 1: all groups green, exit 0.**
- **Run 2: all groups green, exit 0** — this is the run that previously failed.
- `src/backend` contained no `.db` files before run 1, between the runs, or after run 2.

Kernel suite: 98 passed across 11 files, including a new guard asserting the pass-through is valueless (`POLARIS_DATABASE_URL` present, `POLARIS_DATABASE_URL=` absent). `pnpm --dir src/desktop run lint` (tsc) clean.
