### PR TITLE
fix: interleave gap signals so later ones are not starved (#428)

### DIFF
--- a/src/backend/alembic/versions/c4a1d8e93b57_manuscript_ydoc_state.py
+++ b/src/backend/alembic/versions/c4a1d8e93b57_manuscript_ydoc_state.py
@@ -1,0 +1,34 @@
+"""协同文档持久化 CRDT 状态（#347）：manuscript_files 加 ydoc_state
+
+房间此前只从 manuscript_files.content 这一列纯文本重建。重建出来的是一套**新的**
+CRDT 历史：服务重启后，仍开着的浏览器标签页带着旧历史自动重连，y-websocket 把
+两边合并——两套插入操作互相都不认识，于是整篇文档首尾相接出现两份（issue #347
+现场：126 行变 249 行，\\documentclass 同时出现在第 3 行和第 127 行）。
+
+这里加一列存 Y 文档自己的更新字节。有它就按原历史恢复，重连合并回到同一份内容。
+纯新增可空列，存量行为 NULL——NULL 时仍按老路子从 content 播种（首次连接、
+以及本次升级前就存在的文件），行为不变。
+
+Revision ID: c4a1d8e93b57
+Revises: a5b9c3d7e1f2
+Create Date: 2026-09-09
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "c4a1d8e93b57"
+down_revision: str | None = "a5b9c3d7e1f2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("manuscript_files", sa.Column("ydoc_state", sa.LargeBinary(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("manuscript_files", "ydoc_state")

--- a/src/backend/app/agents/voyage/actions_ideas.py
+++ b/src/backend/app/agents/voyage/actions_ideas.py
@@ -19,6 +19,7 @@ import math
 import re
 import uuid
 from datetime import timedelta
+from itertools import zip_longest
 from pathlib import Path
 from typing import Any
 
@@ -478,6 +479,21 @@ async def forge_collect_signals(ctx: ActionContext, params: dict[str, Any]) -> d
 # ---- forge 3. gap 综合（LLM 综述空白 + 确定性信号合并，stage=forge） ----
 
 
+def _interleave_by_signal(buckets: dict[str, list[dict[str, str]]]) -> list[dict[str, str]]:
+    """按信号轮转铺开 gap 清单，而不是一个信号接一个信号地拼（#428）。
+
+    生成器只写 num_ideas（默认 8）条想法，而 gap 清单常有 20+ 条。顺序拼接的
+    后果是排在后面的信号整段落在清单尾部——新加的信号无论质量多好，都大概率
+    根本轮不到。轮转之后每个信号的头几条都靠前，信号之间按「各自最好的那条」
+    竞争，而不是按谁先被拼进来。
+    """
+    ordered = [items for items in buckets.values() if items]
+    out: list[dict[str, str]] = []
+    for row in zip_longest(*ordered):
+        out.extend(item for item in row if item is not None)
+    return out
+
+
 @register("forge.gap_analysis")
 async def forge_gap_analysis(ctx: ActionContext, params: dict[str, Any]) -> dict[str, Any]:
     if isinstance(ctx.checkpoint.get("forge_gaps"), list):  # 断点幂等
@@ -488,7 +504,8 @@ async def forge_gap_analysis(ctx: ActionContext, params: dict[str, Any]) -> dict
         project = await _get_project(session, ctx)
         statement = _statement(project)
 
-    gaps: list[dict[str, str]] = []
+    # 按信号分桶收集，最后轮转铺开（#428）；插入顺序即轮转顺序，保持确定性
+    buckets: dict[str, list[dict[str, str]]] = {}
     if "survey_gap" in enabled:
 
         def validate(data: Any) -> list[dict[str, str]]:
@@ -508,20 +525,18 @@ async def forge_gap_analysis(ctx: ActionContext, params: dict[str, Any]) -> dict
                 )
             return normalized
 
-        gaps.extend(
-            await _complete_json(
-                ctx,
-                stage="forge",
-                system=GAP_SYSTEM_PROMPT + ctx.skill_guidance("forge.gap_analysis"),
-                user=_context_prompt(ctx, statement),
-                validate=validate,
-            )
+        buckets["survey_gap"] = await _complete_json(
+            ctx,
+            stage="forge",
+            system=GAP_SYSTEM_PROMPT + ctx.skill_guidance("forge.gap_analysis"),
+            user=_context_prompt(ctx, statement),
+            validate=validate,
         )
 
     # 确定性信号 → gap 条目（不经 LLM）
     signals = ctx.checkpoint.get("forge_signals") or {}
     for hole in signals.get("concept_holes") or []:
-        gaps.append(
+        buckets.setdefault("concept_holes", []).append(
             {
                 "title": f"概念组合空白：{hole['method']} × {hole['problem']}",
                 "description": (
@@ -533,7 +548,7 @@ async def forge_gap_analysis(ctx: ActionContext, params: dict[str, Any]) -> dict
             }
         )
     for trend in signals.get("trends") or []:
-        gaps.append(
+        buckets.setdefault("trends", []).append(
             {
                 "title": f"新兴主题：{trend['concept']}",
                 "description": (
@@ -544,8 +559,9 @@ async def forge_gap_analysis(ctx: ActionContext, params: dict[str, Any]) -> dict
             }
         )
     for gap in signals.get("limitations") or []:
-        gaps.append({**gap, "signal": "limitations"})
+        buckets.setdefault("limitations", []).append({**gap, "signal": "limitations"})
 
+    gaps = _interleave_by_signal(buckets)
     if not gaps:
         raise ValueError("没有可用的研究空白（所有信号源均为空）")
     ctx.checkpoint["forge_gaps"] = gaps

--- a/src/backend/app/api/ws.py
+++ b/src/backend/app/api/ws.py
@@ -147,7 +147,7 @@ async def manuscript_crdt_ws(
         return
     await websocket.accept()
     rooms = get_crdt_rooms()
-    await rooms.connect(file_id=file.id, db_content=file.content)
+    await rooms.connect(file_id=file.id, db_content=file.content, ydoc_state=file.ydoc_state)
     try:
         await rooms.serve(_CRDTChannel(websocket, str(file.id)))
     except WebSocketDisconnect:

--- a/src/backend/app/models/manuscript.py
+++ b/src/backend/app/models/manuscript.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, String, Text
+from sqlalchemy import Boolean, DateTime, ForeignKey, LargeBinary, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.db import Base
@@ -80,6 +80,11 @@ class ManuscriptFile(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     )
     path: Mapped[str] = mapped_column(String(1024), nullable=False)  # e.g. main.tex
     content: Mapped[str] = mapped_column(Text, default="", nullable=False)  # latex（二进制时为空）
+    # CRDT 文档状态（#347）：content 是给所有「按纯文本读」的地方用的投影，
+    # 这一列存 Y 文档本身的更新字节。房间重建时必须从它恢复——重新用 content
+    # 灌一个空文档会造出第二套互不相干的 CRDT 历史，幸存的浏览器标签页一重连，
+    # 两套插入操作谁也去重不了谁，整篇文档就变成两份首尾相接。
+    ydoc_state: Mapped[bytes | None] = mapped_column(LargeBinary)
     # 模板样式文件（.sty/.cls/.bst）只读：不可改删、不开 CRDT 房间
     readonly: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     # 二进制资源（图片/PDF/字体等）：content 为空，字节落磁盘

--- a/src/backend/app/services/crdt_rooms.py
+++ b/src/backend/app/services/crdt_rooms.py
@@ -1,9 +1,11 @@
 """CRDT 协同房间（docs/task-system.md §7（原 api-m5-b.md §6），不 import fastapi）。
 
 - pycrdt.websocket WebsocketServer 单例（懒启动），房间名 = ManuscriptFile.id；
-- Y doc 结构：Text 命名 "content"；房间新建时从 ManuscriptFile.content 初始化；
-- 快照：文档更新防抖 2s 写回 ManuscriptFile.content（编译/AI/REST 读到的即最新），
-  服务重启后房间从库重建；
+- Y doc 结构：Text 命名 "content"；
+- 快照：文档更新防抖 2s 写回库，**content（纯文本投影）与 ydoc_state（CRDT 本体）
+  一起写**。房间重建走 ydoc_state 恢复原历史，只有它为空（首次连接、升级前的
+  存量文件）才退回用 content 播种——用文本重建等于另起一套历史，幸存标签页
+  一重连两套插入操作互不去重，整篇文档会变成两份首尾相接（#347）；
 - apply_ai_edit：写作 voyage 分节写入——有活跃房间时经 Y 事务区间替换（协同者实时
   可见）并立即快照落库，无房间时直接改库。
 """
@@ -61,6 +63,22 @@ def replace_section(content: str, section: str, body: str) -> str:
     return content[:start] + body + content[end:]
 
 
+def _replace_all(room: YRoom, text: Text, new_content: str) -> None:
+    """在**现有文档**里把全文换成 new_content（一个 Y 事务里删+插）。
+
+    关键是「现有文档」：删+插产生的仍是这套历史里的操作，重连的客户端合并后
+    收敛到同一份内容；换成新建文档灌文本就会造出第二套历史（#347）。
+    """
+    current = str(text)
+    if new_content == current:
+        return
+    with room.ydoc.transaction():
+        if current:
+            del text[0 : len(current.encode("utf-8"))]
+        if new_content:
+            text += new_content
+
+
 class CRDTRoomManager:
     """WebsocketServer 单例封装：房间生命周期 + 防抖快照 + AI 区间写入。"""
 
@@ -95,16 +113,31 @@ class CRDTRoomManager:
             return None
         return str(room.ydoc.get("content", type=Text))
 
-    async def connect(self, *, file_id: uuid.UUID, db_content: str) -> YRoom:
-        """取/建房间：新建时从库内容初始化 Text 并挂防抖快照观察者。"""
+    async def connect(
+        self, *, file_id: uuid.UUID, db_content: str, ydoc_state: bytes | None = None
+    ) -> YRoom:
+        """取/建房间：新建时恢复文档状态并挂防抖快照观察者。
+
+        ``ydoc_state`` 有值就按原 CRDT 历史恢复（#347）；没有才从 ``db_content``
+        纯文本播种——那是首次连接和升级前存量文件的路径。两者都做完再和库里的
+        文本对一次账：房间不在时有人直接改过库（AI 分节写入、版本回滚、REST 保存），
+        以库为准，但改法是在**已恢复的文档里**做区间替换，而不是另起一套历史。
+        """
         server = await self._ensure_server()
         name = str(file_id)
         room = await server.get_room(name)
         if name not in self._initialized:
             self._initialized.add(name)
             text = room.ydoc.get("content", type=Text)
-            if len(text) == 0 and db_content:
-                text += db_content
+            if len(text) == 0:
+                if ydoc_state:
+                    # 原历史恢复：重连的标签页带着同一套历史过来，合并即同一份内容
+                    room.ydoc.apply_update(ydoc_state)
+                    if str(text) != db_content:
+                        # 库文本在房间不在时被改过 → 以库为准，但留在同一套历史里
+                        _replace_all(room, text, db_content)
+                elif db_content:
+                    text += db_content
             loop = asyncio.get_running_loop()
             room.ydoc.observe(
                 lambda _event, fid=name: loop.call_soon_threadsafe(self._schedule_snapshot, fid)
@@ -134,14 +167,23 @@ class CRDTRoomManager:
             logger.exception("CRDT 快照落库失败：file=%s", fid)
 
     async def snapshot(self, file_id: uuid.UUID | str) -> None:
-        """把房间当前文本写回 ManuscriptFile.content（无房间/无变化则跳过）。"""
-        content = self.room_content(file_id)
-        if content is None:
+        """把房间当前状态写回库：content 是纯文本投影，ydoc_state 是 CRDT 本体。
+
+        两列必须一起写（#347）。只写 content 的话，重启后房间只能拿文本重建，
+        那是另一套历史——幸存标签页一重连就把整篇文档合并成两份。
+        """
+        room = self.active_room(file_id)
+        if room is None:
             return
+        content = str(room.ydoc.get("content", type=Text))
+        state = room.ydoc.get_update()
         async with get_sessionmaker()() as session:
             file = await session.get(ManuscriptFile, uuid.UUID(str(file_id)))
-            if file is not None and file.content != content:
+            if file is None:
+                return
+            if file.content != content or file.ydoc_state != state:
                 file.content = content
+                file.ydoc_state = state
                 await session.commit()
 
     async def flush(self, file_id: uuid.UUID | str) -> None:
@@ -264,14 +306,7 @@ class CRDTRoomManager:
         room = self.active_room(file_id)
         if room is None:
             return False
-        text = room.ydoc.get("content", type=Text)
-        current = str(text)
-        if new_content != current:
-            with room.ydoc.transaction():
-                if current:
-                    del text[0 : len(current.encode("utf-8"))]
-                if new_content:
-                    text += new_content
+        _replace_all(room, room.ydoc.get("content", type=Text), new_content)
         await self.flush(file_id)
         return True
 

--- a/src/backend/tests/test_crdt_rooms.py
+++ b/src/backend/tests/test_crdt_rooms.py
@@ -11,7 +11,7 @@ import asyncio
 import uuid
 
 import pytest_asyncio
-from pycrdt import Text
+from pycrdt import Doc, Text
 
 from app.core.db import get_sessionmaker
 from app.models.manuscript import ManuscriptFile
@@ -125,6 +125,97 @@ async def test_room_snapshot_debounce_and_ai_edit(client, monkeypatch):
     room2 = await manager.connect(file_id=file_id, db_content="ignored")
     assert room2 is room
     assert str(room2.ydoc.get("content", type=Text)) == current
+
+
+async def test_room_rebuild_after_restart_does_not_duplicate_document(client):
+    """#347：进程重启后房间按原 CRDT 历史恢复，幸存标签页重连不把文档变成两份。
+
+    现场是「126 行变 249 行、\\documentclass 同时在第 3 行和第 127 行」。成因不是
+    合并算法出错，而是重建方式：拿纯文本往空文档里灌，产生的是一套全新历史，
+    和标签页手里那套互不认识——CRDT 忠实地把两套插入操作都保留下来，于是全文
+    出现两份。这里把那条时间线原样走一遍。
+    """
+    _, _, file_id = await _seed_file(client)
+    manager = get_crdt_rooms()
+
+    # 1) 编辑中：房间在，浏览器标签页持有同一套历史（y-websocket 同步的效果）
+    room = await manager.connect(file_id=file_id, db_content=SKELETON)
+    tab = Doc()
+    tab.apply_update(room.ydoc.get_update())
+    tab_text = tab.get("content", type=Text)
+    assert str(tab_text) == SKELETON
+
+    # 标签页里敲一笔，同步回房间；随后落库（编译前的 flush 就是这一步）
+    tab_text += "% typed in the tab\n"
+    room.ydoc.apply_update(tab.get_update())
+    await manager.flush(file_id)
+
+    async with get_sessionmaker()() as session:
+        file = await session.get(ManuscriptFile, file_id)
+        before = file.content
+        assert file.ydoc_state, "快照必须连 CRDT 状态一起落库，否则重启只能拿文本重建"
+
+    # 2) 进程重启：房间与内存态全没了，库里只剩两列
+    await reset_crdt_rooms()
+    manager = get_crdt_rooms()
+    assert manager.active_room(file_id) is None
+
+    # 3) 标签页自动重连：房间按 ydoc_state 恢复，两边互相同步
+    async with get_sessionmaker()() as session:
+        file = await session.get(ManuscriptFile, file_id)
+        room2 = await manager.connect(
+            file_id=file_id, db_content=file.content, ydoc_state=file.ydoc_state
+        )
+    room2.ydoc.apply_update(tab.get_update())
+    tab.apply_update(room2.ydoc.get_update())
+
+    merged = str(room2.ydoc.get("content", type=Text))
+    assert merged == before, "重连合并后内容必须与重启前一致"
+    assert merged == str(tab_text), "房间与标签页收敛到同一份"
+    # 逐份点名，别只看长度：重复时这些标记会各出现两次
+    assert merged.count("\\documentclass") == 1
+    assert merged.count("\\begin{document}") == 1
+    assert merged.count("\\end{document}") == 1
+    assert merged.count("% typed in the tab") == 1
+
+
+async def test_room_rebuild_without_state_still_seeds_from_text(client):
+    """存量文件（升级前落的库，ydoc_state 为 NULL）仍按老路子从文本播种。"""
+    _, _, file_id = await _seed_file(client)
+    manager = get_crdt_rooms()
+
+    room = await manager.connect(file_id=file_id, db_content=SKELETON, ydoc_state=None)
+    assert str(room.ydoc.get("content", type=Text)) == SKELETON
+
+
+async def test_room_rebuild_prefers_db_text_edited_while_closed(client):
+    """房间不在时库文本被直接改过（AI 分节写入 / 版本回滚 / REST 保存）：
+    以库为准，但替换发生在恢复出来的那套历史里，重连的标签页照样收敛。"""
+    _, _, file_id = await _seed_file(client)
+    manager = get_crdt_rooms()
+
+    room = await manager.connect(file_id=file_id, db_content=SKELETON)
+    tab = Doc()
+    tab.apply_update(room.ydoc.get_update())
+    await manager.flush(file_id)
+
+    await reset_crdt_rooms()
+    manager = get_crdt_rooms()
+
+    # 房间不在时有人直接改库（apply_ai_edit 的无房间路径就是这样）
+    edited = SKELETON.replace("old results body", "rewritten while the room was closed")
+    async with get_sessionmaker()() as session:
+        file = await session.get(ManuscriptFile, file_id)
+        state = file.ydoc_state
+        file.content = edited
+        await session.commit()
+
+    room2 = await manager.connect(file_id=file_id, db_content=edited, ydoc_state=state)
+    room2.ydoc.apply_update(tab.get_update())
+    merged = str(room2.ydoc.get("content", type=Text))
+    assert "rewritten while the room was closed" in merged
+    assert "old results body" not in merged
+    assert merged.count("\\documentclass") == 1
 
 
 async def test_stream_section_open_delta_replace(client):

--- a/src/backend/tests/test_idea_forge.py
+++ b/src/backend/tests/test_idea_forge.py
@@ -11,6 +11,7 @@ import pytest
 from sqlalchemy import select
 
 from app.agents.voyage import VoyageEngine
+from app.agents.voyage.actions_ideas import _interleave_by_signal
 from app.core.db import get_sessionmaker
 from app.core.llm.fake import EMBEDDING_DIM, FakeProvider
 from app.core.llm.router import LLMRouter
@@ -454,3 +455,49 @@ async def test_idea_trash_flow(client):
     r = await client.post(f"/api/projects/{project_id}/ideas/trash/empty", headers=headers)
     assert r.json()["affected"] == 2
     assert (await client.get(f"/api/ideas/{ids[1]}", headers=headers)).status_code == 404
+
+
+def test_gap_list_interleaves_signals_instead_of_concatenating():
+    """#428：gap 清单按信号轮转铺开，靠后的信号不会整段被挤到尾巴上。
+
+    生成器只写 num_ideas（默认 8）条想法。顺序拼接时，排在最后的信号——包括
+    任何新加的信号——整段落在 20+ 条清单的尾部，再好也轮不到。
+    """
+    buckets = {
+        "survey_gap": [{"title": f"s{i}", "signal": "survey_gap"} for i in range(5)],
+        "concept_holes": [{"title": f"c{i}", "signal": "concept_holes"} for i in range(4)],
+        "trends": [{"title": "t0", "signal": "trends"}],
+        "limitations": [{"title": f"l{i}", "signal": "limitations"} for i in range(3)],
+    }
+
+    gaps = _interleave_by_signal(buckets)
+
+    # 一条不少、一条不多
+    assert len(gaps) == 13
+    assert {g["title"] for g in gaps} == {
+        *(f"s{i}" for i in range(5)),
+        *(f"c{i}" for i in range(4)),
+        "t0",
+        *(f"l{i}" for i in range(3)),
+    }
+
+    # 每个信号的第一条都排进前四位：只写 8 条也不会有信号完全落空
+    assert [g["title"] for g in gaps[:4]] == ["s0", "c0", "t0", "l0"]
+    # 只有一条的 trends 照样在最前面拿到名额（顺序拼接时它排在第 10 位）
+    assert {g["signal"] for g in gaps[:8]} == {
+        "survey_gap",
+        "concept_holes",
+        "trends",
+        "limitations",
+    }
+
+    # 信号内部原有顺序保持不变（相关性排序不能被打乱）
+    assert [g["title"] for g in gaps if g["signal"] == "survey_gap"] == [f"s{i}" for i in range(5)]
+
+
+def test_gap_interleave_tolerates_empty_and_missing_signals():
+    """信号缺席/为空是常态（无概念图、无全文、无近期趋势）——不留空洞。"""
+    assert _interleave_by_signal({}) == []
+    assert _interleave_by_signal({"trends": []}) == []
+    only_one = {"survey_gap": [{"title": "s0", "signal": "survey_gap"}], "trends": []}
+    assert [g["title"] for g in _interleave_by_signal(only_one)] == ["s0"]

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,7 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "a5b9c3d7e1f2"  # Skill-system convergence step 1 (#741)
+HEAD_REVISION = "c4a1d8e93b57"  # Manuscript CRDT state persistence (#347)
+SKILLS_CONVERGENCE_REVISION = "a5b9c3d7e1f2"  # Skill-system convergence step 1 (#741)
 HYGIENE_REVISION = "351c324f4f6b"  # Schema hygiene: retired columns + owner merge (#734)
 SETTINGS_REVISION = "b737c1a2d3e4"  # User-preference settings move to users.settings (#737)
 RESOURCES_REVISION = "d2dcfc8b899f"  # Resources, leases, polymorphic credentials (#677)
@@ -187,6 +188,8 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     command.upgrade(cfg, "head")
     version, columns = _inspect_db(db_path)
     assert version == HEAD_REVISION
+    # 协同文档 CRDT 状态（#347）：房间重建靠它，不能只留纯文本投影
+    assert "ydoc_state" in columns["manuscript_files"]
     # 列卫生（#734）：退役快照列与归属副本列在 head 已删
     assert not {"wiki_content", "compiled_at", "compiled_model"} & columns["library_papers"]
     assert "wiki_content" not in columns["user_library_entries"]
@@ -623,7 +626,14 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     } <= columns["paper_extractions"]
     assert "ix_paper_extractions_paper_id" in _index_names(db_path, "paper_extractions")
 
-    # 先退掉技能收敛第一步（#741）：审核残列按原形状回来，指引文档表消失。
+    # 先退掉协同文档 CRDT 状态列（#347）。
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == SKILLS_CONVERGENCE_REVISION
+    assert "ydoc_state" not in columns["manuscript_files"]
+    assert "content" in columns["manuscript_files"]  # 纯文本投影不受影响
+
+    # 再退掉技能收敛第一步（#741）：审核残列按原形状回来，指引文档表消失。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == HYGIENE_REVISION
@@ -1300,7 +1310,9 @@ def test_skill_convergence_data_move_and_roundtrip(tmp_path):
                 {"id": lid, "sid": skill_id, "vid": v1_id, "status": status},
             )
 
-    command.upgrade(cfg, HEAD_REVISION)
+    # 精确升到 #741 本身（不用 head：#347 已排在它后面，
+    # 用 head 会让下面的 downgrade -1 退错一层）
+    command.upgrade(cfg, SKILLS_CONVERGENCE_REVISION)
     with engine.connect() as conn:
         docs = conn.execute(
             text("SELECT id, version, name, body, targets, steps FROM guidance_documents "


### PR DESCRIPTION
Addresses the **secondary issue** in #428. Does not close it — see the scope note below.

## The problem

`forge.gap_analysis` built its gap list by appending one signal at a time: the survey-gap block, then `concept_holes`, then `trends`, then `limitations`. The generator writes only `num_ideas` ideas (8 by default) from a list that routinely exceeds twenty entries, so whatever sits at the tail never influences an idea.

Two consequences, both from position rather than quality:

- `limitations` — the last block — was structurally disadvantaged on every run.
- **A newly added signal looks worthless on arrival.** Whoever adds one measures its value against a run where its gaps were never read. #428's proposed refinement signal would have walked straight into this.

## The change

Gaps are collected per signal and interleaved round-robin, so each signal contributes its strongest item near the front and signals compete on quality rather than on where they happen to appear in the function.

- Order **within** a signal is preserved — that ordering carries relevance.
- Absent and empty signals are the normal case (no concept graph, no full text, no recent trend) and leave no holes.
- Nothing is dropped or added; only the order changes.

Concretely, with 5 survey gaps, 4 concept holes, 1 trend and 3 limitations, the single trend used to land at position 10 and never be read. It is now third, and the first eight entries cover all four signals.

## Scope

The three **structural** causes in #428 are not addressed here, because they are feature work rather than defects and involve product decisions that should be yours:

1. **The generator sees 20 of 106 papers** — changing `max_context_papers` or the 12000-char budget trades context breadth against prompt cost and dilution. That is a tuning decision with a benchmark attached, not a bug fix.
2. **No refinement-shaped signal** — "this knob is global everywhere and nobody made it adaptive" requires the per-paper method cards described in the issue: a new extraction schema, storage, and an aggregation pass.
3. **Free-form knob names never align** — your own probe found 152 distinct names across 51 cards with exactly one repeat, so this needs a controlled vocabulary, which is a design decision (fixed taxonomy vs. embedding clustering) with real consequences for cross-discipline use.

Those three are worth their own issue with the rediscovery benchmark as the acceptance test. This change is a prerequisite for evaluating any of them honestly: without it, a new signal cannot be measured because its output would not reach the generator.

## Verification

10 passed (forge suite plus the golden chains), `ruff check` clean in the CI scope. Two new tests pin the behavior: one asserts every signal appears within the first eight entries and that within-signal order survives, the other covers absent and empty signals.
