### PR TITLE
refactor: extract the plugin host so both forms boot the same way (#754)

### DIFF
--- a/src/desktop/src/main/kernel.ts
+++ b/src/desktop/src/main/kernel.ts
@@ -25,24 +25,15 @@
    ============================================================ */
 
 import { app } from 'electron';
-import { join } from 'node:path';
-import { pathToFileURL } from 'node:url';
 
 import {
-  Loader,
-  MemoryConfigTreeStore,
-  SqliteTree,
-  createImportGuard,
-  createKernel,
-  registerBuiltins,
-  storage,
-  verifyInstalledEntries,
+  createPluginHost,
+  marketPluginsDir as kernelMarketPluginsDir,
   type ConfigEntry,
-  type ConfigTreeStore,
-  type InstallVerifyIssue,
   type Kernel,
   type LegacyEngineConfig,
   type PluginMetaStore,
+  type SqliteTree,
   type StorageService,
 } from '@polaris/kernel';
 
@@ -57,7 +48,7 @@ let kernel: Kernel | null = null;
  * import，必须是文件系统上的普通路径。
  */
 export function marketPluginsDir(): string {
-  return join(app.getPath('userData'), 'plugins');
+  return kernelMarketPluginsDir(app.getPath('userData'));
 }
 
 /**
@@ -161,76 +152,16 @@ async function doStartKernel(): Promise<Kernel> {
   // smoke 等场景会 stop 后再次 start：进度回到初始态，别让上一轮的
   // ready/failed 冒充本轮结论
   bootstrapStatus = { phase: 'starting', done: false };
-  const instance = createKernel({ name: 'polaris-desktop' });
-
-  // 持久层先于 loader 直挂：配置树就存在这里。失败不阻断启动——树退化
-  // 为内存 store（见下），壳仍可用；kernel.status 的 storage=false 会把
-  // 这件事暴露给渲染层与冒烟测试。
-  try {
-    await instance.ctx.plugin(storage, {
-      path: join(app.getPath('userData'), 'kernel', 'storage.db'),
-    });
-  } catch (err) {
-    console.error('[kernel] storage 持久层挂载失败，本次会话不落盘：', err);
-  }
-
-  // storage 挂载失败时的降级：MemoryConfigTreeStore 让 loader 树照常
-  // 工作（首启种子也照种），只是这次会话的改动不落盘。
-  const storageSvc = instance.ctx.get('storage') as StorageService | undefined;
-  const store: ConfigTreeStore = storageSvc?.configTree ?? new MemoryConfigTreeStore();
-  const pluginMeta = storageSvc?.pluginMeta;
-
-  // 三方插件动态 import 的解析基准（#708）：vendor loader 对相对 specifier
-  // 用 new URL(name, ctx.baseUrl) 解析（也是 internal loader 的 parentURL），
-  // EntryTree 构造时从父 ctx 拷贝，所以必须赶在 Loader/SqliteTree 装载之前
-  // 设到根 ctx 上。市场条目虽然存的是绝对 file:// URL 不依赖它，但这让
-  // 手写的相对条目（开发者本地插件）也有明确语义。尾部斜杠是 URL 基准
-  // 目录的规矩，少了最后一段会被当文件名换掉。
-  instance.ctx.baseUrl = `${pathToFileURL(marketPluginsDir()).href}/`;
-
-  // 装载前哈希复核（#708）主挂点：树装载之前扫一遍安装记录，被篡改的
-  // 安装物在打包态直接改持久树为 disabled——树装载用的是事务化 reconcile，
-  // 单条目 import 抛错会整树回滚，只有装载前改 store 能做到「坏的禁掉、
-  // 其余照常」。开发态仅告警（本地改入口文件是正常开发动作）。
-  let installIssues: InstallVerifyIssue[] = [];
-  if (pluginMeta) {
-    try {
-      installIssues = await verifyInstalledEntries({
-        metaStore: pluginMeta,
-        store,
-        strict: app.isPackaged,
-      });
-      for (const issue of installIssues) console.warn(`[kernel] ${issue.message}`);
-    } catch (err) {
-      console.error('[kernel] 安装记录哈希复核失败（跳过，不阻断启动）：', err);
-    }
-  }
-
-  let configTree: SqliteTree | undefined;
-  try {
-    if ((await store.load()).length === 0) await store.save(SEED_ENTRIES);
-    await instance.ctx.plugin(Loader);
-    registerBuiltins(instance.ctx.loader);
-    await instance.ctx.plugin(SqliteTree, {
-      store,
-      // 第二道闸：会话运行中被篡改、用户再点启用时在 import 阶段拒绝
-      //（enable 是单条目 update，失败只回滚它自己，错误经 IPC 给用户）
-      guardImport: pluginMeta
-        ? createImportGuard({
-            metaStore: pluginMeta,
-            strict: app.isPackaged,
-            warn: (message) => console.warn(`[kernel] ${message}`),
-          })
-        : undefined,
-    });
-    configTree = instance.ctx.get('configTree') as SqliteTree | undefined;
-    // 扫描结论挂到条目注记上：被强制禁用的条目要在插件列表里说清原因
-    for (const issue of installIssues) configTree?.warnings.set(issue.entryId, issue.message);
-  } catch (err) {
-    // 树挂不上（数据损坏 / 某条目装载失败整树回滚）只损失插件能力，壳必须
-    // 照常起：configTree 留空，引擎注入被跳过，前端按 localBackend=null 回落远端。
-    console.error('[kernel] 配置树装载失败，本次会话无插件树：', err);
-  }
+  // 装配顺序（storage → baseUrl → 哈希复核 → 种子 → Loader → SqliteTree）
+  // 住在 @polaris/kernel 的 createPluginHost 里，与服务器形态共用一份（#754）：
+  // 装哪些内置插件、树长什么样、三方包的 import 基准在哪，两个形态必须一致，
+  // 否则市场里同一个包在两边装出不同结果。桌面特有的部分（引擎注入）留在下面。
+  const { kernel: instance, configTree } = await createPluginHost({
+    name: 'polaris-desktop',
+    dataRoot: app.getPath('userData'),
+    seedEntries: SEED_ENTRIES,
+    strict: app.isPackaged,
+  });
 
   let engine = parseEngineSpec(process.env.POLARIS_DESKTOP_ENGINE);
   // 并行隔离（壳级 E2E / 同机多实例）：docker 容器名与宿主端口默认是固定值，

--- a/src/kernel/src/host.ts
+++ b/src/kernel/src/host.ts
@@ -1,0 +1,141 @@
+/* ============================================================
+   插件宿主装配（#754）：把「持久层 → 配置树 → loader → fiber」这套
+   开机顺序从桌面主进程里抽出来，桌面与服务器形态共用同一份。
+
+   抽出来的理由不是省代码，是**防漂移**：装哪些内置插件、种子树长什么样、
+   三方包的 import 基准在哪、哈希复核在装载前还是装载后——这些决定了
+   「插件世界」的形状。两个形态各写一份，迟早会变成两套语义不同的插件系统，
+   而市场里同一个包要在两边都能装。
+
+   本模块刻意不认识 electron：数据根与严格模式由调用方给，桌面传
+   app.getPath('userData') 与 app.isPackaged，服务器传数据目录与生产标志。
+   （src/kernel 全包都由 tests/electron-free.test.ts 机械把关。）
+
+   形态差异留在调用方，不进这里：
+   - 桌面还要按 env/打包引导注入 legacy-engine 的运行参数；
+   - 服务器的 Python 边缘是独立容器，树里根本没有 legacy-engine。
+   所以种子树是参数，不是常量。
+   ============================================================ */
+
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+import { Loader } from '@deepseek-ai/cordis-plugin-loader'
+
+import { MemoryConfigTreeStore, type ConfigEntry, type ConfigTreeStore } from './config/tree.ts'
+import { SqliteTree } from './config/sqlite-tree.ts'
+import { createKernel, type Kernel } from './kernel.ts'
+import { createImportGuard, verifyInstalledEntries, type InstallVerifyIssue } from './market/lifecycle.ts'
+import { registerBuiltins } from './plugins/builtins.ts'
+import { storage, type StorageService } from './plugins/storage.ts'
+import type { PluginMetaStore } from './storage/store.ts'
+
+export interface PluginHostLog {
+  warn(message: string): void
+  error(message: string, error?: unknown): void
+}
+
+export interface CreatePluginHostOptions {
+  /** 内核实例名（出现在 kernel.status / 日志里）。 */
+  name: string
+  /** 数据根：storage.db 落在 <dataRoot>/kernel/，市场安装物落在 <dataRoot>/plugins/。 */
+  dataRoot: string
+  /**
+   * 首启种子树。**只在 store 完全为空时写入**——树是用户状态的真相，
+   * 任何非空内容都不做「补齐」，那会把用户显式删掉的条目悄悄种回来。
+   */
+  seedEntries: ConfigEntry[]
+  /**
+   * 安装物哈希复核的严格模式。true = 对不上就强制禁用（打包态/生产），
+   * false = 仅告警（开发态本地改插件入口文件是正常动作）。
+   */
+  strict: boolean
+  log?: PluginHostLog
+}
+
+export interface PluginHost {
+  kernel: Kernel
+  /** 装载失败时为 undefined：宿主仍然可用，只是这次会话没有插件树。 */
+  configTree?: SqliteTree
+  store: ConfigTreeStore
+  /** storage 挂载失败时为 undefined（此时 store 是内存实现，改动不落盘）。 */
+  pluginMeta?: PluginMetaStore
+  installIssues: InstallVerifyIssue[]
+  /** 市场安装物根目录，调用方要用它做 ctx.baseUrl 之外的路径推导时可取。 */
+  pluginsDir: string
+}
+
+/** 市场安装物的落盘根：<dataRoot>/plugins/<包名>/<版本>/。 */
+export function marketPluginsDir(dataRoot: string): string {
+  return join(dataRoot, 'plugins')
+}
+
+const consoleLog: PluginHostLog = {
+  warn: (message) => console.warn(message),
+  error: (message, error) => console.error(message, error),
+}
+
+/**
+ * 按固定顺序装配插件宿主。顺序本身是契约，别重排：
+ *
+ * 1. storage 先于 loader 直挂——配置树就存在它里面；失败则降级为内存 store，
+ *    宿主照常起（kernel.status 的 storage=false 把这件事暴露出去）。
+ * 2. ctx.baseUrl 必须在 Loader/SqliteTree 之前设好：vendor loader 用
+ *    new URL(name, ctx.baseUrl) 解析相对 specifier，EntryTree 构造时从父 ctx
+ *    拷贝，晚设就来不及了。
+ * 3. 哈希复核在**树装载之前**：树装载是事务化 reconcile，单条目 import 抛错
+ *    会整树回滚；只有装载前改 store 才能做到「坏的禁掉、其余照常」。
+ */
+export async function createPluginHost(options: CreatePluginHostOptions): Promise<PluginHost> {
+  const log = options.log ?? consoleLog
+  const pluginsDir = marketPluginsDir(options.dataRoot)
+  const kernel = createKernel({ name: options.name })
+
+  try {
+    await kernel.ctx.plugin(storage, { path: join(options.dataRoot, 'kernel', 'storage.db') })
+  } catch (err) {
+    log.error('[kernel] storage 持久层挂载失败，本次会话不落盘：', err)
+  }
+
+  const storageSvc = kernel.ctx.get('storage') as StorageService | undefined
+  const store: ConfigTreeStore = storageSvc?.configTree ?? new MemoryConfigTreeStore()
+  const pluginMeta = storageSvc?.pluginMeta
+
+  // 尾部斜杠是 URL 基准目录的规矩：少了最后一段会被当文件名换掉
+  kernel.ctx.baseUrl = `${pathToFileURL(pluginsDir).href}/`
+
+  let installIssues: InstallVerifyIssue[] = []
+  if (pluginMeta) {
+    try {
+      installIssues = await verifyInstalledEntries({ metaStore: pluginMeta, store, strict: options.strict })
+      for (const issue of installIssues) log.warn(`[kernel] ${issue.message}`)
+    } catch (err) {
+      log.error('[kernel] 安装记录哈希复核失败（跳过，不阻断启动）：', err)
+    }
+  }
+
+  let configTree: SqliteTree | undefined
+  try {
+    if ((await store.load()).length === 0) await store.save(options.seedEntries)
+    await kernel.ctx.plugin(Loader)
+    registerBuiltins(kernel.ctx.loader)
+    await kernel.ctx.plugin(SqliteTree, {
+      store,
+      // 第二道闸：会话运行中被篡改、用户再点启用时在 import 阶段拒绝
+      guardImport: pluginMeta
+        ? createImportGuard({
+            metaStore: pluginMeta,
+            strict: options.strict,
+            warn: (message) => log.warn(`[kernel] ${message}`),
+          })
+        : undefined,
+    })
+    configTree = kernel.ctx.get('configTree') as SqliteTree | undefined
+    // 扫描结论挂到条目注记上：被强制禁用的条目要在插件列表里说清原因
+    for (const issue of installIssues) configTree?.warnings.set(issue.entryId, issue.message)
+  } catch (err) {
+    log.error('[kernel] 配置树装载失败，本次会话无插件树：', err)
+  }
+
+  return { kernel, configTree, store, pluginMeta, installIssues, pluginsDir }
+}

--- a/src/kernel/src/index.ts
+++ b/src/kernel/src/index.ts
@@ -1,5 +1,12 @@
 export { Kernel, createKernel, type KernelOptions } from './kernel.ts'
 export {
+  createPluginHost,
+  marketPluginsDir,
+  type CreatePluginHostOptions,
+  type PluginHost,
+  type PluginHostLog,
+} from './host.ts'
+export {
   JsonRpcEndpoint,
   type JsonRpcEndpointOptions,
   type NotificationHandler,


### PR DESCRIPTION
First step of #754. No behaviour change — this is the seam the server form needs.

## Why extract rather than write a second boot

The sequence that assembles the plugin world lived inside the Electron main process: mount storage, set the import base URL, run the pre-load hash check, seed the tree, mount the loader, register builtins, mount `SqliteTree`. The server form needs the same sequence.

The reason to share it is not brevity, it is **drift**. That sequence encodes which builtins exist, what the seed tree looks like, where third-party packages resolve their imports, and whether the hash check runs before or after the tree loads. Two copies of those decisions quietly become two different plugin systems — and the market ships one package that has to install identically in both.

## What moved

`createPluginHost` in `src/kernel/src/host.ts` takes `dataRoot` and `strict` instead of reading `app.getPath('userData')` and `app.isPackaged`, so `src/kernel` stays electron-free exactly as `tests/electron-free.test.ts` enforces.

The **seed tree is a parameter, not a constant** — that difference is real: the desktop seeds `legacy-engine` as a disabled placeholder, while a server runs the Python edge as its own containers and should have no such entry.

Form-specific logic deliberately stays in `src/desktop/src/main/kernel.ts`: parsing `POLARIS_DESKTOP_ENGINE`, the packaged-engine bootstrap, injecting the engine spec through `entry.update`, and the bootstrap progress the first-run waiting page polls.

The ordering comments travelled with the code, because the order is a contract: storage before the loader (the tree lives inside it), `ctx.baseUrl` before `Loader`/`SqliteTree` (the vendored loader copies it at construction), and the hash check before the tree loads (tree loading is a transactional reconcile — only changing the store beforehand can disable one bad entry while the rest load).

## Verification

The desktop smoke is the real gate here, and it passes with **0 failures**:

- kernel started, instance name, plugin count
- all three seed entries present, `legacy-engine` still a disabled placeholder
- the tree-driven `sources` service mounted
- `plugins.list` / `exportTree` / `disable` / `enable`
- the full market flow: endpoint default, persistence and reset, the KV read-through shim, `fetchIndex`, install record in `PluginMetaStore`, and the installed entry landing as `file://` + disabled (install/enable separation)

Kernel suite 98 passed; `tsc --noEmit` clean for desktop.
