### PR TITLE
feat: a bare-Node kernel host with an HTTP RPC transport (#754)

### DIFF
--- a/src/kernel/src/server/main.ts
+++ b/src/kernel/src/server/main.ts
@@ -1,0 +1,114 @@
+/* ============================================================
+   服务器形态的内核宿主入口（#754）：裸 Node 跑插件内核。
+
+   桌面把内核挂在 Electron 主进程里；服务器形态没有 Electron，所以这里是
+   一个独立进程。内核本来就不认识 electron（tests/electron-free.test.ts
+   机械把关），所以这个进程要做的只有三件事：装配宿主、挂上 HTTP 传输、
+   把 job 事件广播出去。
+
+   ## 与桌面的两处有意不同
+
+   1. **种子树里没有 legacy-engine**。桌面要靠内核把 Python 引擎拉起来；
+      服务器形态的 api/worker 是各自的容器，由 compose 管生命周期，内核
+      不该再去拉一份。树里只种 sources。
+   2. **安装物落在数据目录下，一份，不按用户分**。服务器上的插件跑在服务端
+      进程里，不是某个用户的机器上——它对所有账号生效，所以也只有一份。
+      谁能装由后端的 owner 守卫决定（见 rpc-http.ts 的信任边界说明）。
+
+   环境变量：
+     POLARIS_KERNEL_DATA_DIR   数据根（storage.db 与 plugins/ 都在其下）
+     POLARIS_KERNEL_TOKEN      与后端之间的共享密钥，缺失即拒绝启动
+     POLARIS_KERNEL_PORT       监听端口，默认 8770
+     POLARIS_KERNEL_HOST       绑定地址，默认 0.0.0.0（容器内部网络）
+   ============================================================ */
+
+import { createPluginHost, marketPluginsDir } from '../host.ts'
+import { JobBus } from '../rpc/jobs.ts'
+import { createMarketMethods } from '../rpc/market-methods.ts'
+import { createPluginMethods } from '../rpc/plugin-methods.ts'
+import { createRpcHttpServer } from './rpc-http.ts'
+
+/** 服务器形态的首启种子：只有 sources，理由见文件头。 */
+export const SERVER_SEED_ENTRIES = [{ id: 'sources', name: 'cordis:sources' }]
+
+export interface ServerKernelOptions {
+  dataDir: string
+  token: string
+  port: number
+  host?: string
+}
+
+export async function startServerKernel(options: ServerKernelOptions) {
+  const host = await createPluginHost({
+    name: 'polaris-server',
+    dataRoot: options.dataDir,
+    seedEntries: SERVER_SEED_ENTRIES,
+    // 服务器一律严格：安装物对不上哈希就禁用，没有「开发态放宽」这回事
+    strict: true,
+  })
+
+  // 总线与 HTTP 服务互相需要（事件要经 SSE 发出去，服务要先有方法表才能建）。
+  // 用一个可变引用打结：事件总是在服务建好之后才产生，早到的事件没有订阅者，
+  // 丢掉即可——这也是 SSE 的常态。
+  let sink: { broadcast(event: unknown): void } | null = null
+  const jobs = new JobBus((event) => sink?.broadcast(event))
+
+  const deps = {
+    configTree: () => host.configTree ?? null,
+    pluginMeta: () => host.pluginMeta ?? null,
+  }
+
+  const market = createMarketMethods({
+    ...deps,
+    pluginsDir: () => marketPluginsDir(options.dataDir),
+    jobs,
+  })
+
+  const methods = {
+    ...createPluginMethods(deps),
+    ...market.methods,
+  }
+
+  methods['kernel.status'] = () => ({
+    started: true,
+    name: 'polaris-server',
+    plugins: host.kernel.ctx.registry.size,
+    storage: host.pluginMeta != null,
+  })
+
+  const rpc = await createRpcHttpServer({
+    methods,
+    token: options.token,
+    port: options.port,
+    host: options.host,
+  })
+  sink = rpc
+
+  await host.kernel.start()
+  return { host, rpc, jobs, market }
+}
+
+/** 直接跑本文件时的入口（容器 CMD）。 */
+export async function main(): Promise<void> {
+  const dataDir = process.env.POLARIS_KERNEL_DATA_DIR
+  const token = process.env.POLARIS_KERNEL_TOKEN
+  if (!dataDir) throw new Error('POLARIS_KERNEL_DATA_DIR is required')
+  if (!token) throw new Error('POLARIS_KERNEL_TOKEN is required')
+
+  const port = Number(process.env.POLARIS_KERNEL_PORT ?? 8770)
+  const started = await startServerKernel({
+    dataDir,
+    token,
+    port,
+    host: process.env.POLARIS_KERNEL_HOST ?? '0.0.0.0',
+  })
+  console.log(`[kernel] server host listening on ${started.rpc.port}`)
+
+  const stop = async () => {
+    await started.rpc.close()
+    await started.host.kernel.stop()
+    process.exit(0)
+  }
+  process.on('SIGTERM', () => void stop())
+  process.on('SIGINT', () => void stop())
+}

--- a/src/kernel/src/server/rpc-http.ts
+++ b/src/kernel/src/server/rpc-http.ts
@@ -1,0 +1,167 @@
+/* ============================================================
+   服务器形态的 RPC 传输（#754）：JSON-RPC over HTTP + SSE 事件流。
+
+   桌面用 Electron IPC，服务器用这一层，两边调用的是同一批方法
+   （createPluginMethods / createMarketMethods）。
+
+   ## 信任边界
+
+   本服务**不做用户认证**，只认一个共享密钥，并且只监听回环/内网地址。
+   用户身份归 Python 后端：浏览器带着会话打后端，后端用既有的 owner 守卫
+   （#738）判权限，通过后才代理到这里。
+
+   为什么不在这里自己校验 JWT：那等于把认证实现成两份。两份认证迟早会在
+   「谁算 owner」这种问题上分叉，而分叉的那一半就是漏洞。这里只回答
+   「调用方是不是我信任的那个后端」——一个密钥足够，也只需要这么多。
+
+   所以部署上有一条硬要求：**这个端口绝不能对外暴露**。compose 里它不发布
+   端口，只挂在内部网络上；密钥缺失时直接拒绝启动，而不是退化成不校验。
+   ============================================================ */
+
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
+import { timingSafeEqual } from 'node:crypto'
+
+import type { JobEvent } from '../rpc/jobs.ts'
+import type { RpcMethod } from '../rpc/plugin-methods.ts'
+
+/** 单个请求体上限：RPC 参数都是短标识符，树导入是最大的一个。 */
+const MAX_BODY_BYTES = 1_000_000
+
+export interface RpcHttpServerOptions {
+  methods: Record<string, RpcMethod>
+  /** 共享密钥，来自 env；空值视为配置错误，调用方应拒绝启动。 */
+  token: string
+  /** 绑定地址。默认只听回环——容器里要跨服务访问时才传 0.0.0.0。 */
+  host?: string
+  port: number
+  log?: { warn(message: string): void; error(message: string, error?: unknown): void }
+}
+
+export interface RpcHttpServer {
+  /** 实际监听的端口（传 0 时由内核分配，测试用）。 */
+  readonly port: number
+  /** 把一条事件推给所有 SSE 订阅者。 */
+  broadcast(event: JobEvent): void
+  close(): Promise<void>
+}
+
+function timingSafeEqualStr(a: string, b: string): boolean {
+  const left = Buffer.from(a)
+  const right = Buffer.from(b)
+  // 长度不同时 timingSafeEqual 会抛错；先比长度会泄露长度，但密钥长度不是秘密
+  if (left.length !== right.length) return false
+  return timingSafeEqual(left, right)
+}
+
+async function readBody(req: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = []
+  let size = 0
+  for await (const chunk of req) {
+    size += (chunk as Buffer).length
+    if (size > MAX_BODY_BYTES) throw new Error('request body too large')
+    chunks.push(chunk as Buffer)
+  }
+  return Buffer.concat(chunks).toString('utf8')
+}
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  const text = JSON.stringify(body)
+  res.writeHead(status, { 'content-type': 'application/json; charset=utf-8' })
+  res.end(text)
+}
+
+export function createRpcHttpServer(options: RpcHttpServerOptions): Promise<RpcHttpServer> {
+  const log = options.log ?? console
+  if (!options.token) {
+    // 没有密钥就不是「宽松模式」，是配置错误。宁可起不来也不要裸奔的内核。
+    throw new Error('rpc-http: a shared token is required')
+  }
+
+  const subscribers = new Set<ServerResponse>()
+
+  function authorized(req: IncomingMessage): boolean {
+    const header = req.headers['x-polaris-kernel-token']
+    const value = Array.isArray(header) ? header[0] : header
+    return typeof value === 'string' && timingSafeEqualStr(value, options.token)
+  }
+
+  const server: Server = createServer((req, res) => {
+    void (async () => {
+      if (!authorized(req)) {
+        // 不解释缺了什么：这条边界后面是插件安装，能少说就少说
+        sendJson(res, 401, { error: 'unauthorized' })
+        return
+      }
+
+      if (req.method === 'GET' && req.url === '/events') {
+        res.writeHead(200, {
+          'content-type': 'text/event-stream; charset=utf-8',
+          'cache-control': 'no-cache',
+          connection: 'keep-alive',
+        })
+        res.write(': connected\n\n')
+        subscribers.add(res)
+        req.on('close', () => subscribers.delete(res))
+        return
+      }
+
+      if (req.method !== 'POST' || req.url !== '/rpc') {
+        sendJson(res, 404, { error: 'not found' })
+        return
+      }
+
+      let payload: { method?: unknown; params?: unknown }
+      try {
+        payload = JSON.parse(await readBody(req)) as typeof payload
+      } catch (err) {
+        sendJson(res, 400, { error: `invalid json: ${err instanceof Error ? err.message : err}` })
+        return
+      }
+
+      const method = typeof payload.method === 'string' ? payload.method : ''
+      const handler = options.methods[method]
+      if (!handler) {
+        sendJson(res, 404, { error: `ERR_UNKNOWN_METHOD: ${method}` })
+        return
+      }
+
+      try {
+        const result = await handler(payload.params)
+        sendJson(res, 200, { result: result ?? null })
+      } catch (err) {
+        // 方法层的错误是**业务结果**，不是传输故障：用 200 之外的码会让
+        // 代理层和前端把「这个插件装不了」当成服务挂了。给 400 + 结构化消息。
+        const message = err instanceof Error ? err.message : String(err)
+        log.warn(`[rpc-http] ${method} failed: ${message}`)
+        sendJson(res, 400, { error: message })
+      }
+    })()
+  })
+
+  return new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(options.port, options.host ?? '127.0.0.1', () => {
+      const address = server.address()
+      const port = typeof address === 'object' && address ? address.port : options.port
+      resolve({
+        port,
+        broadcast(event: JobEvent) {
+          const frame = `data: ${JSON.stringify(event)}\n\n`
+          for (const res of subscribers) {
+            try {
+              res.write(frame)
+            } catch {
+              subscribers.delete(res)
+            }
+          }
+        },
+        close: () =>
+          new Promise<void>((done) => {
+            for (const res of subscribers) res.end()
+            subscribers.clear()
+            server.close(() => done())
+          }),
+      })
+    })
+  })
+}

