### PR TITLE
fix: user-facing copy stops describing a shared lab

### DIFF
--- a/src/frontend/src/features/daily/CollectTreeModal.tsx
+++ b/src/frontend/src/features/daily/CollectTreeModal.tsx
@@ -356,9 +356,9 @@ export function CollectTreeModal({
         </div>
       ) : (
         <div className="col" style={{ gap: 2 }}>
-          {/* —— 实验室文献库 —— */}
+          {/* —— 文献库 —— */}
           <ParentRow
-            label={tr('实验室文献库', 'Shared libraries')}
+            label={tr('文献库', 'Libraries')}
             state={libState}
             expanded={libsOpen}
             onToggleExpand={() => setExpandLibs((o) => !o)}

--- a/src/frontend/src/features/settings/LiteratureSearchSettings.tsx
+++ b/src/frontend/src/features/settings/LiteratureSearchSettings.tsx
@@ -475,7 +475,7 @@ export function LiteratureSearchSettingsPanel() {
           </>
         }
       >
-        <FormField label={tr('密钥标签', 'Credential label')} hint={tr('用于区分同一来源的多个密钥，例如“实验室主账号”。', 'Distinguishes keys in the same pool, such as “Lab primary”.')}>
+        <FormField label={tr('密钥标签', 'Credential label')} hint={tr('用于区分同一来源的多个密钥，例如“主账号”“备用”。', 'Distinguishes keys in the same pool, such as “Primary” or “Backup”.')}>
           <input className="input" maxLength={120} value={credentialDraft.label} placeholder={tr('可选', 'Optional')} onChange={(event) => setCredentialDraft({ ...credentialDraft, label: event.target.value })} />
         </FormField>
         <FormField

--- a/src/frontend/src/features/settings/SettingsPage.tsx
+++ b/src/frontend/src/features/settings/SettingsPage.tsx
@@ -2385,7 +2385,7 @@ function DailyCategoriesSection() {
       </div>
       <div style={{ fontSize: 12, color: 'var(--text-3)', marginBottom: 14 }}>
         {tr(
-          '每天从 arxiv 抓取这些分类下的新提交，全实验室共用一份。改动从下一次抓取开始生效。',
+          '每天从 arxiv 抓取这些分类下的新提交，本部署共用一份。改动从下一次抓取开始生效。',
           'New arxiv submissions in these categories are fetched daily and shared across the deployment. Changes apply from the next fetch.',
         )}
       </div>

--- a/src/frontend/src/features/start/StartPage.tsx
+++ b/src/frontend/src/features/start/StartPage.tsx
@@ -26,8 +26,8 @@ const ENTRIES: { to: string; icon: IconName; zh: [string, string]; en: [string, 
   {
     to: '/libraries',
     icon: 'book',
-    zh: ['实验室文献库', '全实验室共享的方向文献库，可以浏览、检索、和文献对话。'],
-    en: ['Lab libraries', 'Shared topic libraries for the whole lab — browse, search and chat with the papers.'],
+    zh: ['文献库', '按研究方向组织的文献库，可以浏览、检索、和文献对话。'],
+    en: ['Libraries', 'Topic libraries — browse, search and chat with the papers.'],
   },
   {
     to: '/daily',

--- a/src/frontend/src/features/writer/TemplateUploadModal.tsx
+++ b/src/frontend/src/features/writer/TemplateUploadModal.tsx
@@ -138,7 +138,7 @@ export function TemplateUploadModal({ open, onClose, pid, onUploaded }: Template
           className="input"
           value={name}
           onChange={(e) => setName(e.target.value)}
-          placeholder={tr('例如：实验室内部技术报告', 'e.g. Lab internal tech report')}
+          placeholder={tr('例如：内部技术报告', 'e.g. Internal tech report')}
         />
       </FormField>
 


### PR DESCRIPTION
The de-lab work removed the mechanisms — members, invites, curators, governance columns, approval flows, leaderboards — but the interface kept telling users the product was shared by a laboratory.

Reported from a running deployment: the daily-papers setting still reads 「全实验室共用一份」.

## What was wrong

| Where | Said |
| --- | --- |
| `StartPage.tsx` | 「实验室文献库 / 全实验室共享的方向文献库」 · "Lab libraries / Shared topic libraries for the whole lab" |
| `SettingsPage.tsx` (daily papers) | 「每天从 arxiv 抓取…**全实验室共用一份**」 |
| `CollectTreeModal.tsx` | 「实验室文献库」 · "Shared libraries" |
| `LiteratureSearchSettings.tsx` | key label example 「实验室主账号」 · "Lab primary" |
| `TemplateUploadModal.tsx` | placeholder 「实验室内部技术报告」 · "Lab internal tech report" |

**One was already half fixed**, which is the interesting part: the daily-papers setting's English had been corrected to "shared across the deployment" while the Chinese still said the lab. The earlier documentation pass (#735) swept `docs/` and never touched UI strings, so the two languages drifted apart in the same `tr()` call. The Chinese now matches the English that was already right.

## What is deliberately left

Wording that describes **scale** rather than an organisation is correct and stays:

- `Experiment Lab` / 「实验搭建」 — the name of a workbench stage, not a group.
- 「实验室 1-2 人、数张 GPU、3 个月」 in the feasibility rubric — a yardstick for compute scale.
- "lab meeting talk" as an example of a talk to generate slides for — a real thing people present at.

The `/lab` route path also stays: it is already labelled 「文献任务」 / "Library tasks" in the sidebar, and changing the path would break existing bookmarks for cosmetic gain.

## Verification

String literals only, no logic touched. Frontend vitest (node-ci) and the frontend build with `tsc --noEmit` (desktop-build) cover it.
