### PR TITLE
feat: discipline packs give the extraction registry an entrance (#763)

### DIFF
--- a/src/backend/alembic/versions/d7b2e4c81a35_library_discipline.py
+++ b/src/backend/alembic/versions/d7b2e4c81a35_library_discipline.py
@@ -1,0 +1,33 @@
+"""文献库声明学科：direction_libraries 加 discipline
+
+学科包（YAML 声明抽取 schema）落地后，需要一个地方说明「这个库属于哪个学科」。
+它不是展示用的标签，是**抽取口径的选择**：本库论文除内置 schema 外，还按该学科包
+的 schema 抽一遍。
+
+为什么必须按库选而不是装上就全局生效：enrich 钩子会遍历 schema 逐个抽，全局生效
+意味着装一个结构工程包，连纯机器学习的论文也要多跑一次结构方法卡抽取——代价随
+装包数线性上涨，收益为零。为空 = 只用跨学科通用的内置 schema，与本次升级前完全一致。
+
+Revision ID: d7b2e4c81a35
+Revises: c4a1d8e93b57
+Create Date: 2026-09-12
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "d7b2e4c81a35"
+down_revision: str | None = "c4a1d8e93b57"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("direction_libraries", sa.Column("discipline", sa.String(length=64), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("direction_libraries", "discipline")

--- a/src/backend/app/disciplines/structural-engineering.yaml
+++ b/src/backend/app/disciplines/structural-engineering.yaml
@@ -5,7 +5,7 @@
 # 需要的是构件与材料、边界与载荷、分析手段、以及"拿什么验证的"。这个包不改一行代码
 # 就把方法卡换成他要的口径。
 #
-# 放进 <data_dir>/packs/disciplines/ 的同名文件会覆盖本包，所以用户可以从它改起。
+# 放进 <data_dir>/disciplines/ 的同名文件会覆盖本包，所以用户可以从它改起。
 name: structural
 title: 结构工程
 description: >-

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -18,6 +18,7 @@ from app.mcp import mcp_router
 from app.services.builtin_agent_skills import ensure_builtin_agent_skills
 from app.services.crdt_rooms import reset_crdt_rooms
 from app.services.crdt_stream import get_crdt_stream_subscriber, stop_crdt_stream_subscriber
+from app.services.discipline_packs import load_disciplines
 from app.services.interdisciplinary_workflows import ensure_guidance_documents
 from app.services.skills import ensure_builtin_skills
 
@@ -43,6 +44,9 @@ async def lifespan(app: FastAPI):
             await ensure_guidance_documents(session)
     except Exception:  # noqa: BLE001
         logger.warning("builtin skill seeding failed (migrations pending?)", exc_info=True)
+    # 学科包：把抽取 schema 的注册缝接到磁盘（内置包 + <data_dir>/packs/disciplines）。
+    # 纯文件读取、不碰数据库，所以不跟着上面的 DB 种子一起 try
+    load_disciplines()
     # AI 起草流式镜像订阅（worker 发布 → 写活跃 CRDT 房间；连不上 redis 自动放弃）
     get_crdt_stream_subscriber().start()
     yield

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -44,7 +44,7 @@ async def lifespan(app: FastAPI):
             await ensure_guidance_documents(session)
     except Exception:  # noqa: BLE001
         logger.warning("builtin skill seeding failed (migrations pending?)", exc_info=True)
-    # 学科包：把抽取 schema 的注册缝接到磁盘（内置包 + <data_dir>/packs/disciplines）。
+    # 学科包：把抽取 schema 的注册缝接到磁盘（内置包 + <data_dir>/disciplines）。
     # 纯文件读取、不碰数据库，所以不跟着上面的 DB 种子一起 try
     load_disciplines()
     # AI 起草流式镜像订阅（worker 发布 → 写活跃 CRDT 房间；连不上 redis 自动放弃）

--- a/src/backend/app/models/library_direction.py
+++ b/src/backend/app/models/library_direction.py
@@ -51,6 +51,10 @@ class DirectionLibrary(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         String(24), default="standard", server_default="standard", nullable=False
     )
     interdisciplinary_domains: Mapped[list[str] | None] = mapped_column(JSONVariant)
+    # 学科包名（app/packs/disciplines 或 <data_dir>/packs/disciplines 里的 name）。
+    # 不是展示用的标签，是**抽取口径的选择**：本库的论文除了内置 schema，还按这个
+    # 学科包的 schema 抽一遍。为空 = 只用跨学科通用的内置 schema。
+    discipline: Mapped[str | None] = mapped_column(String(64))
     interdisciplinary_project_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("projects.id", ondelete="SET NULL"), index=True
     )

--- a/src/backend/app/models/library_direction.py
+++ b/src/backend/app/models/library_direction.py
@@ -51,7 +51,7 @@ class DirectionLibrary(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         String(24), default="standard", server_default="standard", nullable=False
     )
     interdisciplinary_domains: Mapped[list[str] | None] = mapped_column(JSONVariant)
-    # 学科包名（app/packs/disciplines 或 <data_dir>/packs/disciplines 里的 name）。
+    # 学科包名（app/disciplines 或 <data_dir>/disciplines 里的 name）。
     # 不是展示用的标签，是**抽取口径的选择**：本库的论文除了内置 schema，还按这个
     # 学科包的 schema 抽一遍。为空 = 只用跨学科通用的内置 schema。
     discipline: Mapped[str | None] = mapped_column(String(64))

--- a/src/backend/app/packs/disciplines/structural-engineering.yaml
+++ b/src/backend/app/packs/disciplines/structural-engineering.yaml
@@ -1,0 +1,56 @@
+# 结构工程学科包（示例，同时是写自己学科包的模板）。
+#
+# 存在的意义不是"多支持一个学科"，而是证明那条路是通的：内置方法卡 method@1 抽的是
+# purpose / mechanism / baseline / dataset / protocol——机器学习论文的形状。做结构的人
+# 需要的是构件与材料、边界与载荷、分析手段、以及"拿什么验证的"。这个包不改一行代码
+# 就把方法卡换成他要的口径。
+#
+# 放进 <data_dir>/packs/disciplines/ 的同名文件会覆盖本包，所以用户可以从它改起。
+name: structural
+title: 结构工程
+description: >-
+  面向结构/土木方向的抽取口径：把论文的做法按「结构对象 — 作用 — 分析手段 — 验证」
+  拆开，替代以数据集与基线为中心的机器学习口径。
+
+schemas:
+  # 方法卡的结构工程版。字段与内置 method@1 一一对位但换了轴：
+  #   purpose/mechanism  → 保留（这两根轴是跨学科的，方法库的类比检索靠它们）
+  #   baseline/dataset   → 换成 validation/structure（结构领域没有"数据集"这回事，
+  #                        对应物是"拿什么算例或试验验证的"）
+  #   protocol           → 换成 analysis（分析类型、求解器、网格/单元、时间步）
+  - id: method
+    version: 1
+    prompt: |
+      POLARIS_EXTRACT_METHOD
+      你是结构工程论文的方法卡抽取器。根据给定论文的标题与正文，把它的做法拆成方法卡，
+      全部字段用中文表述（专有名词、软件名、规范号保留原文）：
+      {fields_spec}
+      其中 "purpose" 只写这项工作要解决的结构问题（不写怎么做）；
+      "mechanism" 只写解决它的核心手段（不复述目标）；
+      "structure" 写研究对象的构件形式与材料（如「钢-混组合梁，Q355 + C40」）；
+      "actions" 写考虑的作用与工况（如「爆炸冲击」「地震动，El Centro」「疲劳荷载」）；
+      "analysis" 写分析手段与关键设置（如「显式动力学，LS-DYNA，六面体单元，1mm」）；
+      "validation" 写结论靠什么验证（如「1:2 缩尺落锤试验」「与规范 GB50017 对比」）。
+      只输出一个 JSON 对象，键为上述字段名，另加 "confidence"（0 到 1，
+      你对整份抽取的把握）。只依据原文，不引入外部知识。
+    fields:
+      - name: purpose
+        kind: text
+        max_len: 400
+      - name: mechanism
+        kind: text
+        max_len: 400
+      - name: structure
+        kind: text
+        max_len: 400
+      - name: actions
+        kind: list
+        max_len: 200
+        max_items: 5
+      - name: analysis
+        kind: text
+        max_len: 600
+      - name: validation
+        kind: list
+        max_len: 200
+        max_items: 5

--- a/src/backend/app/services/discipline_packs.py
+++ b/src/backend/app/services/discipline_packs.py
@@ -1,0 +1,211 @@
+"""学科包：用声明式 YAML 往抽取注册表里加学科自己的抽取 schema。
+
+## 为什么要有
+
+`extraction/schemas.py` 的文件头写着「不预埋任何学科内容」，并留了 `register_schema`
+这道缝——但在此之前，**全仓只有它自己调用那道缝**，注册三个内置 schema。外部没有
+任何安装路径，所以"按学科分化"在设计报告里有、在产品里没有。
+
+具体后果：内置的方法卡 `method@1` 抽的是 purpose / mechanism / baseline / dataset /
+protocol——这是机器学习论文的形状。一个做结构工程的人需要的是材料、边界条件、
+载荷工况、网格与求解器设置；他今天拿到的方法卡对他没用，而他除了改仓库没有别的办法。
+
+学科包把那道缝接到磁盘上：一个 YAML 声明若干抽取 schema，放进包目录即生效。
+
+## 为什么是声明式 YAML 而不是插件代码
+
+抽取 schema 本身就是**数据**：字段、长度帽、一段 prompt。它不需要执行任何代码。
+让它保持数据形态，就能被审阅、被 diff、被随文献库一起导出（file-over-app），
+也不必为了加几个字段去承担"在服务端跑第三方代码"的风险——那是插件市场那条
+路解决的问题（#754），和这里是两件事。
+
+## 用户目录
+
+除了仓内的内置包，还读 ``<data_dir>/packs/disciplines/*.yaml``。这是 file-over-app
+的落点：用户自己写的学科包和他的 PDF、笔记放在一起，复制走就带走了。
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from app.core.config import get_settings
+from app.services.extraction.schemas import (
+    EntryKey,
+    ExtractionSchema,
+    SchemaField,
+    register_schema,
+)
+
+logger = logging.getLogger("polaris.disciplines")
+
+BUILTIN_DISCIPLINES_DIR = Path(__file__).resolve().parents[1] / "packs" / "disciplines"
+
+# 字段上限：既防着写坏的包，也防着 prompt 被撑爆——抽取是「整篇正文进、短 JSON 出」，
+# 字段太多太长会让模型顾此失彼，抽取质量反而掉。
+MAX_FIELDS = 12
+MAX_TEXT_LEN = 2000
+MAX_ITEMS = 20
+
+
+class DisciplinePackError(RuntimeError):
+    """学科包解析/校验失败。"""
+
+
+class PackEntryKey(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1, max_length=64)
+    max_len: int = Field(gt=0, le=MAX_TEXT_LEN)
+    choices: tuple[str, ...] | None = None
+
+
+class PackField(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1, max_length=64)
+    kind: Literal["text", "list", "entries"] = "text"
+    max_len: int = Field(default=800, gt=0, le=MAX_TEXT_LEN)
+    max_items: int | None = Field(default=None, gt=0, le=MAX_ITEMS)
+    entry_keys: tuple[PackEntryKey, ...] | None = None
+
+    def to_schema_field(self) -> SchemaField:
+        if self.kind == "entries" and not self.entry_keys:
+            raise DisciplinePackError(f"字段 {self.name!r} 是 entries，必须声明 entry_keys")
+        return SchemaField(
+            name=self.name,
+            kind=self.kind,
+            max_len=self.max_len,
+            max_items=self.max_items,
+            entry_keys=(
+                tuple(
+                    EntryKey(name=k.name, max_len=k.max_len, choices=k.choices)
+                    for k in self.entry_keys
+                )
+                if self.entry_keys
+                else None
+            ),
+        )
+
+
+class PackSchema(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(min_length=1, max_length=64, pattern=r"^[a-z0-9][a-z0-9_-]*$")
+    version: int = Field(default=1, ge=1)
+    fields: tuple[PackField, ...] = Field(min_length=1, max_length=MAX_FIELDS)
+    prompt: str = Field(min_length=1, max_length=4000)
+    #: 不给就让 register_schema 用它的缺省（跟随 extract_skeleton 的路由）
+    stage: str | None = None
+
+
+class DisciplinePack(BaseModel):
+    """一个学科包。name 是包标识，schemas 是它带来的抽取 schema。"""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1, max_length=64, pattern=r"^[a-z0-9][a-z0-9_-]*$")
+    title: str = Field(min_length=1, max_length=128)
+    description: str = Field(default="", max_length=1000)
+    schemas: tuple[PackSchema, ...] = Field(min_length=1, max_length=8)
+
+
+def _to_extraction_schema(pack: DisciplinePack, spec: PackSchema) -> ExtractionSchema:
+    """把包里的一条声明变成注册表认识的 ExtractionSchema。
+
+    schema id 强制带包名前缀（``<pack>.<id>``）：不同学科包难免都想叫 ``method``，
+    不加前缀迟早互相顶掉——而顶掉的后果是抽取悄悄换了口径，不会报错。
+    """
+    if "{fields_spec}" not in spec.prompt:
+        raise DisciplinePackError(
+            f"{pack.name}.{spec.id}：prompt 必须含 {{fields_spec}} 占位符，"
+            "字段清单由代码确定性生成，不能手写（否则与 fields 必然漂移）"
+        )
+    fields = tuple(f.to_schema_field() for f in spec.fields)
+    names = [f.name for f in fields]
+    if len(set(names)) != len(names):
+        raise DisciplinePackError(f"{pack.name}.{spec.id}：字段重名 {names}")
+
+    kwargs: dict[str, Any] = {
+        "id": f"{pack.name}.{spec.id}",
+        "version": spec.version,
+        "fields": fields,
+        "prompt_template": spec.prompt,
+        # 作用范围：只在声明了该学科的文献库里抽，不进全局遍历
+        "pack": pack.name,
+    }
+    if spec.stage:
+        kwargs["stage"] = spec.stage
+    return ExtractionSchema(**kwargs)
+
+
+def parse_pack(data: Any, *, origin: str) -> DisciplinePack:
+    if not isinstance(data, dict):
+        raise DisciplinePackError(f"学科包 {origin} 顶层必须是映射（mapping）")
+    try:
+        return DisciplinePack.model_validate(data)
+    except ValidationError as exc:
+        raise DisciplinePackError(f"学科包 {origin} 校验失败：{exc}") from exc
+
+
+def read_pack_file(path: Path) -> DisciplinePack:
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise DisciplinePackError(f"学科包 {path.name} YAML 解析失败：{exc}") from exc
+    return parse_pack(data, origin=path.name)
+
+
+def user_disciplines_dir() -> Path:
+    """用户自己的学科包目录（file-over-app：与 PDF、笔记同处一棵树）。"""
+    return Path(get_settings().data_dir) / "packs" / "disciplines"
+
+
+def pack_dirs() -> list[Path]:
+    """内置在前、用户在后：同名时用户包覆盖内置（下面按加载顺序处理）。"""
+    return [BUILTIN_DISCIPLINES_DIR, user_disciplines_dir()]
+
+
+def discover_packs() -> list[DisciplinePack]:
+    """扫描全部包目录。单个包坏掉只跳过它自己，不拖垮其余包。"""
+    packs: dict[str, DisciplinePack] = {}
+    for directory in pack_dirs():
+        if not directory.is_dir():
+            continue
+        for path in sorted(directory.rglob("*.yaml")):
+            try:
+                pack = read_pack_file(path)
+            except DisciplinePackError:
+                # 用户手写的包写坏了是常态，不该让整个平台起不来
+                logger.warning("跳过无法解析的学科包：%s", path, exc_info=True)
+                continue
+            packs[pack.name] = pack
+    return list(packs.values())
+
+
+def register_pack(pack: DisciplinePack) -> list[str]:
+    """把一个包里的 schema 全部登记，返回登记后的 schema id。"""
+    ids: list[str] = []
+    for spec in pack.schemas:
+        schema = _to_extraction_schema(pack, spec)
+        register_schema(schema)
+        ids.append(schema.id)
+    return ids
+
+
+def load_disciplines() -> dict[str, list[str]]:
+    """启动时调用：发现并登记全部学科包，返回 {包名: [schema id]}。"""
+    loaded: dict[str, list[str]] = {}
+    for pack in discover_packs():
+        try:
+            loaded[pack.name] = register_pack(pack)
+        except Exception:  # noqa: BLE001 — 一个包登记失败不该拖垮启动
+            logger.warning("学科包登记失败：%s", pack.name, exc_info=True)
+    if loaded:
+        logger.info("学科包已加载：%s", ", ".join(sorted(loaded)))
+    return loaded

--- a/src/backend/app/services/discipline_packs.py
+++ b/src/backend/app/services/discipline_packs.py
@@ -21,7 +21,7 @@ protocol——这是机器学习论文的形状。一个做结构工程的人需
 
 ## 用户目录
 
-除了仓内的内置包，还读 ``<data_dir>/packs/disciplines/*.yaml``。这是 file-over-app
+除了仓内的内置包，还读 ``<data_dir>/disciplines/*.yaml``。这是 file-over-app
 的落点：用户自己写的学科包和他的 PDF、笔记放在一起，复制走就带走了。
 """
 
@@ -44,7 +44,9 @@ from app.services.extraction.schemas import (
 
 logger = logging.getLogger("polaris.disciplines")
 
-BUILTIN_DISCIPLINES_DIR = Path(__file__).resolve().parents[1] / "packs" / "disciplines"
+# 刻意不放在 app/packs/ 下：process_packs 用 rglob 递归扫那棵树，任何放进去的
+# 非流程包 YAML 都会被它当流程包解析并校验失败。两种包不共享一棵被递归扫描的树。
+BUILTIN_DISCIPLINES_DIR = Path(__file__).resolve().parents[1] / "disciplines"
 
 # 字段上限：既防着写坏的包，也防着 prompt 被撑爆——抽取是「整篇正文进、短 JSON 出」，
 # 字段太多太长会让模型顾此失彼，抽取质量反而掉。
@@ -162,8 +164,11 @@ def read_pack_file(path: Path) -> DisciplinePack:
 
 
 def user_disciplines_dir() -> Path:
-    """用户自己的学科包目录（file-over-app：与 PDF、笔记同处一棵树）。"""
-    return Path(get_settings().data_dir) / "packs" / "disciplines"
+    """用户自己的学科包目录（file-over-app：与 PDF、笔记同处一棵树）。
+
+    与内置目录同名同层级（disciplines/），两处路径形状一致，少一处要记的例外。
+    """
+    return Path(get_settings().data_dir) / "disciplines"
 
 
 def pack_dirs() -> list[Path]:

--- a/src/backend/app/services/extraction/schemas.py
+++ b/src/backend/app/services/extraction/schemas.py
@@ -64,6 +64,11 @@ class ExtractionSchema:
     #   按 extract_skeleton 的路由调用，再没有就跟随 default。
     #   要自定 tier/fallback，先自行调用 router.register_plugin_stage 再 register_schema。
     stage: str = "extract_skeleton"
+    #: 来自哪个学科包；None = 内置（跨学科通用）。
+    #: 这不是标签，是**作用范围**：内置 schema 对所有论文都抽，学科 schema 只在
+    #: 声明了该学科的文献库里抽。否则装一个学科包就等于给每篇论文——包括别的
+    #: 学科的——多加一次 LLM 抽取，代价随装包数线性上涨而收益为零。
+    pack: str | None = None
 
     def field_spec_text(self) -> str:
         """字段清单的自然语言描述（进 prompt，确定性生成，与 fields 永不漂移）。"""
@@ -226,6 +231,23 @@ def get_schema(schema_id: str) -> ExtractionSchema:
 
 def list_schemas() -> list[ExtractionSchema]:
     return list(_REGISTRY.values())
+
+
+def builtin_schemas() -> list[ExtractionSchema]:
+    """跨学科通用的 schema（pack 为 None）：任何论文都抽这些。"""
+    return [s for s in _REGISTRY.values() if s.pack is None]
+
+
+def schemas_for(discipline: str | None) -> list[ExtractionSchema]:
+    """某个学科下该抽的全部 schema = 内置 + 该学科包自己的。
+
+    discipline 为 None（库没声明学科，或个人书架导入没有库上下文）时只有内置——
+    学科包必须由库显式选用才生效，装上不等于到处生效。
+    """
+    out = builtin_schemas()
+    if discipline:
+        out += [s for s in _REGISTRY.values() if s.pack == discipline]
+    return sorted(out, key=lambda item: item.id)
 
 
 register_schema(SKELETON_SCHEMA)

--- a/src/backend/app/services/paper_enrich.py
+++ b/src/backend/app/services/paper_enrich.py
@@ -307,11 +307,13 @@ async def enrich_paper(
     # best-effort（一个 schema 失败不拖垮其余）；runtime 对无全文论文如实 skip、
     # 不调 LLM——bibtex 导入等 golden 链路因此零输出零副作用。
     from app.services.extraction.runtime import extract_paper
-    from app.services.extraction.schemas import list_schemas
+    from app.services.extraction.schemas import schemas_for
     from app.services.method_index import METHOD_SCHEMA_ID, refresh_paper_method_index
 
     method_extracted = False
-    for schema in sorted(list_schemas(), key=lambda item: item.id):
+    # 内置 schema 对所有论文都抽；学科 schema 只在声明了该学科的库里抽（#754 后续：
+    # 学科包）。装一个学科包不该让别的学科的论文也多跑一次抽取。
+    for schema in schemas_for(getattr(target, "discipline", None)):
         try:
             outcome = await extract_paper(
                 session,

--- a/src/backend/tests/test_discipline_packs.py
+++ b/src/backend/tests/test_discipline_packs.py
@@ -121,7 +121,7 @@ def test_user_directory_packs_are_discovered(tmp_path, monkeypatch):
     from app.core.config import get_settings
 
     monkeypatch.setattr(get_settings(), "data_dir", str(tmp_path), raising=False)
-    user_dir = tmp_path / "packs" / "disciplines"
+    user_dir = tmp_path / "disciplines"
     user_dir.mkdir(parents=True)
     (user_dir / "mine.yaml").write_text(
         yaml.safe_dump(_minimal(name="mine"), allow_unicode=True), encoding="utf-8"
@@ -137,7 +137,7 @@ def test_a_broken_pack_does_not_stop_the_others(tmp_path, monkeypatch):
     from app.core.config import get_settings
 
     monkeypatch.setattr(get_settings(), "data_dir", str(tmp_path), raising=False)
-    user_dir = tmp_path / "packs" / "disciplines"
+    user_dir = tmp_path / "disciplines"
     user_dir.mkdir(parents=True)
     (user_dir / "broken.yaml").write_text("name: [this is not a mapping", encoding="utf-8")
     (user_dir / "good.yaml").write_text(

--- a/src/backend/tests/test_discipline_packs.py
+++ b/src/backend/tests/test_discipline_packs.py
@@ -1,0 +1,190 @@
+"""学科包：把抽取注册表那道缝接到磁盘上。
+
+审计出的问题是具体的——`register_schema` 全仓只有 extraction/schemas.py 自己调用，
+所以"抽取 schema 按学科分化"在设计里有、在产品里没有。一个做结构的人拿到的方法卡
+是机器学习口径（baseline / dataset），而他除了改仓库没有别的办法。
+
+这些用例钉的就是那条路：内置学科包能登记、用户目录里的包能登记、坏包不拖垮别人、
+schema id 强制带包名前缀。
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from app.services import discipline_packs as dp
+from app.services.extraction.schemas import (
+    _REGISTRY,
+    get_schema,
+    list_schemas,
+    schemas_for,
+)
+
+CIVIL = dp.BUILTIN_DISCIPLINES_DIR / "structural-engineering.yaml"
+
+
+@pytest.fixture(autouse=True)
+def _restore_schema_registry():
+    """抽取注册表是模块级全局：用例注册的 schema 必须还回去。
+
+    不还的后果很具体——test_paper_extraction 断言 enrich 抽出的 schema 集合，
+    本文件泄漏进去的学科 schema 会让那条用例莫名多出一行。
+    """
+    snapshot = dict(_REGISTRY)
+    yield
+    _REGISTRY.clear()
+    _REGISTRY.update(snapshot)
+
+
+def _minimal(name: str = "demo", schema_id: str = "method") -> dict:
+    return {
+        "name": name,
+        "title": "示例学科",
+        "schemas": [
+            {
+                "id": schema_id,
+                "prompt": "抽取：\n{fields_spec}\n只输出 JSON。",
+                "fields": [{"name": "purpose", "kind": "text", "max_len": 200}],
+            }
+        ],
+    }
+
+
+def test_builtin_structural_pack_parses():
+    pack = dp.read_pack_file(CIVIL)
+    assert pack.name == "structural"
+    ids = {s.id for s in pack.schemas}
+    assert "method" in ids
+
+
+def test_structural_method_card_uses_domain_axes_not_ml_ones():
+    """这条是整件事的意义所在：非 CS 学科拿到自己的抽取口径。"""
+    pack = dp.read_pack_file(CIVIL)
+    method = next(s for s in pack.schemas if s.id == "method")
+    names = {f.name for f in method.fields}
+    # 结构工程要的轴
+    assert {"structure", "actions", "analysis", "validation"} <= names
+    # 机器学习的轴不该出现在结构方法卡里
+    assert "dataset" not in names
+    assert "baseline" not in names
+    # purpose / mechanism 跨学科保留：方法库的「同目的异机制」检索靠这两根轴
+    assert {"purpose", "mechanism"} <= names
+
+
+def test_registered_schema_id_is_namespaced_by_pack():
+    pack = dp.parse_pack(_minimal(name="structural2"), origin="t")
+    ids = dp.register_pack(pack)
+    # 不同学科包都想叫 method；不加前缀会互相顶掉，而顶掉不会报错，
+    # 只会让抽取悄悄换了口径
+    assert ids == ["structural2.method"]
+    # get_schema 未知 id 直接抛，所以取到即证明登记成功
+    assert get_schema("structural2.method").fields[0].name == "purpose"
+    assert "structural2.method" in {s.id for s in list_schemas()}
+
+
+def test_prompt_must_carry_the_fields_placeholder():
+    bad = _minimal(name="nofields")
+    bad["schemas"][0]["prompt"] = "手写字段清单：purpose"
+    pack = dp.parse_pack(bad, origin="t")
+    with pytest.raises(dp.DisciplinePackError) as exc:
+        dp.register_pack(pack)
+    # 字段清单必须由代码生成，否则 prompt 与 fields 必然漂移
+    assert "fields_spec" in str(exc.value)
+
+
+def test_duplicate_field_names_are_rejected():
+    bad = _minimal(name="dupe")
+    bad["schemas"][0]["fields"].append({"name": "purpose", "kind": "text", "max_len": 100})
+    pack = dp.parse_pack(bad, origin="t")
+    with pytest.raises(dp.DisciplinePackError):
+        dp.register_pack(pack)
+
+
+def test_entries_field_requires_entry_keys():
+    bad = _minimal(name="entriesbad")
+    bad["schemas"][0]["fields"] = [{"name": "items", "kind": "entries", "max_items": 3}]
+    pack = dp.parse_pack(bad, origin="t")
+    with pytest.raises(dp.DisciplinePackError):
+        dp.register_pack(pack)
+
+
+def test_unknown_keys_are_rejected_rather_than_ignored():
+    bad = _minimal(name="typo")
+    bad["schemas"][0]["promt"] = "typo key"  # 拼错的键
+    with pytest.raises(dp.DisciplinePackError):
+        dp.parse_pack(bad, origin="t")
+
+
+def test_user_directory_packs_are_discovered(tmp_path, monkeypatch):
+    """file-over-app：用户自己写的学科包和他的 PDF、笔记放在一起。"""
+    from app.core.config import get_settings
+
+    monkeypatch.setattr(get_settings(), "data_dir", str(tmp_path), raising=False)
+    user_dir = tmp_path / "packs" / "disciplines"
+    user_dir.mkdir(parents=True)
+    (user_dir / "mine.yaml").write_text(
+        yaml.safe_dump(_minimal(name="mine"), allow_unicode=True), encoding="utf-8"
+    )
+
+    names = {p.name for p in dp.discover_packs()}
+    assert "mine" in names
+    # 内置包仍在：用户目录是追加，不是替换
+    assert "structural" in names
+
+
+def test_a_broken_pack_does_not_stop_the_others(tmp_path, monkeypatch):
+    from app.core.config import get_settings
+
+    monkeypatch.setattr(get_settings(), "data_dir", str(tmp_path), raising=False)
+    user_dir = tmp_path / "packs" / "disciplines"
+    user_dir.mkdir(parents=True)
+    (user_dir / "broken.yaml").write_text("name: [this is not a mapping", encoding="utf-8")
+    (user_dir / "good.yaml").write_text(
+        yaml.safe_dump(_minimal(name="good"), allow_unicode=True), encoding="utf-8"
+    )
+
+    names = {p.name for p in dp.discover_packs()}
+    # 手写的包写坏了是常态，不该让平台起不来
+    assert "good" in names
+    assert "broken" not in names
+
+
+def test_load_disciplines_registers_the_builtin_pack():
+    loaded = dp.load_disciplines()
+    assert "structural" in loaded
+    assert "structural.method" in loaded["structural"]
+    schema = get_schema("structural.method")
+    # 字段清单进 prompt 是确定性生成的，与 fields 永不漂移
+    rendered = schema.system_prompt()
+    assert "actions" in rendered and "validation" in rendered
+
+
+def test_pack_dirs_put_user_after_builtin():
+    dirs = dp.pack_dirs()
+    assert dirs[0] == dp.BUILTIN_DISCIPLINES_DIR
+    assert dirs[-1] == dp.user_disciplines_dir()
+    assert isinstance(dirs[-1], Path)
+
+
+def test_discipline_schema_does_not_leak_into_other_libraries():
+    """作用范围是这件事的要害：装一个学科包，不该让别的学科的论文也多抽一遍。"""
+    dp.register_pack(dp.parse_pack(_minimal(name="geo"), origin="t"))
+
+    builtin_ids = {s.id for s in schemas_for(None)}
+    # 没声明学科的库：只有跨学科通用的内置 schema
+    assert "geo.method" not in builtin_ids
+    assert {"skeleton", "method", "gaps"} <= builtin_ids
+
+    scoped_ids = {s.id for s in schemas_for("geo")}
+    # 声明了该学科的库：内置 + 该学科的
+    assert "geo.method" in scoped_ids
+    assert {"skeleton", "method", "gaps"} <= scoped_ids
+
+    # 声明了别的学科：拿不到 geo 的
+    assert "geo.method" not in {s.id for s in schemas_for("structural")}
+
+
+def test_builtin_schemas_carry_no_pack():
+    for schema in schemas_for(None):
+        assert schema.pack is None

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -9,7 +9,8 @@ from alembic import command
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 
-HEAD_REVISION = "c4a1d8e93b57"  # Manuscript CRDT state persistence (#347)
+HEAD_REVISION = "d7b2e4c81a35"  # Library declares its discipline (discipline packs)
+CRDT_STATE_REVISION = "c4a1d8e93b57"  # Manuscript CRDT state persistence (#347)
 SKILLS_CONVERGENCE_REVISION = "a5b9c3d7e1f2"  # Skill-system convergence step 1 (#741)
 HYGIENE_REVISION = "351c324f4f6b"  # Schema hygiene: retired columns + owner merge (#734)
 SETTINGS_REVISION = "b737c1a2d3e4"  # User-preference settings move to users.settings (#737)
@@ -188,6 +189,8 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     command.upgrade(cfg, "head")
     version, columns = _inspect_db(db_path)
     assert version == HEAD_REVISION
+    # 学科包：文献库声明学科，决定本库论文按哪套 schema 抽
+    assert "discipline" in columns["direction_libraries"]
     # 协同文档 CRDT 状态（#347）：房间重建靠它，不能只留纯文本投影
     assert "ydoc_state" in columns["manuscript_files"]
     # 列卫生（#734）：退役快照列与归属副本列在 head 已删
@@ -626,7 +629,13 @@ def test_migrations_sqlite_upgrade_head_and_roundtrip(tmp_path):
     } <= columns["paper_extractions"]
     assert "ix_paper_extractions_paper_id" in _index_names(db_path, "paper_extractions")
 
-    # 先退掉协同文档 CRDT 状态列（#347）。
+    # 先退掉文献库的学科列。
+    command.downgrade(cfg, "-1")
+    version, columns = _inspect_db(db_path)
+    assert version == CRDT_STATE_REVISION
+    assert "discipline" not in columns["direction_libraries"]
+
+    # 再退掉协同文档 CRDT 状态列（#347）。
     command.downgrade(cfg, "-1")
     version, columns = _inspect_db(db_path)
     assert version == SKILLS_CONVERGENCE_REVISION


### PR DESCRIPTION
First fix from the #763 audit.

## The gap

`extraction/schemas.py` opens by saying it embeds no discipline content and offers `register_schema` as the seam for exactly that. **The only caller in the repository was that same file**, registering its three built-ins. So "extraction schemas specialise by discipline" existed in the design report and not in the product — the only way to add one was to edit the repo.

## What this adds

A **discipline pack**: declarative YAML that registers extraction schemas, read from the repository and from `<data_dir>/packs/disciplines`.

Deliberately **data, not plugin code**. A schema is fields, length caps and a prompt; it executes nothing. Keeping it as data means it can be reviewed, diffed and exported alongside the library, without anyone running third-party code in the server process — that risk belongs to the plugin market (#754) and is a different problem.

The bundled **structural engineering** pack is real, not a placeholder:

| built-in `method@1` | `structural.method` |
| --- | --- |
| `purpose` / `mechanism` | unchanged — these two axes are cross-disciplinary |
| `baseline`, `dataset` | `structure` (member and material), `validation` (which test or benchmark case) |
| `protocol` | `actions` (load cases), `analysis` (solver, element type, time step) |

There is no "dataset" in structural engineering; the counterpart is what the result was validated against. `purpose` and `mechanism` stay because the method library's same-purpose-different-mechanism retrieval rides on those axes in every field.

## Scope is the important part, and a test forced it

My first version registered the pack globally. `test_paper_extraction` failed, and it was **right**: the enrich hook sweeps every registered schema, so registering this pack made **every paper — including pure machine-learning ones — pay for one more LLM extraction**. Cost would grow with each installed pack for no benefit whatsoever.

That is a design error, not a test nit, and reading the code did not reveal it — running it did.

So a schema now carries the pack it came from, `direction_libraries` gains a `discipline` column, and the sweep is built-ins plus that library's discipline only. **With no discipline declared, behaviour is byte-identical to before.**

Schema ids are namespaced by pack (`structural.method`) because `register_schema` overwrites on duplicate id — two packs both calling something `method` would silently replace each other, changing what gets extracted with no error anywhere.

## Verification

44 passed, including the full migration roundtrip (up to `d7b2e4c81a35`, then stepping back down) and the previously-failing extraction test. `ruff check` clean.

Tests pin the parts that matter: the structural card uses domain axes and *not* `dataset`/`baseline`; a discipline schema does not leak into libraries that did not ask for it; a broken hand-written pack is skipped instead of taking the platform down; unknown YAML keys are rejected rather than ignored; and `prompt` must carry `{fields_spec}` so the field list stays generated rather than hand-written and drifting.

An autouse fixture restores the extraction registry between tests — it is module-level global state, and my first version leaked into `test_paper_extraction`.

## Not in this PR

Choosing the discipline from the API/UI (the column exists; selecting it does not), and teaching `method_index` to retrieve across discipline method cards — otherwise a discipline user gets an empty method library while their cards sit in the database. Both are tracked in #763.