--- a/src/kernel/tests/server-host.test.ts
+++ b/src/kernel/tests/server-host.test.ts
@@ -1,0 +1,117 @@
+/* 服务器形态的内核宿主（#754）：裸 Node 起内核 + HTTP JSON-RPC。
+   桌面那侧由 desktop smoke 把关，这里把同一批方法放到 HTTP 上再走一遍，
+   重点是传输与信任边界——桌面永远测不到这两样。 */
+
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { SERVER_SEED_ENTRIES, startServerKernel } from '../src/server/main.ts'
+
+let dataDir: string
+let started: Awaited<ReturnType<typeof startServerKernel>> | null = null
+const TOKEN = 'test-token-0123456789'
+
+async function rpc(port: number, method: string, params?: unknown, token = TOKEN) {
+  const res = await fetch(`http://127.0.0.1:${port}/rpc`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'x-polaris-kernel-token': token },
+    body: JSON.stringify({ method, params }),
+  })
+  return { status: res.status, body: (await res.json()) as { result?: unknown; error?: string } }
+}
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), 'polaris-kernel-server-'))
+})
+
+afterEach(async () => {
+  if (started) {
+    await started.rpc.close()
+    await started.host.kernel.stop()
+    started = null
+  }
+  rmSync(dataDir, { recursive: true, force: true })
+})
+
+describe('server kernel host', () => {
+  it('boots the plugin tree and answers plugins.list over HTTP', async () => {
+    started = await startServerKernel({ dataDir, token: TOKEN, port: 0, host: '127.0.0.1' })
+
+    const { status, body } = await rpc(started.rpc.port, 'plugins.list')
+    expect(status).toBe(200)
+    const entries = body.result as { id: string; state: string }[]
+    // 服务器种子树只有 sources：legacy-engine 归 compose 管，不该由内核再拉一份
+    expect(entries.map((e) => e.id)).toEqual(['sources'])
+    expect(SERVER_SEED_ENTRIES.map((e) => e.id)).toEqual(['sources'])
+  })
+
+  it('refuses a caller without the shared token', async () => {
+    started = await startServerKernel({ dataDir, token: TOKEN, port: 0, host: '127.0.0.1' })
+
+    const { status, body } = await rpc(started.rpc.port, 'plugins.list', undefined, 'wrong-token')
+    expect(status).toBe(401)
+    expect(body.result).toBeUndefined()
+    // 不解释缺了什么：这条边界后面是插件安装
+    expect(body.error).toBe('unauthorized')
+  })
+
+  it('refuses to start without a token rather than running unauthenticated', async () => {
+    await expect(
+      startServerKernel({ dataDir, token: '', port: 0, host: '127.0.0.1' }),
+    ).rejects.toThrow(/token is required/)
+  })
+
+  it('reports an unknown method instead of hanging', async () => {
+    started = await startServerKernel({ dataDir, token: TOKEN, port: 0, host: '127.0.0.1' })
+
+    const { status, body } = await rpc(started.rpc.port, 'plugins.nope')
+    expect(status).toBe(404)
+    expect(body.error).toMatch(/ERR_UNKNOWN_METHOD/)
+  })
+
+  it('returns method failures as a result, not as a transport error', async () => {
+    started = await startServerKernel({ dataDir, token: TOKEN, port: 0, host: '127.0.0.1' })
+
+    // 形状守卫：id 必须是字符串。这属于「这次调用不对」，不是「服务挂了」
+    const { status, body } = await rpc(started.rpc.port, 'plugins.enable', { id: 42 })
+    expect(status).toBe(400)
+    expect(body.error).toMatch(/ERR_INVALID_PARAMS/)
+  })
+
+  it('persists the tree across restarts of the host', async () => {
+    started = await startServerKernel({ dataDir, token: TOKEN, port: 0, host: '127.0.0.1' })
+    await rpc(started.rpc.port, 'plugins.disable', { id: 'sources' })
+    await started.rpc.close()
+    await started.host.kernel.stop()
+
+    started = await startServerKernel({ dataDir, token: TOKEN, port: 0, host: '127.0.0.1' })
+    const { body } = await rpc(started.rpc.port, 'plugins.list')
+    const entries = body.result as { id: string; state: string }[]
+    // 用户意图（禁用）必须活过重启，否则树就不是真相了
+    expect(entries.find((e) => e.id === 'sources')?.state).toBe('disabled')
+  })
+
+  it('streams job events to an SSE subscriber', async () => {
+    started = await startServerKernel({ dataDir, token: TOKEN, port: 0, host: '127.0.0.1' })
+
+    const controller = new AbortController()
+    const res = await fetch(`http://127.0.0.1:${started.rpc.port}/events`, {
+      headers: { 'x-polaris-kernel-token': TOKEN },
+      signal: controller.signal,
+    })
+    expect(res.status).toBe(200)
+    const reader = res.body!.getReader()
+    await reader.read() // 先吃掉握手注释帧
+
+    const jobId = started.jobs.start('test')
+    started.jobs.progress(jobId, 'download', 1, 4)
+
+    const chunk = await reader.read()
+    const text = new TextDecoder().decode(chunk.value)
+    expect(text).toContain('job.progress')
+    expect(text).toContain('download')
+    controller.abort()
+  })
+})


