### PR TITLE
fix: the daily feed resolves its sources from the registry (#753)

### DIFF
--- a/src/backend/app/services/daily_feed.py
+++ b/src/backend/app/services/daily_feed.py
@@ -17,6 +17,7 @@ import json
 import logging
 import re
 import uuid
+from dataclasses import dataclass
 from typing import Any
 
 from sqlalchemy import Date, Float, String, case, cast, delete, func, literal, or_, select, text
@@ -47,8 +48,13 @@ logger = logging.getLogger(__name__)
 
 # 订阅分类是用户偏好（#737 配置分层）：存 owner 用户的 settings['daily.categories']，
 # 旧 system_settings 键只作迁移期只读回退（deprecated，一期后连旧行一起删）。
+# 每日池的默认源。它不再是「唯一的源」，只是历史扁平配置归一化时的归属。
+ARXIV_SOURCE = "arxiv"
+
 CATEGORIES_SETTING_KEY = "daily_feed_categories"
 CATEGORIES_USER_KEY = "daily.categories"
+# 非 arXiv 源的订阅单独一个键：旧键的形状与 legacy 读路径因此完全不受影响
+SUBSCRIPTIONS_USER_KEY = "daily.subscriptions"
 
 # 注：论文级向量的管理员开关已升格为平台总闸并改名（daily_feed_embed_enabled →
 # 默认关意味着每日推送的论文连论文级向量都没有、语义检索里根本搜不到；而只管每日推送
@@ -82,6 +88,98 @@ def _today_utc() -> dt.date:
 
 
 # ---- 订阅分类配置 ----
+
+
+@dataclass(frozen=True, slots=True)
+class Subscription:
+    """一条订阅：在哪个源上、订哪些词。
+
+    arxiv 的「词」是分类（cs.AI）；别的源是检索词（「structural engineering」）。
+    两者形状相同、语义由源自己解释——每日池不该假定全世界都用 arXiv 的分类体系。
+    """
+
+    source: str
+    terms: tuple[str, ...]
+
+
+def _normalize_extra(value: Any) -> list[Subscription]:
+    """归一化非 arXiv 源的订阅（新键 ``daily.subscriptions`` 的内容）。
+
+    坏行跳过而不是整段作废：这份配置是人写的，一行写错不该让整个每日池停摆。
+    """
+    if not isinstance(value, list):
+        return []
+    out: list[Subscription] = []
+    for row in value:
+        if not isinstance(row, dict):
+            continue
+        source = str(row.get("source") or "").strip().lower()
+        raw_terms = row.get("terms")
+        if not source or source == ARXIV_SOURCE or not isinstance(raw_terms, list):
+            continue
+        terms = tuple(str(t).strip() for t in raw_terms if str(t).strip())
+        if terms:
+            out.append(Subscription(source=source, terms=terms))
+    return out
+
+
+async def get_subscriptions(session: AsyncSession) -> list[Subscription]:
+    """全部订阅 = arXiv（旧键，形状不变）+ 其余源（新键）。
+
+    **arXiv 的订阅仍存在原来的键、仍是扁平分类列表。** 第一版我把它改成了统一的
+    ``[{source, terms}]`` 一起塞回旧键，结果是既有测试大面积翻车——那不是测试的
+    问题：那个键有 legacy 读路径，换形状等于让老读者看见它不认识的东西。新概念
+    用新键承载，旧键一个字节都不动，存量部署因此不需要任何迁移。
+    """
+    subs: list[Subscription] = []
+    arxiv_terms = await get_categories(session)
+    if arxiv_terms:
+        subs.append(Subscription(source=ARXIV_SOURCE, terms=tuple(arxiv_terms)))
+    extra = await owner_settings.read_setting(session, SUBSCRIPTIONS_USER_KEY, legacy_key=None)
+    subs.extend(_normalize_extra(extra))
+    return subs
+
+
+async def set_subscriptions(
+    session: AsyncSession, subscriptions: list[Subscription], *, user: User | None = None
+) -> list[Subscription]:
+    """写回订阅：arXiv 那条走旧键（校验分类格式），其余源走新键（自由检索词）。"""
+    arxiv_terms: list[str] = []
+    others: list[Subscription] = []
+    for sub in subscriptions:
+        source = sub.source.strip().lower()
+        if not source:
+            continue
+        terms: list[str] = []
+        for raw in sub.terms:
+            term = raw.strip()
+            if term and term not in terms:
+                terms.append(term)
+        if not terms:
+            continue
+        if source == ARXIV_SOURCE:
+            # arXiv 的词是分类，格式固定（set_categories 会校验）
+            arxiv_terms.extend(terms)
+        else:
+            # 别的源是自由检索词：拿 arXiv 分类正则去校验它，只会把
+            # 「structural engineering」这种完全正当的订阅挡在门外
+            others.append(Subscription(source=source, terms=tuple(terms)))
+
+    saved_arxiv = await set_categories(session, arxiv_terms, user=user)
+    await owner_settings.write_setting(
+        session,
+        SUBSCRIPTIONS_USER_KEY,
+        [{"source": s.source, "terms": list(s.terms)} for s in others],
+        legacy_key=None,
+        user=user,
+    )
+    await session.commit()
+
+    out: list[Subscription] = []
+    if saved_arxiv:
+        out.append(Subscription(source=ARXIV_SOURCE, terms=tuple(saved_arxiv)))
+    out.extend(others)
+    return out
 
 
 async def get_categories(session: AsyncSession) -> list[str]:
@@ -303,35 +401,57 @@ async def fetch_new_by_category(
 
     状态取值：``ok``（抓到了，可能是 0 篇——周末/无公告是正常的）、``error``。
     """
-    categories = await get_categories(session)
-    # 经源注册表取 arXiv 适配器；get_arxiv_client 模块属性保留为客户端注入缝
-    client = literature_sources.require_source("arxiv", client=get_arxiv_client())
+    subscriptions = await get_subscriptions(session)
+    # 能干这件事的源由注册表回答（能力探测），而不是这里写死一个 id。
+    # get_arxiv_client 模块属性保留为客户端注入缝。
+    capable = dict(
+        literature_sources.sources_with_capability(
+            "fetch_new", clients={ARXIV_SOURCE: get_arxiv_client()}
+        )
+    )
+    categories: list[str] = []
     by_category: dict[str, list[dict[str, Any]]] = {}
     statuses: dict[str, dict[str, Any]] = {}
-    for category in categories:
-        try:
-            entries, batch_at = await client.fetch_new(category)
-        except asyncio.CancelledError:
-            raise
-        except Exception as e:  # noqa: BLE001 — 单分类失败不打断其余分类
-            logger.warning("daily feed RSS failed for %s", category, exc_info=True)
-            by_category[category] = []
+    for sub in subscriptions:
+        client = capable.get(sub.source)
+        for category in sub.terms:
+            categories.append(category)
+            if client is None:
+                # 订了一个当前拿不到/不支持日更的源：如实报出来，而不是静默少抓。
+                # 「这个源没装」和「这个源今天没有新论文」必须可区分。
+                by_category[category] = []
+                statuses[category] = {
+                    "count": 0,
+                    "status": "error",
+                    "detail": f"source {sub.source!r} 不可用或不支持每日新增",
+                }
+                continue
+            try:
+                entries, batch_at = await client.fetch_new(category)
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:  # noqa: BLE001 — 单个订阅词失败不打断其余
+                logger.warning(
+                    "daily feed fetch failed for %s/%s", sub.source, category, exc_info=True
+                )
+                by_category[category] = []
+                statuses[category] = {
+                    "count": 0,
+                    "status": "error",
+                    "detail": f"{type(e).__name__}: {e}"[:200],
+                }
+                continue
+            by_category[category] = entries
+            batch_date = batch_at.astimezone(dt.UTC).date() if batch_at else None
             statuses[category] = {
-                "count": 0,
-                "status": "error",
-                "detail": f"{type(e).__name__}: {e}"[:200],
+                "count": len(entries),
+                "status": "ok",
+                "detail": None,
+                # 源自己声明这批是哪天的（arXiv 有公告日；没有的源给 None）；
+                # 调用方据此判断有没有抓早了
+                "batch_date": batch_date.isoformat() if batch_date else None,
+                "stale": bool(batch_date and batch_date < _today_utc()),
             }
-            continue
-        by_category[category] = entries
-        batch_date = batch_at.astimezone(dt.UTC).date() if batch_at else None
-        statuses[category] = {
-            "count": len(entries),
-            "status": "ok",
-            "detail": None,
-            # arXiv 自己声明这批是哪天的公告；调用方据此判断有没有抓早了
-            "batch_date": batch_date.isoformat() if batch_date else None,
-            "stale": bool(batch_date and batch_date < _today_utc()),
-        }
     return categories, by_category, statuses
 
 
@@ -385,15 +505,20 @@ async def upsert_entries(
         for entry in entries:
             title = (entry.get("title") or "").strip()
             arxiv_id = entry.get("arxiv_id")
-            if not title or not arxiv_id:
+            doi = entry.get("doi")
+            # 身份不再限定 arXiv id：非 arXiv 的源给不出 arxiv_id，以前会在这里被
+            # 静默丢掉——抓回来了、也解析了，然后一条不落地。有 DOI 就够定位一篇
+            # 论文（find_pool_paper / pool_dedup_key 本来就按 arxiv → doi → 标题哈希
+            # 级联）。两者都没有才真的无从去重，跳过。
+            if not title or not (arxiv_id or doi):
                 continue
             paper = await find_pool_paper(
                 session,
                 arxiv_id=arxiv_id,
-                doi=entry.get("doi"),
+                doi=doi,
                 dedup_key=pool_dedup_key(
                     arxiv_id=arxiv_id,
-                    doi=entry.get("doi"),
+                    doi=doi,
                     title=title,
                     year=entry.get("year"),
                     authors=entry.get("authors"),
@@ -1724,18 +1849,26 @@ async def todays_batch_available(session: AsyncSession) -> tuple[bool, str | Non
     找到一个没收过的就够了，所以命中即返回：常态下 cs.AI 有新论文，仍然只发一次
     请求；只有像那天一样首个分类全中时才会继续往后问。
     """
-    categories = await get_categories(session)
-    if not categories:
-        # 没订阅任何分类：无可收之物，不该开一轮同步（空转还会把当天锁死）
+    subscriptions = await get_subscriptions(session)
+    probes = [(sub.source, term) for sub in subscriptions for term in sub.terms]
+    if not probes:
+        # 没订阅任何东西：无可收之物，不该开一轮同步（空转还会把当天锁死）
         return False, None
 
+    capable = dict(
+        literature_sources.sources_with_capability(
+            "fetch_new", clients={ARXIV_SOURCE: get_arxiv_client()}
+        )
+    )
     today = _today_utc()
     latest: dt.date | None = None
-    for category in categories:
+    for source_id, category in probes:
+        client = capable.get(source_id)
+        if client is None:
+            # 源不可用：探测不下结论，交给正式抓取去如实报错
+            return True, None
         try:
-            entries, batch_at = await literature_sources.require_source(
-                "arxiv", client=get_arxiv_client()
-            ).fetch_new(category)
+            entries, batch_at = await client.fetch_new(category)
         except Exception:  # noqa: BLE001 — 探测失败不下结论，交给正式抓取去报错
             logger.warning("daily feed probe failed for %s", category, exc_info=True)
             return True, None

--- a/src/backend/app/services/literature/sources.py
+++ b/src/backend/app/services/literature/sources.py
@@ -391,6 +391,25 @@ def require_source(source_id: str, *, client: Any | None = None) -> Any:
     return adapter
 
 
+def sources_with_capability(
+    capability: str, *, clients: dict[str, Any] | None = None
+) -> list[tuple[str, Any]]:
+    """按注册顺序给出实现了某项能力的源（id, adapter）。
+
+    能力模型见模块头：search 必选，其余按源实现、调用方 hasattr 探测。此前每个
+    旁路调用点都是自己写死一个源 id 去取适配器——「谁能干这件事」这个问题于是
+    散落在各处，加一个源要改所有调用点。这里把探测收成一处。
+
+    ``clients`` 让调用方沿用自己的客户端注入缝（daily_feed 的 get_arxiv_client 等）。
+    """
+    found: list[tuple[str, Any]] = []
+    for source_id in _SPECS:
+        adapter = get_source(source_id, client=(clients or {}).get(source_id))
+        if adapter is not None and hasattr(adapter, capability):
+            found.append((source_id, adapter))
+    return found
+
+
 def resolvers_for(kind: str) -> tuple[str, ...]:
     """能解析某类标识的源 id，按 resolve_priority 升序（= 级联尝试顺序）。
 

--- a/src/backend/app/services/owner_settings.py
+++ b/src/backend/app/services/owner_settings.py
@@ -39,19 +39,22 @@ async def owner_user(session: AsyncSession) -> User | None:
     return await session.get(User, owner_id)
 
 
-async def read_setting(session: AsyncSession, key: str, *, legacy_key: str) -> Any:
+async def read_setting(session: AsyncSession, key: str, *, legacy_key: str | None) -> Any:
     """读 owner 的命名空间偏好；新键缺席时回读旧 system_settings 行。
 
     回退只此一期（deprecated）：数据迁移已把存量拷进 owner.settings，这里兜的是
     「迁移后才从备份恢复出旧行」之类的残局。下一期删回退时连 legacy 行一起清。
     取值合法性不在这里管——各业务 getter 自带「非法回落默认」。
+
+    ``legacy_key=None``：这个键是本期新增的，没有旧行可回读——不该逼着新键
+    去编一个从来不存在的 legacy 名字。
     """
     owner = await owner_user(session)
     if owner is not None:
         value = (owner.settings or {}).get(key, _MISSING)
         if value is not _MISSING:
             return value
-    row = await session.get(SystemSetting, legacy_key)
+    row = await session.get(SystemSetting, legacy_key or key)
     return row.value if row is not None else None
 
 
@@ -60,7 +63,7 @@ async def write_setting(
     key: str,
     value: Any,
     *,
-    legacy_key: str,
+    legacy_key: str | None,
     user: User | None = None,
 ) -> None:
     """把偏好写到 owner 的 settings 上（不 commit，沿用调用方的提交时机）。
@@ -75,8 +78,12 @@ async def write_setting(
         # 整字典替换而不是就地改：JSON 列的变更检测认的是赋值
         target.settings = {**(target.settings or {}), key: value}
         return
-    row = await session.get(SystemSetting, legacy_key)
+    # 还没有任何用户时仍要落盘：写丢了就是「设了订阅、下次打开没了」。
+    # 本期新增的键没有 legacy 名字，就用键名自己当行名——回退行的意义是
+    # 「别丢」，不是「必须叫某个历史名字」。
+    row_key = legacy_key or key
+    row = await session.get(SystemSetting, row_key)
     if row is None:
-        session.add(SystemSetting(key=legacy_key, value=value))
+        session.add(SystemSetting(key=row_key, value=value))
     else:
         row.value = value

--- a/src/backend/tests/test_daily_feed_sources.py
+++ b/src/backend/tests/test_daily_feed_sources.py
@@ -1,0 +1,185 @@
+"""每日池的源解耦（#753）。
+
+审计判据是「一个做结构工程的人能用吗」：arXiv 上几乎没有土木，所以对他，每日池
+不是「相关性差」，是**空的**。而且此前的耦合有四层，只改抓取那一行是装样子——
+非 arXiv 的条目会在两步之后被 upsert 静默丢掉。
+
+所以这里的用例刻意**走完整条路**：注册一个假源 → 订阅它 → 抓取 → 落库，
+断言条目真的进了池子，而不是只断言「抓回来了」。
+"""
+
+import datetime as dt
+
+import pytest
+
+from app.services import daily_feed
+from app.services.literature import sources as literature_sources
+from app.services.literature.sources import SourceSpec, register_source, unregister_source
+
+
+class _FakeCivilSource:
+    """一个非 arXiv 的源：给 DOI、不给 arxiv_id，正是以前会被丢掉的形状。"""
+
+    name = "civil"
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def search(self, request):  # pragma: no cover - 本用例不走检索
+        raise NotImplementedError
+
+    async def fetch_new(self, category: str):
+        self.calls.append(category)
+        return (
+            [
+                {
+                    "title": f"Blast response of composite beams ({category})",
+                    "doi": f"10.1000/civil.{category}",
+                    "authors": ["Wei Zhang"],
+                    "year": 2026,
+                    "abstract": "Impact loading on steel-concrete members.",
+                }
+            ],
+            dt.datetime.now(dt.UTC),
+        )
+
+
+@pytest.fixture
+def civil_source():
+    fake = _FakeCivilSource()
+    register_source(
+        SourceSpec(id="civil", build=lambda _ctx: fake, default_factory=lambda _c: fake)
+    )
+    yield fake
+    unregister_source("civil")
+
+
+def test_capability_probe_finds_sources_that_can_do_daily(civil_source):
+    ids = {sid for sid, _ in literature_sources.sources_with_capability("fetch_new")}
+    # 谁能干这件事由注册表回答，而不是调用点写死一个 id
+    assert "civil" in ids
+    assert "arxiv" in ids
+
+
+def test_a_source_without_the_capability_is_not_offered():
+    ids = {sid for sid, _ in literature_sources.sources_with_capability("fetch_new")}
+    # openalex 现在没有日更能力（只有年粒度过滤），不该被当成可日更的源
+    assert "openalex" not in ids
+
+
+def test_malformed_subscription_rows_are_skipped_not_fatal():
+    """这份配置是人写的，一行写错不该让整个每日池停摆。"""
+    subs = daily_feed._normalize_extra(
+        [{"source": "civil"}, {"terms": ["x"]}, "junk", {"source": "ok", "terms": ["t"]}]
+    )
+    assert [s.source for s in subs] == ["ok"]
+
+
+def test_arxiv_rows_never_come_from_the_new_key():
+    """arXiv 的订阅只有一个真相来源（旧键）；新键里混进 arxiv 行要被忽略，
+    否则同一个源会有两处配置、且互相看不见。"""
+    subs = daily_feed._normalize_extra([{"source": "arxiv", "terms": ["cs.AI"]}])
+    assert subs == []
+
+
+async def test_non_arxiv_terms_are_not_forced_into_arxiv_category_shape(client):
+    """自由检索词必须能订：把「structural engineering」按 arXiv 分类格式校验就是把
+    非 CS 学科挡在门外。"""
+    from app.core.db import get_sessionmaker
+
+    async with get_sessionmaker()() as session:
+        saved = await daily_feed.set_subscriptions(
+            session,
+            [daily_feed.Subscription(source="civil", terms=("structural engineering",))],
+        )
+    assert saved[0].terms == ("structural engineering",)
+
+    async with get_sessionmaker()() as session:
+        # arXiv 的词仍按分类格式校验——它的词确实是分类
+        with pytest.raises(daily_feed.InvalidCategoryError):
+            await daily_feed.set_subscriptions(
+                session,
+                [daily_feed.Subscription(source="arxiv", terms=("not a category!",))],
+            )
+
+
+async def test_legacy_key_keeps_its_flat_shape(client):
+    """存量部署的 arXiv 订阅仍存在原键、仍是扁平列表——升级不需要迁移数据。"""
+    from app.core.db import get_sessionmaker
+    from app.services import owner_settings
+
+    async with get_sessionmaker()() as session:
+        await daily_feed.set_subscriptions(
+            session,
+            [
+                daily_feed.Subscription(source="arxiv", terms=("cs.AI",)),
+                daily_feed.Subscription(source="civil", terms=("blast loading",)),
+            ],
+        )
+    async with get_sessionmaker()() as session:
+        stored = await owner_settings.read_setting(
+            session, daily_feed.CATEGORIES_USER_KEY, legacy_key=daily_feed.CATEGORIES_SETTING_KEY
+        )
+    assert stored == ["cs.AI"], "旧键必须还是扁平分类列表，老读者才不会看见不认识的形状"
+
+
+async def test_arxiv_compat_accessor_preserves_other_sources(client):
+    """旧的 set_categories 只动 arXiv 那条，别的源的订阅在另一个键上不受影响。"""
+    from app.core.db import get_sessionmaker
+
+    async with get_sessionmaker()() as session:
+        await daily_feed.set_subscriptions(
+            session,
+            [
+                daily_feed.Subscription(source="arxiv", terms=("cs.AI",)),
+                daily_feed.Subscription(source="civil", terms=("blast loading",)),
+            ],
+        )
+    async with get_sessionmaker()() as session:
+        await daily_feed.set_categories(session, ["cs.CV"])
+    async with get_sessionmaker()() as session:
+        subs = {s.source: s.terms for s in await daily_feed.get_subscriptions(session)}
+    assert subs["arxiv"] == ("cs.CV",)
+    assert subs["civil"] == ("blast loading",)  # 没被 arXiv 口径的外壳抹掉
+
+
+async def test_unavailable_source_is_reported_not_silently_skipped(client):
+    from app.core.db import get_sessionmaker
+
+    async with get_sessionmaker()() as session:
+        await daily_feed.set_subscriptions(
+            session, [daily_feed.Subscription(source="ghost", terms=("anything",))]
+        )
+    async with get_sessionmaker()() as session:
+        _cats, _entries, statuses = await daily_feed.fetch_new_by_category(session)
+    # 「这个源没装」和「今天没有新论文」必须可区分
+    assert statuses["anything"]["status"] == "error"
+    assert "ghost" in statuses["anything"]["detail"]
+
+
+async def test_entry_with_only_a_doi_reaches_the_pool(client, civil_source):
+    """这条是整件事的要害：以前非 arXiv 的条目抓回来了，然后在 upsert 被静默丢掉。"""
+    from sqlalchemy import select
+
+    from app.core.db import get_sessionmaker
+    from app.models.daily_feed import DailyFeedEntry
+
+    async with get_sessionmaker()() as session:
+        await daily_feed.set_subscriptions(
+            session, [daily_feed.Subscription(source="civil", terms=("blast",))]
+        )
+
+    async with get_sessionmaker()() as session:
+        categories, by_category, statuses = await daily_feed.fetch_new_by_category(session)
+        assert statuses["blast"]["status"] == "ok"
+        assert len(by_category["blast"]) == 1
+        await daily_feed.upsert_entries(
+            session,
+            by_category=by_category,
+            batch_dates=daily_feed.batch_dates_from_statuses(statuses),
+        )
+        await session.commit()
+
+    async with get_sessionmaker()() as session:
+        rows = (await session.execute(select(DailyFeedEntry))).scalars().all()
+    assert len(rows) == 1, "只有 DOI 的条目必须能进池，否则非 arXiv 的源接了也没用"


### PR DESCRIPTION
Closes #753. Second fix from the #763 audit.

## Why changing one line would have been theatre

The coupling was four layers deep. A non-arXiv entry was fetched, parsed, and then **silently dropped two steps later** by a check requiring an arXiv id. Wiring the registry into the fetch call alone would have looked like pluggability while changing nothing.

All four move together:

| Layer | Before | Now |
| --- | --- | --- |
| which source | `require_source("arxiv", …)` hardcoded at two call sites | registry capability probe — `sources_with_capability("fetch_new")` |
| subscriptions | one flat arXiv category list | grouped per source |
| term validation | arXiv category regex for everything | per source — arXiv terms are categories, others are free search terms |
| entry identity | `if not arxiv_id: continue` | arXiv id **or** DOI |

Entry identity needed almost nothing: `find_pool_paper` and `pool_dedup_key` already cascade arXiv → DOI → title hash. That one line was the whole blockage.

An unavailable source is now **reported** rather than quietly contributing nothing. "That source is not installed" and "that source has nothing new today" must stay distinguishable — this file's own header criticises the earlier habit of swallowing errors into empty lists, and a silent skip would have reintroduced it one level up.

## Storage shape deliberately does not change

My first attempt unified everything into the existing key, and **23 existing tests broke**. Those tests were right: that key has a legacy read path, so changing its shape shows old readers something they cannot parse.

So arXiv subscriptions stay in the original key as a flat category list, and other sources live in a new key. No data migration; no deployment can stop receiving papers because of this upgrade. A test pins the legacy key's shape so a future refactor cannot quietly change it.

`owner_settings` now accepts `legacy_key=None`, since a key introduced this release has no historical row to fall back to. One detail worth calling out: an early version of that made writes return early when no user exists yet — which would mean a user sets subscriptions and finds them gone. Writes still persist in that state, keyed by the new name.

## OpenAlex is deliberately not wired up

Its `search_source` only filters by **year**, so a daily feed built on it would pull the whole year back every day. Shipping that would trade one visible problem for a worse invisible one. The seam is now real; adding a source with genuine date filtering is a small change.

## Verification

74 passed with `-p no:randomly`, per the project convention for order-dependent suites; ruff clean.

The decisive test drives a **fake non-arXiv source end to end** — register, subscribe, fetch, and **upsert** — asserting the entry actually lands in the pool. Asserting only "it was fetched" is exactly how the silent drop survived.

A golden failure appeared mid-way and was **pre-existing order dependence**, not this change: it passes in isolation, passes pairwise with the new tests, and passes with randomisation disabled.
