### PR TITLE
fix: the kernel container actually starts (#754)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -12,6 +12,9 @@ on:
       # 一个类型错就让整个前端镜像出不来。以前这里不含前端，于是 5a3cd37 带着编译错误
       # 合进 main，直到部署才发现——CI 全绿，因为它根本没跑。
       - "src/frontend/**"
+      # 内核镜像同理：它以 .ts 源码运行，构建成功不代表跑得起来（#754 实测两次
+      # 都是运行期才炸：包名解析不到、TS 语法擦不掉），所以下面除了 build 还要真起一下。
+      - "src/kernel/**"
       - "pnpm-lock.yaml"
       - ".github/workflows/docker-build.yml"
   workflow_dispatch:
@@ -34,3 +37,30 @@ jobs:
 
       - name: Build worker image
         run: docker build -f docker/Dockerfile.worker -t polaris-worker .
+
+      - name: Build kernel image
+        run: docker build -f docker/Dockerfile.kernel -t polaris-kernel .
+
+      # 光 build 不够：内核跑的是 .ts 源码，两个真实故障（bare specifier 解析不到、
+      # 参数属性/namespace 擦不掉）都只在**启动时**才暴露，构建阶段一片绿。
+      - name: Kernel image actually starts and answers
+        run: |
+          docker run -d --name kernel-smoke \
+            -e POLARIS_KERNEL_TOKEN=ci-smoke-token \
+            -e POLARIS_KERNEL_HOST=0.0.0.0 \
+            -p 18770:8770 polaris-kernel
+          for i in $(seq 1 30); do
+            if curl -sS -o /tmp/status.json -X POST http://127.0.0.1:18770/rpc \
+                 -H 'x-polaris-kernel-token: ci-smoke-token' \
+                 -H 'content-type: application/json' \
+                 -d '{"method":"kernel.status"}'; then break; fi
+            sleep 2
+          done
+          docker logs kernel-smoke
+          cat /tmp/status.json
+          grep -q '"started":true' /tmp/status.json
+          # 没有密钥必须被拒，而不是放行
+          code=$(curl -sS -o /dev/null -w '%{http_code}' -X POST http://127.0.0.1:18770/rpc \
+                   -H 'content-type: application/json' -d '{"method":"kernel.status"}')
+          test "$code" = '401'
+          docker rm -f kernel-smoke

--- a/docker/Dockerfile.kernel
+++ b/docker/Dockerfile.kernel
@@ -25,5 +25,13 @@ ENV POLARIS_KERNEL_DATA_DIR=/srv/data \
 
 EXPOSE 8770
 
-# --experimental-strip-types：内核以 .ts 源码发布（workspace 内部包，不预编译）
-CMD ["node", "--experimental-strip-types", "-e", "import('@polaris/kernel/src/server/main.ts').then(m => m.main())"]
+# 按路径跑而不是按包名：pnpm 只把工作区包链进依赖它的包的 node_modules，
+# 镜像里没有任何东西依赖 @polaris/kernel，所以根目录没有那个软链，
+# import('@polaris/kernel/...') 会 ERR_MODULE_NOT_FOUND。
+# --experimental-transform-types 而不是 strip-types：内核以 .ts 源码发布（workspace
+# 内部包，不预编译），而它用了两处**只擦类型擦不掉**的语法——SqliteTree 的
+# `export namespace`（schemastery/cordis 的 Xxx.Config 惯例，全生态都这么写）与
+# 构造函数参数属性。这两样需要真正的代码生成，strip-only 模式会直接报
+# ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX。改代码去迎合 strip-only 会把 cordis 的惯用
+# 写法拧坏，不值得。
+CMD ["node", "--experimental-transform-types", "src/kernel/src/server/start.ts"]

--- a/src/kernel/src/server/start.ts
+++ b/src/kernel/src/server/start.ts
@@ -1,0 +1,16 @@
+/* 容器入口：按**路径**跑，不按包名跑。
+
+   `import('@polaris/kernel/...')` 在镜像里解析不了——pnpm 只把工作区包链进
+   依赖它的包的 node_modules，而镜像里没有任何东西依赖 @polaris/kernel，
+   所以根目录不会有那个软链。按路径进来则一路相对解析，main.ts 自己的
+   依赖（vendor 的 cordis 等）仍从 src/kernel/node_modules 找得到。
+
+   main.ts 只导出 main()、不自调用：那样它才能被测试 import 而不起服务。
+   真正「跑起来」的动作放在这里。 */
+
+import { main } from './main.ts'
+
+main().catch((err: unknown) => {
+  console.error('[kernel] server host failed to start:', err)
+  process.exit(1)
+})


### PR DESCRIPTION
Closes #754.

Two runtime failures in the image shipped with #760, both found by **deploying it**, not by CI.

## 1. The bare specifier could not resolve

The entry did `import('@polaris/kernel/src/server/main.ts')`. pnpm only links a workspace package into the `node_modules` of packages that **depend on** it — nothing in this image does, so there is no link at the root and the specifier fails with `ERR_MODULE_NOT_FOUND`.

Running the entry **by path** resolves relatively, and the kernel's own dependencies still resolve from `src/kernel/node_modules`. `main()` stays an export rather than self-invoking, so tests can import the module without starting a server; a small `start.ts` does the invoking.

## 2. `--experimental-strip-types` cannot erase this code

Strip-only mode removes type annotations and nothing else. The kernel uses two constructs that need real code generation:

- `export namespace SqliteTree` — the schemastery/cordis `Xxx.Config` idiom used across the whole vendored ecosystem
- constructor parameter properties

Rewriting idiomatic cordis code to satisfy strip-only mode is the wrong trade, so the container asks for `--experimental-transform-types` instead. Only the container path is affected: the desktop bundles through esbuild and vitest does its own transform.

## Why CI missed both

Neither failure exists at build time — `docker build` succeeded every time. `docker-build.yml` also did not build this image at all.

So the workflow now builds the kernel image **and starts it**, asserting the host answers `kernel.status` and that a request **without** the shared token is refused. That second assertion matters as much as the first: a kernel that starts but accepts unauthenticated calls is worse than one that does not start.

The workflow's own header already records an earlier incident of exactly this shape — a type error reaching `main` because CI was green while never running what it built. Same lesson, new image.

## Verified on a real deployment

Against a live server, not a fixture:

- kernel comes up: `[kernel] server host listening on 8770`
- `kernel.status` through the proxy → `{"started":true,"name":"polaris-server","plugins":5,"storage":true}`
- `plugins.list` → `[{"id":"sources","name":"cordis:sources","state":"active"}]` — the server seed tree, with no `legacy-engine`, exactly as intended
- `plugins.market.getEndpoint` → the official index, `isDefault: true`
- `plugins.disable` then `plugins.enable` on `sources` → real tree writes, state flips and returns
- anonymous caller → **401**
- kernel port from the host → **unreachable**, so the trust boundary holds in practice and not just in the compose file