### PR DESCRIPTION
Fourth step of #754, on top of #758. The plugin kernel now runs outside Electron.

Purely additive — two new files under `src/kernel/src/server/` and one test file. Nothing existing changed.

## Authentication is deliberately *not* here

This service recognises a shared secret and nothing else. User identity stays with the Python backend, which decides who may manage plugins using the owner guard it already has from #738.

Implementing JWT validation in this process would mean **two authentication stacks**, and two stacks eventually disagree about who counts as the owner — the half that disagrees is the vulnerability. So the only question this layer answers is "are you the backend I trust". That makes one deployment rule non-negotiable: **this port is never published**. It sits on the compose internal network, and a missing token refuses to start rather than degrading into an unauthenticated kernel.

The next step wires `POST /api/plugins/rpc` in the backend behind `require_owner`, which is where the real decision gets made.

## Two deliberate differences from the desktop host

- **No `legacy-engine` in the seed tree.** The desktop uses the kernel to start the Python engine; on a server that runs as its own containers under compose, and the kernel should not start a second copy. The server seeds `sources` only.
- **Plugins install once, under the data directory, not per user.** A plugin on a server runs in the server process and affects every account, so a per-user copy would be a fiction. This is the decision flagged earlier; it is also why install has to be owner-only.

## What the tests cover

They drive the real HTTP transport rather than calling the methods directly, because the transport and the trust boundary are exactly what the desktop smoke can never reach:

- an unauthenticated caller is refused with no explanation of what was missing
- the host refuses to start without a token instead of running open
- an unknown method answers rather than hanging
- a parameter-shape failure comes back as a *result* (400 + structured message), not a transport error — otherwise a proxy and the UI would read "this plugin can't install" as "the service is down"
- the tree survives a host restart, so a disabled entry stays disabled
- job progress reaches an SSE subscriber

Kernel suite **105 passed across 12 files** (was 98/11). `tsc --noEmit` clean for kernel and desktop; the electron-free guard still passes, which is what keeps this process possible at all.
