### PR TITLE
refactor: market methods and the job bus become transport-agnostic (#754)

### DIFF
--- a/src/desktop/src/main/ipc/events.ts
+++ b/src/desktop/src/main/ipc/events.ts
@@ -4,7 +4,7 @@
    request/response 的 invoke，第二期要么被迫轮询，要么临时开一条新通道——
    后者意味着 preload 与前端订阅代码全部返工。 */
 
-import { randomUUID } from 'node:crypto';
+import { JobBus, type JobEvent } from '@polaris/kernel';
 
 import { IPC_CHANNEL_EVENT, type HostEvent } from '../../shared/contract';
 import { getWindow } from '../window';
@@ -14,41 +14,32 @@ export function emit(event: HostEvent): void {
   if (win && !win.isDestroyed()) win.webContents.send(IPC_CHANNEL_EVENT, event);
 }
 
-interface Job {
-  id: string;
-  kind: string;
-  cancel?: () => void;
-}
-
-const jobs = new Map<string, Job>();
+/**
+ * job 登记表住在 kernel（#754，服务器形态用同一份），桌面只提供落点：
+ * 事件经 webContents 推给渲染进程。
+ */
+export const jobBus = new JobBus((event: JobEvent) => emit(event as HostEvent));
 
 export function startJob(kind: string, cancel?: () => void): string {
-  const id = randomUUID();
-  jobs.set(id, { id, kind, cancel });
-  return id;
+  return jobBus.start(kind, cancel);
 }
 
 export function progress(jobId: string, phase: string, done: number, total: number, note?: string): void {
-  emit({ type: 'job.progress', jobId, phase, done, total, note });
+  jobBus.progress(jobId, phase, done, total, note);
 }
 
 export function log(jobId: string, chunk: string): void {
-  emit({ type: 'job.log', jobId, chunk });
+  jobBus.log(jobId, chunk);
 }
 
 export function finish(jobId: string, result: unknown): void {
-  jobs.delete(jobId);
-  emit({ type: 'job.done', jobId, result });
+  jobBus.finish(jobId, result);
 }
 
 export function fail(jobId: string, code: string, message: string): void {
-  jobs.delete(jobId);
-  emit({ type: 'job.error', jobId, code, message });
+  jobBus.fail(jobId, code, message);
 }
 
 export function cancelJob(jobId: string): void {
-  const job = jobs.get(jobId);
-  if (!job) return;
-  job.cancel?.();
-  jobs.delete(jobId);
+  jobBus.cancel(jobId);
 }

--- a/src/desktop/src/main/ipc/methods.market.ts
+++ b/src/desktop/src/main/ipc/methods.market.ts
@@ -1,74 +1,36 @@
 /* ============================================================
-   plugins.market.* 的实现（#708）：市场索引 + 安装/卸载 + 源配置。
+   plugins.market.* 在桌面侧的绑定（#708，#754 起实现搬进 kernel）。
 
-   语义全部住在 kernel（@polaris/kernel 的 market/）里，这里只负责：
-   - 能力门槛：与 plugins.* 同一事实源（kernelConfigTree），install/
-     uninstall 额外要求 pluginMeta 在位——安装记录进不了持久层，装载前
-     哈希复核链路就是断的，宁可拒装也不装出「无记录安装物」；
-   - install 的长任务化：invoke 立刻返回 JobHandle，kernel 的四个安装
-     阶段（下载/校验/解压/登记）翻译成 job.progress，成败走 job.done/
-     job.error（错误码用 MarketError.code，前端可分流展示）；
-   - 索引源持久化（#737 配置分层）：市场源配置的是 kernel 的行为（索引
-     从哪拉、装什么包），归内核持久层——存 PluginMetaStore（kernel 的
-     SQLite KV）键 'market:endpoint'。旧 electron store 的 marketEndpoint
-     只作读穿回退：KV 无值时读旧 store，非默认值顺手迁移写入 KV（一期
-     后删）。KV 不可用的降级会话（storage 挂载失败）退回旧 store，壳的
-     换源能力不因持久层故障消失。空串复位官方默认。
+   语义与守卫都住在 @polaris/kernel 的 rpc/market-methods.ts，服务器形态用
+   的是同一份。这里只接三样桌面独有的东西：
 
-   fetch 经模块级变量注入：smoke 测试把它换成离线替身跑完整安装链路，
-   生产路径永远是 globalThis.fetch（不换源不叠代理，网络语义与索引
-   拉取保持一致）。
+   - 宿主句柄（树 / 持久层 / 安装物目录）——都是模块级单例，传函数现读；
+   - job 事件的落点——桌面经 webContents 推给渲染进程（events.ts）；
+   - 旧 electron store 的索引源读穿——一次性迁移，服务器没有这回事，
+     所以在 kernel 那边是可选依赖。
+
+   fetch 替身仍由本模块持有：冒烟把它换成离线实现跑完整安装链路，
+   生产路径永远是 globalThis.fetch。
    ============================================================ */
 
 import {
-  MarketError,
-  fetchIndex,
-  installAndRegister,
-  uninstallAndRemove,
+  MARKET_ENDPOINT_META_KEY as KERNEL_MARKET_ENDPOINT_META_KEY,
+  OFFICIAL_INDEX_URL,
+  createMarketMethods,
   type FetchImpl,
-  type SqliteTree,
+  type RpcMethod,
 } from '@polaris/kernel';
 
 import {
-  ERR_CAPABILITY_UNAVAILABLE,
-  ERR_INVALID_PARAMS,
   MARKET_ENDPOINT_DEFAULT,
-  type JobHandle,
   type MarketEndpoint,
   type MarketIndexEntry,
   type MarketUninstallResult,
+  type MethodName,
 } from '../../shared/contract';
 import { kernelConfigTree, kernelPluginMeta, marketPluginsDir } from '../kernel';
 import { readConfig, writeConfig } from '../store';
-import { fail, finish, progress, startJob } from './events';
-
-/** 市场索引源在 kernel 持久层（PluginMetaStore）里的键（#737）。 */
-export const MARKET_ENDPOINT_META_KEY = 'market:endpoint';
-
-/** 当前生效的索引源：优先 kernel KV，读穿旧 electron store（见文件头）。 */
-function readEndpoint(): string {
-  const meta = kernelPluginMeta();
-  const stored = meta?.get(MARKET_ENDPOINT_META_KEY);
-  if (typeof stored === 'string' && stored) return stored;
-  const legacy = readConfig().marketEndpoint;
-  // 迁移写入只搬「用户改过源」这个事实；默认值不落 KV，让「从未配置」
-  // 与「显式选了官方源」保持可区分（也避免每次读都白写一行）。
-  if (meta && legacy !== MARKET_ENDPOINT_DEFAULT) meta.set(MARKET_ENDPOINT_META_KEY, legacy);
-  return legacy;
-}
-
-function writeEndpoint(endpoint: string): void {
-  const meta = kernelPluginMeta();
-  if (meta) {
-    meta.set(MARKET_ENDPOINT_META_KEY, endpoint);
-    return;
-  }
-  // 持久层不可用（内存树会话）：退回旧 store，至少本机仍能换源
-  writeConfig({ marketEndpoint: endpoint });
-}
-
-/** 安装阶段 → job.progress 的进度分子（分母恒为 4）。 */
-const PHASE_STEP: Record<string, number> = { download: 1, verify: 2, extract: 3, register: 4 };
+import { jobBus } from './events';
 
 let fetchImpl: FetchImpl | undefined;
 
@@ -77,86 +39,57 @@ export function setMarketFetchForTesting(impl: FetchImpl | undefined): void {
   fetchImpl = impl;
 }
 
+const market = createMarketMethods({
+  configTree: () => kernelConfigTree(),
+  pluginMeta: () => kernelPluginMeta(),
+  pluginsDir: () => marketPluginsDir(),
+  jobs: jobBus,
+  fetchImpl: () => fetchImpl,
+  legacyEndpoint: {
+    read: () => readConfig().marketEndpoint,
+    write: (endpoint) => writeConfig({ marketEndpoint: endpoint }),
+  },
+});
+
+type MarketMethodName = Extract<MethodName, `plugins.market.${string}`>;
+
+export const marketMethods = market.methods as Record<MarketMethodName, RpcMethod>;
+
 /** 尚未落定的安装任务，仅供 smoke 等待 job 收尾（生产走 job.* 事件）。 */
-const pendingInstalls = new Map<string, Promise<void>>();
-
 export function awaitInstallForTesting(jobId: string): Promise<void> {
-  return pendingInstalls.get(jobId) ?? Promise.resolve();
+  return market.awaitInstall(jobId);
 }
 
-function requireMarket(): { tree: SqliteTree; meta: NonNullable<ReturnType<typeof kernelPluginMeta>> } {
-  const tree = kernelConfigTree();
-  if (!tree) {
-    throw new Error(`${ERR_CAPABILITY_UNAVAILABLE}: plugins.manage — kernel 配置树不可用`);
-  }
-  const meta = kernelPluginMeta();
-  if (!meta) {
-    // storage 挂载失败的内存树会话：没有持久层就没有安装记录，
-    // 哈希复核无从谈起，市场写操作整体不可用
-    throw new Error(`${ERR_CAPABILITY_UNAVAILABLE}: plugins.market — 持久层不可用，无法记录安装`);
-  }
-  return { tree, meta };
-}
+/* 具名直调入口：冒烟在主进程内不经 IPC 驱动这几个方法。 */
 
-export async function marketFetchIndex(): Promise<MarketIndexEntry[]> {
-  // 读索引不需要树/持久层，网络与校验失败原样抛给前端展示
-  return await fetchIndex(readEndpoint(), { fetchImpl });
-}
-
-export function marketInstall(name: string, version: string): JobHandle {
-  const { tree, meta } = requireMarket(); // 门槛在返回 JobHandle 之前查：装不了就立刻报错
-  const jobId = startJob('plugins.market.install');
-  const run = (async () => {
-    try {
-      const { entryId, record } = await installAndRegister({
-        name,
-        version,
-        pluginsDir: marketPluginsDir(),
-        fetchImpl,
-        tree,
-        metaStore: meta,
-        onPhase: (phase) => progress(jobId, phase, PHASE_STEP[phase] ?? 0, 4),
-      });
-      finish(jobId, { entryId, name: record.name, version: record.version });
-    } catch (err) {
-      // MarketError.code 透传给前端分流（integrity-mismatch / registry-http…）
-      const code = err instanceof MarketError ? err.code : 'install-failed';
-      fail(jobId, code, err instanceof Error ? err.message : String(err));
-    } finally {
-      pendingInstalls.delete(jobId);
-    }
-  })();
-  pendingInstalls.set(jobId, run);
-  return { jobId };
-}
-
-export async function marketUninstall(name: string): Promise<MarketUninstallResult> {
-  const { tree, meta } = requireMarket();
-  return await uninstallAndRemove({
-    name,
-    pluginsDir: marketPluginsDir(),
-    tree,
-    metaStore: meta,
-  });
+export function marketFetchIndex(): Promise<MarketIndexEntry[]> {
+  return marketMethods['plugins.market.fetchIndex'](undefined) as Promise<MarketIndexEntry[]>;
 }
 
 export function marketGetEndpoint(): MarketEndpoint {
-  const endpoint = readEndpoint();
-  return { endpoint, isDefault: endpoint === MARKET_ENDPOINT_DEFAULT };
+  return marketMethods['plugins.market.getEndpoint'](undefined) as MarketEndpoint;
 }
 
 export function marketSetEndpoint(endpoint: string): MarketEndpoint {
-  // 空串 = 复位默认源（UI 的「恢复官方源」不需要知道默认值是什么）
-  const next = endpoint === '' ? MARKET_ENDPOINT_DEFAULT : endpoint;
-  let parsed: URL;
-  try {
-    parsed = new URL(next);
-  } catch {
-    throw new Error(`${ERR_INVALID_PARAMS}: endpoint must be a valid URL`);
-  }
-  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
-    throw new Error(`${ERR_INVALID_PARAMS}: endpoint must be http(s)`);
-  }
-  writeEndpoint(next);
-  return { endpoint: next, isDefault: next === MARKET_ENDPOINT_DEFAULT };
+  return marketMethods['plugins.market.setEndpoint']({ endpoint }) as MarketEndpoint;
+}
+
+// 默认索引源的字面量在两处各有一份：kernel 的 OFFICIAL_INDEX_URL（isDefault
+// 判定用它）与渲染层契约的 MARKET_ENDPOINT_DEFAULT。两边漂了的话，「恢复官方源」
+// 会写进一个前端永远认不出是默认值的地址——安静地坏掉。启动即对账，宁可炸在这里。
+if (MARKET_ENDPOINT_DEFAULT !== OFFICIAL_INDEX_URL) {
+  throw new Error(
+    `market endpoint default drifted: contract=${MARKET_ENDPOINT_DEFAULT} kernel=${OFFICIAL_INDEX_URL}`,
+  );
+}
+
+/** 市场索引源在持久层里的键；冒烟直接查这一行，从 kernel 转出保持单一来源。 */
+export const MARKET_ENDPOINT_META_KEY = KERNEL_MARKET_ENDPOINT_META_KEY;
+
+export function marketInstall(name: string, version: string): { jobId: string } {
+  return marketMethods['plugins.market.install']({ name, version }) as { jobId: string };
+}
+
+export function marketUninstall(name: string): Promise<MarketUninstallResult> {
+  return marketMethods['plugins.market.uninstall']({ name }) as Promise<MarketUninstallResult>;
 }

--- a/src/desktop/src/main/ipc/router.ts
+++ b/src/desktop/src/main/ipc/router.ts
@@ -50,6 +50,9 @@ const HANDLERS: Record<MethodName, Handler> = {
   // 传输共用同一份；能力门槛（树不可达 → ERR_CAPABILITY_UNAVAILABLE）也在那里。
   // 摊在最前面：下面的具名键是桌面独有的，任何重名都该以具名的为准。
   ...plugins.pluginMethods,
+  // plugins.market.*（#708）：守卫与语义同样在 kernel（#754）；包名/版本的
+  // 语义校验本来就在安装引擎里，这一层只管形状
+  ...market.marketMethods,
   'host.info': () => host.hostInfo(),
   'host.setServerUrl': (p) => host.setServerUrl(asString(p, 'url')),
   'host.testServer': (p) => host.testServer(asString(p, 'url')),
@@ -62,13 +65,6 @@ const HANDLERS: Record<MethodName, Handler> = {
   'kernel.status': () => kernelStatus(),
   'kernel.localBackend': () => localBackend(),
   'kernel.engineBootstrapStatus': () => engineBootstrapStatus(),
-  // plugins.market.*（#708）：包名/版本的语义校验（合法 npm 名、无路径字符）
-  // 在 kernel 的安装引擎里，这里只做 IPC 形状
-  'plugins.market.fetchIndex': () => market.marketFetchIndex(),
-  'plugins.market.install': (p) => market.marketInstall(asString(p, 'name'), asString(p, 'version')),
-  'plugins.market.uninstall': (p) => market.marketUninstall(asString(p, 'name')),
-  'plugins.market.getEndpoint': () => market.marketGetEndpoint(),
-  'plugins.market.setEndpoint': (p) => market.marketSetEndpoint(asString(p, 'endpoint')),
   // 取消是 main 内的簿记（events.ts 的 job 注册表），不涉及任何外部进程
   'local.job.cancel': (p) => cancelJob(asString(p, 'jobId')),
 };

--- a/src/kernel/src/index.ts
+++ b/src/kernel/src/index.ts
@@ -12,6 +12,14 @@ export {
   type NotificationHandler,
   type RpcHandler,
 } from './rpc/jsonrpc.ts'
+export { JobBus, type JobEvent } from './rpc/jobs.ts'
+export {
+  MARKET_ENDPOINT_META_KEY,
+  createMarketMethods,
+  type MarketEndpointInfo,
+  type MarketMethods,
+  type MarketRpcDeps,
+} from './rpc/market-methods.ts'
 export {
   ERR_CAPABILITY_UNAVAILABLE,
   ERR_INVALID_PARAMS,

--- a/src/kernel/src/rpc/jobs.ts
+++ b/src/kernel/src/rpc/jobs.ts
@@ -1,0 +1,62 @@
+/* ============================================================
+   长任务（job）登记与进度广播，与传输无关（#754）。
+
+   登记表本身是纯簿记：谁在跑、能不能取消。真正跟传输绑死的只有一件事——
+   把事件送到订阅者手上。桌面是 webContents.send，服务器是 SSE/WS 广播，
+   所以 emit 做成构造参数，其余照搬。
+
+   为什么一期就要有 job 而不是让 invoke 直接等：安装要下载、校验、解压、
+   登记四步，前端要能显示进度；把它做成 request/response 就只剩下「转圈」，
+   而且第二期真要进度时 preload 与订阅代码得整体返工。
+   ============================================================ */
+
+import { randomUUID } from 'node:crypto'
+
+/** 事件的最小形状；具体事件类型由各形态的契约声明。 */
+export interface JobEvent {
+  type: string
+  [key: string]: unknown
+}
+
+interface Job {
+  id: string
+  kind: string
+  cancel?: () => void
+}
+
+export class JobBus {
+  private readonly jobs = new Map<string, Job>()
+
+  constructor(private readonly emit: (event: JobEvent) => void) {}
+
+  start(kind: string, cancel?: () => void): string {
+    const id = randomUUID()
+    this.jobs.set(id, { id, kind, cancel })
+    return id
+  }
+
+  progress(jobId: string, phase: string, done: number, total: number, note?: string): void {
+    this.emit({ type: 'job.progress', jobId, phase, done, total, note })
+  }
+
+  log(jobId: string, chunk: string): void {
+    this.emit({ type: 'job.log', jobId, chunk })
+  }
+
+  finish(jobId: string, result: unknown): void {
+    this.jobs.delete(jobId)
+    this.emit({ type: 'job.done', jobId, result })
+  }
+
+  fail(jobId: string, code: string, message: string): void {
+    this.jobs.delete(jobId)
+    this.emit({ type: 'job.error', jobId, code, message })
+  }
+
+  cancel(jobId: string): void {
+    const job = this.jobs.get(jobId)
+    if (!job) return
+    job.cancel?.()
+    this.jobs.delete(jobId)
+  }
+}

--- a/src/kernel/src/rpc/market-methods.ts
+++ b/src/kernel/src/rpc/market-methods.ts
@@ -1,0 +1,166 @@
+/* ============================================================
+   plugins.market.* 的实现，与传输无关（#754）。
+
+   语义住在 market/ 下（索引校验、安装引擎、卸载），这里只负责三件事：
+   - 能力门槛：树要在，**持久层也要在**——安装记录进不了持久层，装载前的
+     哈希复核链路就是断的，宁可拒装也不装出「无记录安装物」；
+   - install 的长任务化：立刻返回 JobHandle，四个安装阶段翻成 job.progress，
+     成败走 job.done / job.error（错误码用 MarketError.code，前端可分流）；
+   - 索引源读写：优先内核持久层的 KV，旧存储只作读穿回退。
+
+   旧存储读穿（legacyEndpoint）是桌面独有的一次性迁移，服务器形态没有它，
+   所以做成可选依赖而不是必需参数。
+   ============================================================ */
+
+import type { SqliteTree } from '../config/sqlite-tree.ts'
+import { MarketError } from '../market/contract.ts'
+import { OFFICIAL_INDEX_URL, fetchIndex } from '../market/index-client.ts'
+import { installAndRegister, uninstallAndRemove } from '../market/lifecycle.ts'
+import type { FetchImpl } from '../sources/contract.ts'
+import type { PluginMetaStore } from '../storage/store.ts'
+import type { JobBus } from './jobs.ts'
+import {
+  ERR_CAPABILITY_UNAVAILABLE,
+  ERR_INVALID_PARAMS,
+  asString,
+  type RpcMethod,
+} from './plugin-methods.ts'
+
+/** 市场索引源在持久层（PluginMetaStore）里的键。 */
+export const MARKET_ENDPOINT_META_KEY = 'market:endpoint'
+
+/** 安装阶段 → job.progress 的进度分子（分母恒为 4）。 */
+const PHASE_STEP: Record<string, number> = { download: 1, verify: 2, extract: 3, register: 4 }
+
+export interface MarketEndpointInfo {
+  endpoint: string
+  isDefault: boolean
+}
+
+export interface MarketRpcDeps {
+  configTree(): SqliteTree | null
+  pluginMeta(): PluginMetaStore | null
+  /** 市场安装物的落盘根。 */
+  pluginsDir(): string
+  jobs: JobBus
+  /** 测试注入的离线 fetch 替身；生产返回 undefined 走真实网络。 */
+  fetchImpl?(): FetchImpl | undefined
+  /**
+   * 旧存储读穿（桌面一次性迁移）。KV 里没有值时读它，且只在「用户改过源」
+   * 时回写 KV——默认值不落 KV，让「从未配置」与「显式选了官方源」保持可区分。
+   */
+  legacyEndpoint?: { read(): string; write(endpoint: string): void }
+}
+
+export interface MarketMethods {
+  methods: Record<string, RpcMethod>
+  /** 仅供测试等待安装 job 收尾；生产路径走 job.* 事件。 */
+  awaitInstall(jobId: string): Promise<void>
+}
+
+export function createMarketMethods(deps: MarketRpcDeps): MarketMethods {
+  const pendingInstalls = new Map<string, Promise<void>>()
+  const fetchImpl = () => deps.fetchImpl?.()
+
+  function readEndpoint(): string {
+    const meta = deps.pluginMeta()
+    const stored = meta?.get(MARKET_ENDPOINT_META_KEY)
+    if (typeof stored === 'string' && stored) return stored
+    const legacy = deps.legacyEndpoint?.read() ?? OFFICIAL_INDEX_URL
+    if (meta && legacy !== OFFICIAL_INDEX_URL) meta.set(MARKET_ENDPOINT_META_KEY, legacy)
+    return legacy
+  }
+
+  function writeEndpoint(endpoint: string): void {
+    const meta = deps.pluginMeta()
+    if (meta) {
+      meta.set(MARKET_ENDPOINT_META_KEY, endpoint)
+      return
+    }
+    // 持久层不可用（内存树会话）：退回旧存储，至少本机仍能换源
+    deps.legacyEndpoint?.write(endpoint)
+  }
+
+  function requireMarket(): { tree: SqliteTree; meta: PluginMetaStore } {
+    const tree = deps.configTree()
+    if (!tree) {
+      throw new Error(`${ERR_CAPABILITY_UNAVAILABLE}: plugins.manage — kernel 配置树不可用`)
+    }
+    const meta = deps.pluginMeta()
+    if (!meta) {
+      throw new Error(`${ERR_CAPABILITY_UNAVAILABLE}: plugins.market — 持久层不可用，无法记录安装`)
+    }
+    return { tree, meta }
+  }
+
+  function endpointInfo(endpoint: string): MarketEndpointInfo {
+    return { endpoint, isDefault: endpoint === OFFICIAL_INDEX_URL }
+  }
+
+  return {
+    awaitInstall: (jobId) => pendingInstalls.get(jobId) ?? Promise.resolve(),
+    methods: {
+      // 读索引不需要树/持久层，网络与校验失败原样抛给前端展示
+      'plugins.market.fetchIndex': () => fetchIndex(readEndpoint(), { fetchImpl: fetchImpl() }),
+
+      'plugins.market.install': (p) => {
+        const name = asString(p, 'name')
+        const version = asString(p, 'version')
+        // 门槛在返回 JobHandle 之前查：装不了就立刻报错，别先给一个注定失败的 job
+        const { tree, meta } = requireMarket()
+        const jobId = deps.jobs.start('plugins.market.install')
+        const run = (async () => {
+          try {
+            const { entryId, record } = await installAndRegister({
+              name,
+              version,
+              pluginsDir: deps.pluginsDir(),
+              fetchImpl: fetchImpl(),
+              tree,
+              metaStore: meta,
+              onPhase: (phase) => deps.jobs.progress(jobId, phase, PHASE_STEP[phase] ?? 0, 4),
+            })
+            deps.jobs.finish(jobId, { entryId, name: record.name, version: record.version })
+          } catch (err) {
+            // MarketError.code 透传给前端分流（integrity-mismatch / registry-http…）
+            const code = err instanceof MarketError ? err.code : 'install-failed'
+            deps.jobs.fail(jobId, code, err instanceof Error ? err.message : String(err))
+          } finally {
+            pendingInstalls.delete(jobId)
+          }
+        })()
+        pendingInstalls.set(jobId, run)
+        return { jobId }
+      },
+
+      'plugins.market.uninstall': async (p) => {
+        const { tree, meta } = requireMarket()
+        return await uninstallAndRemove({
+          name: asString(p, 'name'),
+          pluginsDir: deps.pluginsDir(),
+          tree,
+          metaStore: meta,
+        })
+      },
+
+      'plugins.market.getEndpoint': () => endpointInfo(readEndpoint()),
+
+      'plugins.market.setEndpoint': (p) => {
+        // 空串 = 复位默认源（UI 的「恢复官方源」不需要知道默认值是什么）
+        const raw = asString(p, 'endpoint')
+        const next = raw === '' ? OFFICIAL_INDEX_URL : raw
+        let parsed: URL
+        try {
+          parsed = new URL(next)
+        } catch {
+          throw new Error(`${ERR_INVALID_PARAMS}: endpoint must be a valid URL`)
+        }
+        if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+          throw new Error(`${ERR_INVALID_PARAMS}: endpoint must be http(s)`)
+        }
+        writeEndpoint(next)
+        return endpointInfo(next)
+      },
+    },
+  }
+}


### PR DESCRIPTION
Third step of #754, on top of #757. Completes the transport-agnostic RPC surface; still no behaviour change.

## Why this one was left behind

`plugins.market.*` stayed on the desktop side in #757 because it needed two things the `plugins.*` family did not: a channel to report install progress, and the legacy endpoint read-through.

**The job registry is pure bookkeeping.** Who is running, can it be cancelled — with exactly one transport-bound act: delivering the event. `JobBus` now owns the registry and takes the delivery function as a constructor argument, so the desktop hands it `webContents.send` and a server can hand it an SSE or WebSocket broadcast. The desktop's named helpers (`startJob`, `progress`, `finish`, `fail`, `cancelJob`) remain as thin forwards, so nothing calling them changed.

**The legacy read-through is desktop-only.** Migrating the market endpoint out of the old electron-store is a one-time desktop concern, so it is an optional dependency rather than a required parameter — a server has no such store and should not have to pretend otherwise. Its subtlety is preserved: the migration write only records *that the user changed the source*, never the default, so "never configured" and "explicitly chose official" stay distinguishable.

## A latent bug found while wiring

The default index URL was written out twice:

- `OFFICIAL_INDEX_URL` in the kernel, which decides `isDefault`
- `MARKET_ENDPOINT_DEFAULT` in the renderer contract, which the UI compares against

Identical today, with nothing keeping them that way. If they ever drift, "restore the official source" writes an address the frontend can never recognise as default — the reset button appears to work and silently doesn't. The desktop binding now reconciles them at import and throws on mismatch, so the failure is loud and immediate instead of a puzzling UI state.

## Verification

Desktop smoke **0 failures**, which is the meaningful gate here since it drives the real install path in a packaged main process:

- full lifecycle: install → listed as disabled → enable (real `file://` dynamic import) → refuse uninstall while enabled → disable → uninstall → tree entry, disk and install record all cleaned
- both endpoint persistence paths: kernel KV, and the legacy read-through including its migration write and the empty-string reset after migration

Kernel suite 98 passed; `tsc --noEmit` clean.

With this, `plugins.*` and `plugins.market.*` both run on shared implementations behind injected dependencies. What remains for #754 is the server host itself: a bare-Node entry, a JSON-RPC transport with an owner check, and a web bridge so the existing settings UI can be reused unchanged.
