### PR TITLE
feat: the backend proxies plugin management behind the owner guard (#754)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,8 +17,13 @@ POLARIS_ENV=dev
 POLARIS_SECRET_KEY=change-me-random-64-chars
 # SSH credential encryption (python -c "from cryptography.fernet import Fernet;print(Fernet.generate_key().decode())")
 POLARIS_ENCRYPTION_KEY=change-me-fernet-key
-# Registration invite code (the lab runs invite-only)
+# Registration invite code (registration is invite-only)
 POLARIS_INVITE_CODE=polaris-lab
+# Shared secret between the api service and the plugin kernel host (#754).
+# The kernel does no user authentication of its own and its port is never
+# published; the api proxies plugin calls behind the owner guard and presents
+# this secret. Required by the compose kernel service; set any long random value.
+POLARIS_KERNEL_TOKEN=change-me-kernel-token
 # Public server root used only by stdio MCP download links. HTTP MCP always
 # reuses the origin of the current /mcp request.
 # POLARIS_PUBLIC_BASE_URL=https://polaris.example.edu

--- a/docker/Dockerfile.kernel
+++ b/docker/Dockerfile.kernel
@@ -1,0 +1,29 @@
+# 插件内核宿主（#754）：裸 Node 跑 @polaris/kernel 的服务器入口。
+#
+# 不带 Electron、不带 Python：内核包本身就是 electron-free 的（由
+# src/kernel/tests/electron-free.test.ts 机械把关），所以这里只要一个 Node。
+#
+# node:22 而不是 alpine：storage 插件用的是 node:sqlite（Node ≥ 22 内建），
+# alpine 的 musl 下这条零编译路径不保证可用，而「零编译」正是选它的理由。
+FROM node:22-slim
+
+WORKDIR /srv
+
+# 只装内核与它依赖的 vendor 包：前端/桌面的依赖树与这个进程无关
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY vendor ./vendor
+COPY src/kernel ./src/kernel
+
+RUN corepack enable \
+    && pnpm install --frozen-lockfile --filter @polaris/kernel... \
+    && pnpm store prune
+
+# 数据根由 compose 挂载；端口不发布，只在内部网络可达（见 rpc-http.ts 的信任边界）
+ENV POLARIS_KERNEL_DATA_DIR=/srv/data \
+    POLARIS_KERNEL_PORT=8770 \
+    POLARIS_KERNEL_HOST=0.0.0.0
+
+EXPOSE 8770
+
+# --experimental-strip-types：内核以 .ts 源码发布（workspace 内部包，不预编译）
+CMD ["node", "--experimental-strip-types", "-e", "import('@polaris/kernel/src/server/main.ts').then(m => m.main())"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -34,6 +34,9 @@ services:
     env_file: ../.env
     environment:
       POLARIS_DATA_DIR: /srv/data   # PDF/产物写挂载卷，勿写进代码树（会触发 --watch 重载）
+      # 插件内核（#754）：api 是唯一被允许调它的人，密钥两边同一个
+      POLARIS_KERNEL_URL: http://kernel:8770
+      POLARIS_KERNEL_TOKEN: ${POLARIS_KERNEL_TOKEN:-}
     depends_on:
       postgres:
         condition: service_healthy
@@ -66,6 +69,20 @@ services:
       - appdata:/srv/data
       - tectonic-cache:/root/.cache/Tectonic   # tectonic 宏包缓存（与 api 共享）
 
+  # 插件内核宿主（#754）。**刻意不发布端口**：它只认共享密钥、不做用户认证，
+  # 认证在 api 那侧用 owner 守卫做（见 app/api/plugins.py）。端口一旦对外，
+  # 拿到密钥就等于拿到在服务端装插件的权限。
+  kernel:
+    image: ${POLARIS_IMAGE_PREFIX:-tricktreat}/polaris-kernel:${POLARIS_IMAGE_TAG:-latest}
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.kernel
+    restart: unless-stopped
+    environment:
+      POLARIS_KERNEL_TOKEN: ${POLARIS_KERNEL_TOKEN:?set POLARIS_KERNEL_TOKEN in .env}
+    volumes:
+      - kerneldata:/srv/data
+
   frontend:
     image: ${POLARIS_IMAGE_PREFIX:-tricktreat}/polaris-frontend:${POLARIS_IMAGE_TAG:-latest}
     build:
@@ -81,4 +98,5 @@ volumes:
   pgdata:
   redisdata:
   appdata:
+  kerneldata:
   tectonic-cache:

--- a/src/backend/app/api/plugins.py
+++ b/src/backend/app/api/plugins.py
@@ -1,0 +1,111 @@
+"""插件管理代理（#754）：浏览器 → 后端（判权限）→ 内核宿主（干活）。
+
+服务器形态下插件内核是独立的 Node 进程。它只认一个共享密钥、只挂在 compose
+内部网络上，**不做用户认证**——认证在这里做，用的是既有的 owner 守卫。
+
+为什么是代理而不是让前端直连内核：
+
+- 认证只有一套。内核那侧再实现一遍 JWT 校验，等于两套认证栈，迟早在「谁算
+  owner」上分叉，分叉的那一半就是漏洞。
+- 在服务器上装插件 = 在服务端进程里跑第三方代码，对**所有账号**生效，不是
+  桌面那种「装在自己机器上」。所以门槛是 owner，而不是「已登录」。
+- 内核端口不对外，攻击面只剩后端这一个入口。
+
+未配置内核（kernel_url / kernel_token 任一为空）时整族返回 503，让前端把
+「这个部署没有插件能力」与「内核挂了」区分开。
+"""
+
+import json
+from typing import Any
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.responses import StreamingResponse
+
+from app.core.config import get_settings
+from app.models.user import User
+from app.services.owner import require_owner
+
+router = APIRouter(prefix="/plugins", tags=["plugins"])
+
+# 安装要下载 + 解压，慢是正常的；读方法都是本地树操作，快。取一个够宽的上限。
+_RPC_TIMEOUT = httpx.Timeout(connect=5.0, read=180.0, write=30.0, pool=5.0)
+
+
+def _kernel_target() -> tuple[str, str]:
+    settings = get_settings()
+    url = (settings.kernel_url or "").rstrip("/")
+    token = settings.kernel_token or ""
+    if not url or not token:
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE, detail="KERNEL_NOT_CONFIGURED"
+        )
+    return url, token
+
+
+@router.post("/rpc")
+async def plugins_rpc(
+    payload: dict[str, Any],
+    _owner: User = Depends(require_owner),
+) -> Any:
+    """把一次 JSON-RPC 调用转给内核宿主。
+
+    方法名与参数不在这里白名单化：内核自己有方法表（未知方法 404）与逐个参数的
+    形状守卫，再抄一份清单只会多一处漂移点。这里只负责「谁能调」。
+    """
+    url, token = _kernel_target()
+    try:
+        async with httpx.AsyncClient(timeout=_RPC_TIMEOUT) as client:
+            response = await client.post(
+                f"{url}/rpc",
+                json=payload,
+                headers={"x-polaris-kernel-token": token},
+            )
+    except httpx.HTTPError as exc:
+        # 连不上内核是运行故障，不是调用错误：502 让前端说「插件服务不可达」
+        raise HTTPException(
+            status.HTTP_502_BAD_GATEWAY, detail=f"KERNEL_UNREACHABLE: {exc}"
+        ) from exc
+
+    body = response.json()
+    if response.status_code >= 400:
+        # 内核把方法失败表达成 4xx + {"error": ...}：原样透出错误文本，
+        # 前端要靠 MarketError 的错误码分流展示（integrity-mismatch 等）
+        raise HTTPException(response.status_code, detail=body.get("error", "kernel error"))
+    return body.get("result")
+
+
+@router.get("/events")
+async def plugins_events(
+    request: Request,
+    _owner: User = Depends(require_owner),
+) -> StreamingResponse:
+    """把内核的 job 事件流（SSE）透传给浏览器。
+
+    安装是长任务：四个阶段的进度经这条流回到前端。断流由客户端重连处理，
+    这里不做缓冲——错过的进度不值得攒着，收尾的 job.done/job.error 会重发结论。
+    """
+    url, token = _kernel_target()
+
+    async def relay():
+        try:
+            async with (
+                httpx.AsyncClient(timeout=httpx.Timeout(None)) as client,
+                client.stream(
+                    "GET", f"{url}/events", headers={"x-polaris-kernel-token": token}
+                ) as upstream,
+            ):
+                async for chunk in upstream.aiter_raw():
+                    if await request.is_disconnected():
+                        break
+                    yield chunk
+        except httpx.HTTPError as exc:
+            # 流里报错只能用数据面：发一条结构化事件，别让前端以为只是断了
+            yield f"data: {json.dumps({'type': 'kernel.error', 'message': str(exc)})}\n\n".encode()
+
+    return StreamingResponse(
+        relay(),
+        media_type="text/event-stream",
+        # nginx 默认会缓冲代理响应，SSE 必须关掉才逐条到达（与 /api 的其余流式面一致）
+        headers={"cache-control": "no-cache", "x-accel-buffering": "no"},
+    )

--- a/src/backend/app/api/router.py
+++ b/src/backend/app/api/router.py
@@ -31,6 +31,7 @@ from app.api import (
     notes,
     paper_assets,
     papers,
+    plugins,
     presentations,
     projects,
     publications,
@@ -92,3 +93,4 @@ api_router.include_router(evidence.router)
 api_router.include_router(experiments.router)
 api_router.include_router(manuscripts.router)
 api_router.include_router(export.router)
+api_router.include_router(plugins.router)

--- a/src/backend/app/core/config.py
+++ b/src/backend/app/core/config.py
@@ -51,6 +51,13 @@ class Settings(BaseSettings):
     # 注意：前端拼 new-issue 链接用的是自己写死的 REPO_URL 常量，不读这里。
     github_repo: str = "ZJU-REAL/Polaris"
 
+    # ---- Plugin kernel (#754) ----
+    # 服务器形态下插件内核是独立的 Node 进程（compose 服务 kernel，不发布端口）。
+    # 后端只做代理：浏览器带会话打后端，后端用 owner 守卫判权限，通过后带共享密钥
+    # 转发到内核。两个值都为空 = 这个部署没接内核，plugins.* 整族按不可用处理。
+    kernel_url: str | None = None
+    kernel_token: str | None = None
+
     # ---- Database / Cache ----
     # 默认回退 sqlite+aiosqlite，便于无 docker 的本地开发与测试；生产用 postgresql+asyncpg
     database_url: str = "sqlite+aiosqlite:///./polaris_dev.db"

--- a/src/backend/tests/test_plugins_proxy.py
+++ b/src/backend/tests/test_plugins_proxy.py
@@ -1,0 +1,164 @@
+"""插件管理代理（#754）：谁能调、没配内核时什么表现、内核错误怎么透出。
+
+这一层不实现插件语义（那在 Node 内核里，由 kernel 套件把关），它只负责一件事——
+**在服务器上装插件 = 在服务端进程里跑第三方代码，对所有账号生效**，所以门槛必须是
+主人而不是「已登录」。下面钉的就是这条线。
+"""
+
+import httpx
+import pytest
+
+from app.core.config import get_settings
+from tests.conftest import register_and_login
+
+PROBES = [
+    ("POST", "/api/plugins/rpc", {"method": "plugins.list"}),
+    ("GET", "/api/plugins/events", None),
+]
+
+
+@pytest.fixture(autouse=True)
+def _kernel_configured(monkeypatch):
+    """默认给一个内核地址；不配的用例自己覆盖回 None。"""
+    settings = get_settings()
+    monkeypatch.setattr(settings, "kernel_url", "http://kernel.invalid:8770", raising=False)
+    monkeypatch.setattr(settings, "kernel_token", "unit-test-token", raising=False)
+    yield
+
+
+async def test_second_user_cannot_manage_plugins(client):
+    await register_and_login(client, email="owner@example.com")
+    second = await register_and_login(client, email="second@example.com")
+    headers = {"Authorization": f"Bearer {second}"}
+
+    for method, url, payload in PROBES:
+        resp = await client.request(method, url, json=payload, headers=headers)
+        # 装插件影响整个部署，不是「我自己的机器」——非主人一律 403
+        assert resp.status_code == 403, (url, resp.status_code)
+        assert resp.json()["detail"] == "OWNER_REQUIRED"
+
+
+async def test_anonymous_cannot_manage_plugins(client):
+    for method, url, payload in PROBES:
+        resp = await client.request(method, url, json=payload)
+        assert resp.status_code == 401, (url, resp.status_code)
+
+
+async def test_unconfigured_kernel_reads_as_unavailable_not_broken(client, monkeypatch):
+    token = await register_and_login(client, email="owner@example.com")
+    settings = get_settings()
+    monkeypatch.setattr(settings, "kernel_url", None, raising=False)
+
+    resp = await client.post(
+        "/api/plugins/rpc",
+        json={"method": "plugins.list"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    # 「这个部署没接内核」与「内核挂了」必须可区分，前端据此决定显不显示插件页
+    assert resp.status_code == 503
+    assert resp.json()["detail"] == "KERNEL_NOT_CONFIGURED"
+
+
+async def test_owner_call_forwards_with_the_shared_token(client, monkeypatch):
+    token = await register_and_login(client, email="owner@example.com")
+    seen: dict = {}
+
+    class _Response:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {"result": [{"id": "sources", "state": "active"}]}
+
+    class _Client:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_exc):
+            return False
+
+        async def post(self, url, json=None, headers=None):
+            seen["url"] = url
+            seen["json"] = json
+            seen["headers"] = headers
+            return _Response()
+
+    monkeypatch.setattr(httpx, "AsyncClient", _Client)
+
+    resp = await client.post(
+        "/api/plugins/rpc",
+        json={"method": "plugins.list"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == [{"id": "sources", "state": "active"}]
+    assert seen["url"] == "http://kernel.invalid:8770/rpc"
+    # 密钥只在服务端之间流动，浏览器永远看不到它
+    assert seen["headers"]["x-polaris-kernel-token"] == "unit-test-token"
+    assert seen["json"] == {"method": "plugins.list"}
+
+
+async def test_kernel_method_failure_keeps_its_status_and_message(client, monkeypatch):
+    token = await register_and_login(client, email="owner@example.com")
+
+    class _Response:
+        status_code = 400
+
+        @staticmethod
+        def json():
+            return {"error": "integrity-mismatch: sha512 did not match"}
+
+    class _Client:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_exc):
+            return False
+
+        async def post(self, *_args, **_kwargs):
+            return _Response()
+
+    monkeypatch.setattr(httpx, "AsyncClient", _Client)
+
+    resp = await client.post(
+        "/api/plugins/rpc",
+        json={"method": "plugins.market.install", "params": {"name": "x", "version": "1.0.0"}},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    # 安装失败是业务结果：错误码要原样到前端，好按 MarketError 分流展示
+    assert resp.status_code == 400
+    assert "integrity-mismatch" in resp.json()["detail"]
+
+
+async def test_unreachable_kernel_is_a_gateway_error(client, monkeypatch):
+    token = await register_and_login(client, email="owner@example.com")
+
+    class _Client:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_exc):
+            return False
+
+        async def post(self, *_args, **_kwargs):
+            raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr(httpx, "AsyncClient", _Client)
+
+    resp = await client.post(
+        "/api/plugins/rpc",
+        json={"method": "plugins.list"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    # 连不上是运行故障，与「这次调用不对」分开：502 而不是 400/503
+    assert resp.status_code == 502
+    assert "KERNEL_UNREACHABLE" in resp.json()["detail"]


### PR DESCRIPTION
Fifth step of #754, on top of #759. This is where the permission decision actually gets made.

## The shape

```
browser (session cookie)  →  api  /api/plugins/rpc   →  kernel  http://kernel:8770/rpc
                             require_owner              x-polaris-kernel-token
```

The kernel's port is never published, so the backend is the only way in.

## Owner, not merely authenticated

The gate is `require_owner`, and the reason is specific to the server form: **installing a plugin here runs third-party code inside the server process and affects every account.** On the desktop that risk lands on the user's own machine, which is exactly why the same action needs no such check there. Same feature, different blast radius, different gate.

## Method names are deliberately not whitelisted

The kernel already has a method table that answers unknown methods, plus per-parameter shape guards. Copying that list into the proxy would add a second place to drift without adding a check — the proxy's job is *who*, not *what*.

## Failure modes stay distinguishable

The frontend has to react to these differently, so they are not collapsed:

| Situation | Response |
| --- | --- |
| no kernel configured | `503 KERNEL_NOT_CONFIGURED` — the UI can hide plugin management entirely |
| kernel unreachable | `502 KERNEL_UNREACHABLE` |
| method failed | the kernel's own status and message, so an install error keeps its `MarketError` code for the UI to branch on |

## Deployment

Compose gains a `kernel` service with **no published ports** and its own data volume; the `api` service learns where the kernel lives. The token is required rather than defaulted (`${POLARIS_KERNEL_TOKEN:?…}`), so a deployment cannot accidentally bring up an unauthenticated kernel — the compose up fails instead.

The kernel image is `node:22-slim` rather than alpine on purpose: the storage plugin uses `node:sqlite`, and the zero-compile path that motivated choosing it is not guaranteed under musl.

## Verification

**12 passed**, covering the boundary rather than the plumbing: a second user and an anonymous caller are refused on *both* endpoints, the unconfigured case reads as unavailable rather than broken, an owner call forwards with the secret (and the secret never reaches the browser), a kernel method failure keeps its status and message, and an unreachable kernel is a gateway error. Owner-guard and golden suites included; `ruff check` clean.

The new ruff gate from #747 earned its keep here — it caught a nested `async with` in the SSE relay on first run.

Remaining for #754: the web bridge, so `PluginsSettings.tsx` and `PluginsMarketSection.tsx` can be reused unchanged, plus granting `plugins.manage` to the owner on the server profile.
