### PR TITLE
refactor: plugins.* methods and guards become transport-agnostic (#754)

### DIFF
--- a/src/desktop/src/main/ipc/methods.plugins.ts
+++ b/src/desktop/src/main/ipc/methods.plugins.ts
@@ -1,94 +1,50 @@
 /* ============================================================
-   plugins.* 的实现（#705）：全部是「取 configTree 句柄 → 调 kernel 侧
-   方法」的薄壳。语义都住在 kernel（@polaris/kernel 的 SqliteTree）里，
-   这里只负责三件事：
-   - 能力门槛：树不可达时统一抛 ERR_CAPABILITY_UNAVAILABLE（与能力位
-     plugins.manage 读同一个 kernelConfigTree()，可用性天然一致）；
-   - 把校验错误按契约作为数据返回（PluginValidationResult），把装载
-     失败作为异常抛出——前者是用户输入问题要就地回显，后者是运行故障；
-   - 写操作后 flush：树的 write 是防抖合并的，IPC 返回前落盘，renderer
-     看到成功即已持久。
-   参数形状校验在 router 的手写守卫里（见 router.ts 文件头），这里默认
-   拿到的已是形状正确的值；语义校验（__jsExpr/未知字段/重复 id/schema）
-   由 kernel 层完成——双层校验各管一层，互不重复。
+   plugins.* 在桌面侧的绑定（#705，#754 起实现搬进 kernel）。
+
+   语义与参数守卫都住在 @polaris/kernel 的 rpc/plugin-methods.ts——服务器
+   形态要的是同一批方法、同一套校验，只是传输不同，所以实现只有一份。
+   这里剩下的唯一职责是把桌面的宿主句柄（模块级单例）接上去。
+
+   句柄传的是函数不是值：树与持久层在会话中可能尚未就绪（storage 挂载失败、
+   树装载失败），能力门槛必须每次调用现读。
    ============================================================ */
 
-import type { SqliteTree } from '@polaris/kernel';
+import { createPluginMethods, type RpcMethod } from '@polaris/kernel';
 
-import {
-  ERR_CAPABILITY_UNAVAILABLE,
-  ERR_INVALID_PARAMS,
-  type PluginEntryInfo,
-  type PluginTreeExport,
-  type PluginValidationResult,
-} from '../../shared/contract';
+import type { MethodName, PluginEntryInfo, PluginTreeExport } from '../../shared/contract';
 import { kernelConfigTree, kernelPluginMeta } from '../kernel';
 
-function requireTree(): SqliteTree {
-  const tree = kernelConfigTree();
-  if (!tree) {
-    throw new Error(`${ERR_CAPABILITY_UNAVAILABLE}: plugins.manage — kernel 配置树不可用`);
-  }
-  return tree;
-}
+/**
+ * 本表覆盖的方法名：plugins.* 去掉 plugins.market.*（市场那族还在桌面侧，
+ * 它要 job 事件与旧 store 读穿）。写成受约束的子集而不是 Record<string>，
+ * 是为了保住 router 那张表的穷尽性——契约里新增一个 plugins.* 方法却没实现，
+ * 应该当场编译失败，而不是运行时才报未知方法。
+ */
+type SharedPluginMethod = Exclude<
+  Extract<MethodName, `plugins.${string}`>,
+  `plugins.market.${string}`
+>;
 
-/** 变更后的条目回执：让 UI 开关不用再发一次 list 就能拿到最终运行态。 */
-function entryInfo(tree: SqliteTree, id: string): PluginEntryInfo {
-  const info = tree.listEntries().find((entry) => entry.id === id);
-  // resolve 成功过的 id 一定在列表里；防御性兜底只为类型收窄
-  if (!info) throw new Error(`${ERR_INVALID_PARAMS}: unknown plugin entry ${id}`);
-  return info;
-}
+export const pluginMethods = createPluginMethods({
+  configTree: () => kernelConfigTree(),
+  pluginMeta: () => kernelPluginMeta(),
+}) as Record<SharedPluginMethod, RpcMethod>;
+
+/* 具名直调入口：冒烟测试在主进程内不经 IPC 直接驱动这几个方法，保留带类型的
+   包装让它免去自己拼参数对象。生产路径（router）走上面那张表。 */
 
 export function pluginsList(): PluginEntryInfo[] {
-  return requireTree().listEntries();
+  return pluginMethods['plugins.list'](undefined) as PluginEntryInfo[];
 }
 
-export async function pluginsEnable(id: string): Promise<PluginEntryInfo> {
-  const tree = requireTree();
-  // disabled: null = 删除该键（loader 的 isNullable 语义），回到默认启用。
-  // 拉起失败时 Entry.update 自己回滚 options（树不被污染），错误照抛。
-  await tree.update(id, { disabled: null });
-  await tree.flush();
-  return entryInfo(tree, id);
+export function pluginsEnable(id: string): Promise<PluginEntryInfo> {
+  return pluginMethods['plugins.enable']({ id }) as Promise<PluginEntryInfo>;
 }
 
-export async function pluginsDisable(id: string): Promise<PluginEntryInfo> {
-  const tree = requireTree();
-  await tree.update(id, { disabled: true });
-  await tree.flush();
-  return entryInfo(tree, id);
-}
-
-export async function pluginsUpdateConfig(
-  id: string,
-  config: unknown,
-): Promise<PluginValidationResult> {
-  const tree = requireTree();
-  const entry = tree.resolve(id); // 未知 id 在这里抛错
-  if (entry.options.group) {
-    // 组条目的 config 是子条目列表（loader 内部表示），从这里改会拆树
-    throw new Error(`${ERR_INVALID_PARAMS}: entry ${id} is a group; groups carry no plugin config`);
-  }
-  const result = tree.validateConfig(entry.options.name, config);
-  // 校验错误是数据不是异常：ok=false 时什么都没改，前端就地回显
-  if (!result.ok) return result;
-  await tree.update(id, { config });
-  await tree.flush();
-  return result;
-}
-
-export function pluginsValidateConfig(name: string, config: unknown): PluginValidationResult {
-  return requireTree().validateConfig(name, config);
+export function pluginsDisable(id: string): Promise<PluginEntryInfo> {
+  return pluginMethods['plugins.disable']({ id }) as Promise<PluginEntryInfo>;
 }
 
 export function pluginsExportTree(): PluginTreeExport {
-  // version 是 IPC 契约的事：kernel 只管树本身，这里包上版本号
-  return { version: 1, entries: requireTree().exportTree() };
-}
-
-export async function pluginsImportTree(tree: PluginTreeExport): Promise<void> {
-  // last-good 快照落 PluginMetaStore；storage 失败的内存树会话拿不到
-  // meta，导入照常（本次会话本来就不落盘），见 kernel.ts 的说明
-  await requireTree().importTree(tree.entries, kernelPluginMeta() ?? undefined);
+  return pluginMethods['plugins.exportTree'](undefined) as PluginTreeExport;
 }

--- a/src/desktop/src/main/ipc/router.ts
+++ b/src/desktop/src/main/ipc/router.ts
@@ -17,7 +17,6 @@ import {
   IPC_CHANNEL_INFO_SYNC,
   IPC_CHANNEL_RPC,
   type MethodName,
-  type PluginTreeExport,
   type RpcRequest,
 } from '../../shared/contract';
 import { capabilityManifest } from '../capabilities';
@@ -44,70 +43,13 @@ function asNumber(params: unknown, key: string): number {
   return value;
 }
 
-/**
- * 插件配置载荷：一律是纯对象。数组/原始值/null 在 schema 层面没有合法
- * 形状，在 IPC 边界先挡掉；对象内部的语义（__jsExpr、schema 匹配）归
- * kernel 层校验——两层各管一层，见 methods.plugins.ts 文件头。
- */
-function asPluginConfig(params: unknown): Record<string, unknown> {
-  const value = (params as Record<string, unknown> | null)?.['config'];
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-    throw new Error(`${ERR_INVALID_PARAMS}: config must be a plain object`);
-  }
-  return value as Record<string, unknown>;
-}
-
-/** 树导入嵌套上限。真实树两三层，16 层只为拦住构造出来的深递归载荷。 */
-const MAX_TREE_DEPTH = 16;
-
-function assertTreeEntryShape(value: unknown, path: string, depth: number): void {
-  if (depth > MAX_TREE_DEPTH) {
-    throw new Error(`${ERR_INVALID_PARAMS}: ${path} exceeds max tree depth ${MAX_TREE_DEPTH}`);
-  }
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-    throw new Error(`${ERR_INVALID_PARAMS}: ${path} must be an object`);
-  }
-  const entry = value as Record<string, unknown>;
-  if (typeof entry.id !== 'string' || !entry.id) {
-    throw new Error(`${ERR_INVALID_PARAMS}: ${path}.id must be a non-empty string`);
-  }
-  if (typeof entry.name !== 'string' || !entry.name) {
-    throw new Error(`${ERR_INVALID_PARAMS}: ${path}.name must be a non-empty string`);
-  }
-  if (entry.disabled !== undefined && typeof entry.disabled !== 'boolean') {
-    throw new Error(`${ERR_INVALID_PARAMS}: ${path}.disabled must be a boolean`);
-  }
-  if (entry.children !== undefined) {
-    if (!Array.isArray(entry.children)) {
-      throw new Error(`${ERR_INVALID_PARAMS}: ${path}.children must be an array`);
-    }
-    entry.children.forEach((child, index) =>
-      assertTreeEntryShape(child, `${path}.children[${index}]`, depth + 1),
-    );
-  }
-  // 多余字段/重复 id/__jsExpr 故意不在这里查：那是语义校验，kernel 的
-  // importTree 会用与装载完全相同的一套规则拒绝（校验不复制两份）
-}
-
-function asPluginTreeExport(params: unknown): PluginTreeExport {
-  const value = (params as Record<string, unknown> | null)?.['tree'];
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-    throw new Error(`${ERR_INVALID_PARAMS}: tree must be an object`);
-  }
-  const tree = value as Record<string, unknown>;
-  if (tree.version !== 1) {
-    throw new Error(`${ERR_INVALID_PARAMS}: unsupported tree export version ${String(tree.version)}`);
-  }
-  if (!Array.isArray(tree.entries)) {
-    throw new Error(`${ERR_INVALID_PARAMS}: tree.entries must be an array`);
-  }
-  tree.entries.forEach((entry, index) => assertTreeEntryShape(entry, `entries[${index}]`, 0));
-  return value as unknown as PluginTreeExport;
-}
-
 type Handler = (params: unknown) => unknown | Promise<unknown>;
 
 const HANDLERS: Record<MethodName, Handler> = {
+  // plugins.*：守卫与语义都在 kernel 的 createPluginMethods 里（#754），两种
+  // 传输共用同一份；能力门槛（树不可达 → ERR_CAPABILITY_UNAVAILABLE）也在那里。
+  // 摊在最前面：下面的具名键是桌面独有的，任何重名都该以具名的为准。
+  ...plugins.pluginMethods,
   'host.info': () => host.hostInfo(),
   'host.setServerUrl': (p) => host.setServerUrl(asString(p, 'url')),
   'host.testServer': (p) => host.testServer(asString(p, 'url')),
@@ -120,15 +62,6 @@ const HANDLERS: Record<MethodName, Handler> = {
   'kernel.status': () => kernelStatus(),
   'kernel.localBackend': () => localBackend(),
   'kernel.engineBootstrapStatus': () => engineBootstrapStatus(),
-  // plugins.*：能力门槛（树不可达 → ERR_CAPABILITY_UNAVAILABLE）在实现里统一做
-  'plugins.list': () => plugins.pluginsList(),
-  'plugins.enable': (p) => plugins.pluginsEnable(asString(p, 'id')),
-  'plugins.disable': (p) => plugins.pluginsDisable(asString(p, 'id')),
-  'plugins.updateConfig': (p) => plugins.pluginsUpdateConfig(asString(p, 'id'), asPluginConfig(p)),
-  'plugins.validateConfig': (p) =>
-    plugins.pluginsValidateConfig(asString(p, 'name'), asPluginConfig(p)),
-  'plugins.exportTree': () => plugins.pluginsExportTree(),
-  'plugins.importTree': (p) => plugins.pluginsImportTree(asPluginTreeExport(p)),
   // plugins.market.*（#708）：包名/版本的语义校验（合法 npm 名、无路径字符）
   // 在 kernel 的安装引擎里，这里只做 IPC 形状
   'plugins.market.fetchIndex': () => market.marketFetchIndex(),

--- a/src/kernel/src/index.ts
+++ b/src/kernel/src/index.ts
@@ -13,6 +13,19 @@ export {
   type RpcHandler,
 } from './rpc/jsonrpc.ts'
 export {
+  ERR_CAPABILITY_UNAVAILABLE,
+  ERR_INVALID_PARAMS,
+  MAX_TREE_DEPTH,
+  asNumber,
+  asPluginConfig,
+  asPluginTreeExport,
+  asString,
+  createPluginMethods,
+  type PluginRpcDeps,
+  type PluginTreeExportShape,
+  type RpcMethod,
+} from './rpc/plugin-methods.ts'
+export {
   MemoryConfigTreeStore,
   type ConfigEntry,
   type ConfigTreeStore,

--- a/src/kernel/src/rpc/plugin-methods.ts
+++ b/src/kernel/src/rpc/plugin-methods.ts
@@ -1,0 +1,180 @@
+/* ============================================================
+   plugins.* 的实现与参数守卫，与传输无关（#754）。
+
+   原先这套住在桌面主进程里：守卫在 ipc/router.ts、实现在 ipc/methods.plugins.ts，
+   两者都直接读桌面的模块级单例。服务器形态要的是同一批方法、同一套校验，
+   只是传输从 Electron IPC 换成 HTTP/WS —— 所以把「校验 + 语义」搬到这里，
+   两侧各自只写一个薄传输适配器。
+
+   分层照旧，没有变：
+   - 本模块只管**形状**（是不是字符串、是不是纯对象、树有没有超深）；
+   - **语义**（__jsExpr、未知字段、重复 id、schema 匹配）归 SqliteTree，
+     用与装载完全相同的一套规则拒绝，校验不复制两份；
+   - 校验错误按契约**作为数据返回**（PluginValidationResult）给用户就地回显，
+     装载失败**作为异常抛出**——前者是输入问题，后者是运行故障。
+
+   信任边界也照旧：调用方传来的参数一律当作不可信输入独立校验，不因为
+   「前端已经检查过」而省略。服务器形态下这一点更要紧——那头是网络。
+   ============================================================ */
+
+import type { PluginEntryInfo, PluginValidationResult, SqliteTree } from '../config/sqlite-tree.ts'
+import type { ConfigEntry } from '../config/tree.ts'
+import type { PluginMetaStore } from '../storage/store.ts'
+
+export const ERR_INVALID_PARAMS = 'ERR_INVALID_PARAMS'
+export const ERR_CAPABILITY_UNAVAILABLE = 'ERR_CAPABILITY_UNAVAILABLE'
+
+/** 树导入嵌套上限。真实树两三层，16 层只为拦住构造出来的深递归载荷。 */
+export const MAX_TREE_DEPTH = 16
+
+export interface PluginTreeExportShape {
+  version: 1
+  /** 形状已由 asPluginTreeExport 逐条校验过；语义仍由 importTree 再判一次。 */
+  entries: ConfigEntry[]
+}
+
+export function asString(params: unknown, key: string): string {
+  const value = (params as Record<string, unknown> | null)?.[key]
+  if (typeof value !== 'string') {
+    throw new Error(`${ERR_INVALID_PARAMS}: ${key} must be a string`)
+  }
+  return value
+}
+
+export function asNumber(params: unknown, key: string): number {
+  const value = (params as Record<string, unknown> | null)?.[key]
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new Error(`${ERR_INVALID_PARAMS}: ${key} must be a finite number`)
+  }
+  return value
+}
+
+/**
+ * 插件配置载荷：一律是纯对象。数组/原始值/null 在 schema 层面没有合法形状，
+ * 在边界先挡掉；对象内部的语义归树层校验。
+ */
+export function asPluginConfig(params: unknown): Record<string, unknown> {
+  const value = (params as Record<string, unknown> | null)?.['config']
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${ERR_INVALID_PARAMS}: config must be a plain object`)
+  }
+  return value as Record<string, unknown>
+}
+
+function assertTreeEntryShape(value: unknown, path: string, depth: number): void {
+  if (depth > MAX_TREE_DEPTH) {
+    throw new Error(`${ERR_INVALID_PARAMS}: ${path} exceeds max tree depth ${MAX_TREE_DEPTH}`)
+  }
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${ERR_INVALID_PARAMS}: ${path} must be an object`)
+  }
+  const entry = value as Record<string, unknown>
+  if (typeof entry.id !== 'string' || !entry.id) {
+    throw new Error(`${ERR_INVALID_PARAMS}: ${path}.id must be a non-empty string`)
+  }
+  if (typeof entry.name !== 'string' || !entry.name) {
+    throw new Error(`${ERR_INVALID_PARAMS}: ${path}.name must be a non-empty string`)
+  }
+  if (entry.disabled !== undefined && typeof entry.disabled !== 'boolean') {
+    throw new Error(`${ERR_INVALID_PARAMS}: ${path}.disabled must be a boolean`)
+  }
+  if (entry.children !== undefined) {
+    if (!Array.isArray(entry.children)) {
+      throw new Error(`${ERR_INVALID_PARAMS}: ${path}.children must be an array`)
+    }
+    entry.children.forEach((child, index) =>
+      assertTreeEntryShape(child, `${path}.children[${index}]`, depth + 1),
+    )
+  }
+  // 多余字段/重复 id/__jsExpr 故意不在这里查：那是语义校验，importTree 会用
+  // 与装载完全相同的一套规则拒绝
+}
+
+export function asPluginTreeExport(params: unknown): PluginTreeExportShape {
+  const value = (params as Record<string, unknown> | null)?.['tree']
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${ERR_INVALID_PARAMS}: tree must be an object`)
+  }
+  const tree = value as Record<string, unknown>
+  if (tree.version !== 1) {
+    throw new Error(`${ERR_INVALID_PARAMS}: unsupported tree export version ${String(tree.version)}`)
+  }
+  if (!Array.isArray(tree.entries)) {
+    throw new Error(`${ERR_INVALID_PARAMS}: tree.entries must be an array`)
+  }
+  tree.entries.forEach((entry, index) => assertTreeEntryShape(entry, `entries[${index}]`, 0))
+  return value as unknown as PluginTreeExportShape
+}
+
+/**
+ * 宿主句柄。传函数而不是传值：树与持久层在会话中可能尚未就绪（storage 挂载
+ * 失败、树装载失败），能力门槛必须每次调用现读，不能在构造时固化成快照。
+ */
+export interface PluginRpcDeps {
+  configTree(): SqliteTree | null
+  pluginMeta(): PluginMetaStore | null
+}
+
+export type RpcMethod = (params: unknown) => unknown | Promise<unknown>
+
+export function createPluginMethods(deps: PluginRpcDeps): Record<string, RpcMethod> {
+  /** 能力门槛：树不可达时全族抛同一个码，与能力位 plugins.manage 读同一事实源。 */
+  function requireTree(): SqliteTree {
+    const tree = deps.configTree()
+    if (!tree) {
+      throw new Error(`${ERR_CAPABILITY_UNAVAILABLE}: plugins.manage — kernel 配置树不可用`)
+    }
+    return tree
+  }
+
+  /** 变更后的条目回执：UI 开关不用再发一次 list 就能拿到最终运行态。 */
+  function entryInfo(tree: SqliteTree, id: string): PluginEntryInfo {
+    const info = tree.listEntries().find((entry) => entry.id === id)
+    if (!info) throw new Error(`${ERR_INVALID_PARAMS}: unknown plugin entry ${id}`)
+    return info
+  }
+
+  /** 写操作后 flush：树的 write 是防抖合并的，返回前落盘，调用方看到成功即已持久。 */
+  async function setDisabledOption(id: string, disabled: true | null): Promise<PluginEntryInfo> {
+    const tree = requireTree()
+    // disabled: null = 删除该键（loader 的 isNullable 语义），回到默认启用。
+    // 拉起失败时 Entry.update 自己回滚 options（树不被污染），错误照抛。
+    await tree.update(id, { disabled })
+    await tree.flush()
+    return entryInfo(tree, id)
+  }
+
+  return {
+    'plugins.list': () => requireTree().listEntries(),
+    'plugins.enable': (p) => setDisabledOption(asString(p, 'id'), null),
+    'plugins.disable': (p) => setDisabledOption(asString(p, 'id'), true),
+    'plugins.updateConfig': async (p) => {
+      const tree = requireTree()
+      const id = asString(p, 'id')
+      const config = asPluginConfig(p)
+      const entry = tree.resolve(id) // 未知 id 在这里抛错
+      if (entry.options.group) {
+        // 组条目的 config 是子条目列表（loader 内部表示），从这里改会拆树
+        throw new Error(
+          `${ERR_INVALID_PARAMS}: entry ${id} is a group; groups carry no plugin config`,
+        )
+      }
+      const result: PluginValidationResult = tree.validateConfig(entry.options.name, config)
+      // 校验错误是数据不是异常：ok=false 时什么都没改，前端就地回显
+      if (!result.ok) return result
+      await tree.update(id, { config })
+      await tree.flush()
+      return result
+    },
+    'plugins.validateConfig': (p) =>
+      requireTree().validateConfig(asString(p, 'name'), asPluginConfig(p)),
+    // version 是 RPC 契约的事：kernel 树只管条目本身，这里包上版本号
+    'plugins.exportTree': () => ({ version: 1, entries: requireTree().exportTree() }),
+    'plugins.importTree': async (p) => {
+      // last-good 快照落 PluginMetaStore；storage 失败的内存树会话拿不到 meta，
+      // 导入照常（本次会话本来就不落盘）
+      const exported = asPluginTreeExport(p)
+      await requireTree().importTree(exported.entries, deps.pluginMeta() ?? undefined)
+    },
+  }
+}


### PR DESCRIPTION
Second step of #754, on top of #756. Still no behaviour change.

## What was tangled

The `plugins.*` family was split across two Electron-bound files: the parameter guards lived in the `ipcMain` router, the semantics in a module that read the desktop's module-level singletons directly. The server form needs the same methods with the same validation and only a different transport — so both move into the kernel package behind `createPluginMethods`, and each transport keeps a thin adapter.

## What did not change

The two-layer split is deliberate and survives intact:

- this layer checks **shape** only — is it a string, a plain object, a tree within depth;
- **meaning** (`__jsExpr`, unknown fields, duplicate ids, schema match) stays with `SqliteTree`, which rejects using exactly the rules it loads by.

Validation is not duplicated in two places, which was the point of the original design. Validation failures are still returned as *data* so the UI can show them in place; load failures are still thrown.

## Two details worth noting

**Dependencies are functions, not values.** The tree and the persistence layer may not exist yet in a session where storage failed to mount, so the capability gate has to read the current fact on each call rather than capture a snapshot at construction time.

**The desktop table keeps its exhaustiveness.** The shared set is typed as the `plugins.*` method names minus `plugins.market.*`:

```ts
type SharedPluginMethod = Exclude<
  Extract<MethodName, `plugins.${string}`>,
  `plugins.market.${string}`
>;
```

so adding a method to the contract without implementing it fails to compile, instead of showing up as an unknown method at runtime. A blanket `Record<string, …>` would have quietly lost that.

`plugins.market.*` deliberately stays on the desktop side for now — it needs the job-event channel and the legacy store read-through, which is the next step.

## Verification

Desktop smoke **0 failures**, including `plugins.list` / `exportTree` / `disable` / `enable` and the entire market install flow end to end (install → listed as disabled → enable → refuse-uninstall-while-enabled → disable → uninstall → disk cleaned). Kernel suite 98 passed, `tsc --noEmit` clean.

While porting I checked the method bodies against the originals rather than reproducing them from the call sites, which caught that enable is `update(id, { disabled: null })` (the loader's nullable-key semantics, not a boolean flag), that `updateConfig` refuses group entries before validating, and that `exportTree` wraps the tree in the contract's version envelope.
